### PR TITLE
fix: correct config.json copy path in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -677,7 +677,7 @@ setup_config() {
     # Copy config.json
     if [ "$SKIP_CONFIG_COPY" != true ]; then
         if [ -f "${SCRIPT_DIR}/config.json" ]; then
-            run_cmd "cp ${SCRIPT_DIR}/config.json ${CONFIG_FILE}/"
+            run_cmd "cp ${SCRIPT_DIR}/config.json ${CONFIG_FILE}"
             log_success "config.json copied successfully"
         else
             log_error "config.json not found in ${SCRIPT_DIR}"


### PR DESCRIPTION
## Summary
- Fixed invalid path in `setup_config()` function that prevented config.json from being copied
- Removed trailing slash from `${CONFIG_FILE}` in the cp command on line 680

## Problem
When running option 1 (quick setup) or overwriting an existing config.json, a backup file was successfully created, but the subsequent copy command would fail silently. This was because:
- `CONFIG_FILE` is defined as `${CONFIG_DIR}/config.json` (full path with filename)
- The copy command used `${CONFIG_FILE}/` which created an invalid path like `~/.config/opencode/config.json/`
- This caused the cp command to fail while the backup succeeded

## Solution
Remove the trailing slash from the destination path:
```bash
# Before (broken)
run_cmd "cp ${SCRIPT_DIR}/config.json ${CONFIG_FILE}/"

# After (fixed)  
run_cmd "cp ${SCRIPT_DIR}/config.json ${CONFIG_FILE}"
```

## Test plan
- [x] Tested quick setup option (option 1) - backup created and file copied successfully
- [x] Tested overwrite scenario - backup created and file copied successfully
- [x] Verified the fix resolves the silent copy failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)