### PR TITLE
Fix: Remove double prompt when copying config.json in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -665,20 +665,23 @@ setup_config() {
 
         # Create backup
         create_backup "$CONFIG_FILE"
+    else
+        # Config doesn't exist, prompt to copy
+        if ! prompt_yes_no "Copy config.json to ${CONFIG_DIR}/?" "y"; then
+            log_info "Skipping config.json copy"
+            SKIP_CONFIG_COPY=true
+            return 0
+        fi
     fi
 
     # Copy config.json
     if [ "$SKIP_CONFIG_COPY" != true ]; then
-        if prompt_yes_no "Copy config.json to ${CONFIG_DIR}/?" "y"; then
-            if [ -f "${SCRIPT_DIR}/config.json" ]; then
-                run_cmd "cp ${SCRIPT_DIR}/config.json ${CONFIG_FILE}/"
-                log_success "config.json copied successfully"
-            else
-                log_error "config.json not found in ${SCRIPT_DIR}"
-                return 1
-            fi
+        if [ -f "${SCRIPT_DIR}/config.json" ]; then
+            run_cmd "cp ${SCRIPT_DIR}/config.json ${CONFIG_FILE}/"
+            log_success "config.json copied successfully"
         else
-            log_info "Skipping config.json copy"
+            log_error "config.json not found in ${SCRIPT_DIR}"
+            return 1
         fi
     fi
 


### PR DESCRIPTION
## 📝 Summary
- Fixed redundant double-prompt issue in setup.sh configuration setup
- Simplified user experience by removing unnecessary confirmation

## 🐰 Problem
The `setup_config()` function was prompting users twice:
1. When config.json exists: "Do you want to overwrite it?" [n]
2. Then again: "Copy config.json to ~/.config/opencode/?" [y]

This was confusing since saying "yes" to overwrite obviously means you want to copy the file.

## ✨ Solution
Refactored the prompt logic to only ask **once**:
- **If config exists**: "Do you want to overwrite it?" [n] → Copies if yes
- **If config doesn't exist**: "Copy config.json to ~/.config/opencode/?" [y] → Copies if yes

## 📝 Changes
- Modified `setup_config()` function (lines 655-686)
- Added `else` block for new config scenario
- Removed redundant second prompt from the main copy logic
- All functionality preserved (backup creation, directory creation, etc.)

## ✅ Testing
- ✓ Syntax validation passed
- ✓ Logic flow verified for both scenarios
- ✓ No breaking changes to existing functionality

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)