### PR TITLE
Add OpenTofu provider skills: keycloak, aws, neon, kubernetes

### DIFF
--- a/OPENTOFU_PLAN.md
+++ b/OPENTOFU_PLAN.md
@@ -1,0 +1,47 @@
+# OPENTOFU_PLAN.md
+
+## Overview
+Create 4 specific OpenTofu/Terraform provider skills based on requested provider documentation URLs.
+
+## Issue Reference
+- Issue: #38
+- URL: https://github.com/darellchua2/opencode-config-template/issues/38
+
+## Skills to Create
+
+### TODO List
+
+- [x] **opentofu-keycloak-explorer**
+  - URL: https://registry.terraform.io/providers/keycloak/keycloak/latest/docs
+  - Status: ✅ COMPLETED
+  - Commit: 0aaf4a3
+
+- [x] **opentofu-aws-explorer**
+  - URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+  - Status: ✅ COMPLETED
+  - Commit: 0aaf4a3
+
+- [ ] **opentofu-neon-explorer**
+  - URL: https://github.com/kislerdm/terraform-provider-neon
+  - Latest version: v0.13.0
+  - Status: ⏳ PENDING
+
+- [ ] **opentofu-kubernetes-explorer**
+  - URL: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs
+  - Status: ⏳ PENDING
+
+## Success Criteria
+
+- [ ] All 4 provider skills created
+- [ ] Each skill includes reference URL to provider documentation
+- [ ] Skills follow SKILL.md format with proper frontmatter
+- [ ] Each skill committed to issue-38 branch
+- [ ] All changes pushed to remote
+- [ ] Skills use latest provider version information
+
+## Notes
+
+- OpenTofu and Terraform are used interchangeably
+- OpenTofu is an open-source implementation of Terraform
+- All provider documentation sourced from Terraform Registry (compatible with OpenTofu)
+- Focus on latest provider versions and best practices

--- a/OPENTOFU_PLAN.md
+++ b/OPENTOFU_PLAN.md
@@ -21,10 +21,11 @@ Create 4 specific OpenTofu/Terraform provider skills based on requested provider
   - Status: ✅ COMPLETED
   - Commit: 0aaf4a3
 
-- [ ] **opentofu-neon-explorer**
+- [x] **opentofu-neon-explorer**
   - URL: https://github.com/kislerdm/terraform-provider-neon
   - Latest version: v0.13.0
-  - Status: ⏳ PENDING
+  - Status: ✅ COMPLETED
+  - Commit: 99e6788
 
 - [ ] **opentofu-kubernetes-explorer**
   - URL: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs

--- a/OPENTOFU_PLAN.md
+++ b/OPENTOFU_PLAN.md
@@ -27,18 +27,19 @@ Create 4 specific OpenTofu/Terraform provider skills based on requested provider
   - Status: ✅ COMPLETED
   - Commit: 99e6788
 
-- [ ] **opentofu-kubernetes-explorer**
+- [x] **opentofu-kubernetes-explorer**
   - URL: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs
-  - Status: ⏳ PENDING
+  - Status: ✅ COMPLETED
+  - Commit: 628d955
 
 ## Success Criteria
 
-- [ ] All 4 provider skills created
-- [ ] Each skill includes reference URL to provider documentation
-- [ ] Skills follow SKILL.md format with proper frontmatter
-- [ ] Each skill committed to issue-38 branch
-- [ ] All changes pushed to remote
-- [ ] Skills use latest provider version information
+- [x] All 4 provider skills created
+- [x] Each skill includes reference URL to provider documentation
+- [x] Skills follow SKILL.md format with proper frontmatter
+- [x] Each skill committed to issue-38 branch
+- [x] All changes pushed to remote
+- [x] Skills use latest provider version information
 
 ## Notes
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,64 +1,106 @@
-# Plan: Create OpenCode Skill Auditor for Modularization and Optimization
+# Plan: Add OpenTofu related skills for infrastructure provisioning
 
 ## Overview
-This issue implements the opencode-skill-auditor skill to analyze existing OpenCode skills for redundancy, overlap, and opportunities for modularization. The skill will identify granular functionality that can be extracted into reusable components following DRY principles.
+Add new skills to the OpenCode framework that provide guidance on using OpenTofu (the open-source fork of Terraform) for infrastructure provisioning. These skills should leverage official OpenTofu and Terraform provider documentation to ensure best practices and proper implementation patterns.
 
-## Ticket Reference
-- Issue: #34
-- URL: https://github.com/darellchua2/opencode-config-template/issues/34
-- Labels: enhancement, documentation
+## Issue Reference
+- Issue: #38
+- URL: https://github.com/darellchua2/opencode-config-template/issues/38
+- Labels: enhancement
 
-## Files to Modify
-1. `skills/opencode-skill-auditor/SKILL.md` - Main skill definition (already created)
-2. `README.md` - Update to include skill auditor documentation
-3. `AGENTS.md` - Add skill auditor guidelines if needed
-4. `config.json` - Add skill auditor agent configuration
+## Requirements
+
+### Scope
+
+Create one or more skills in the `skills/` directory that provide:
+
+1. **OpenTofu Provider Setup Skills**
+   - Guidance on configuring OpenTofu with various cloud providers
+   - Best practices for provider authentication and configuration
+   - State management strategies
+
+2. **OpenTofu Provisioning Workflows**
+   - Infrastructure as Code (IaC) development patterns
+   - Resource lifecycle management
+   - Configuration and state management workflows
+
+### Documentation Requirements
+
+Each skill MUST include:
+- **Reference URL**: Link to the official provider documentation (OpenTofu or Terraform Registry)
+- **Best Practices**: Verified implementation patterns from provider documentation
+- **Common Examples**: Typical use cases and configurations
+
+#### Example Skill Structure
+
+```
+skills/opentofu-provider-setup/SKILL.md
+- Provider configuration overview
+- Authentication setup
+- State backend configuration
+- Reference URL: https://opentofu.org/docs/providers/
+
+skills/opentofu-provisioning-workflow/SKILL.md
+- Resource provisioning patterns
+- Dependency management
+- State lifecycle management
+- Reference URL: https://registry.terraform.io/providers/
+```
+
+## Rationale
+
+OpenTofu is gaining traction as a community-driven fork of Terraform. Adding skills for OpenTofu:
+- Provides support for open-source infrastructure provisioning
+- Enables users to leverage provider documentation effectively
+- Ensures best practices are followed through documented workflows
+- Aligns with the open-source nature of the OpenCode framework
+
+## Files to Modify/Create
+
+1. `skills/opentofu-provider-setup/SKILL.md` - New skill for provider setup
+2. `skills/opentofu-provisioning-workflow/SKILL.md` - New skill for provisioning workflows
+3. `README.md` - Update to document new OpenTofu skills (optional)
+4. `setup.sh` - Add OpenTofu dependency checks (if needed)
 
 ## Approach
-### Phase 1: Skill Implementation
-- Review existing skill auditor implementation
-- Ensure skill follows OpenCode best practices
-- Validate skill metadata and structure
 
-### Phase 2: Skill Audit Execution
-- Run skill auditor against existing skills directory
-- Identify redundant functionality and overlap
-- Document opportunities for modularization
+### Phase 1: Research and Planning
+1. Review OpenTofu documentation structure and best practices
+2. Identify common use cases for OpenTofu provisioning
+3. Select representative cloud providers (AWS, Azure, GCP) for examples
+4. Document reference URLs for each provider
 
-### Phase 3: Documentation Updates
-- Update README.md with skill auditor information
-- Create examples of modular skill architecture
-- Document best practices for skill creation
+### Phase 2: Skill Development (using opencode-skill-creation)
+1. Use opencode-skill-creation skill to create `opentofu-provider-setup` skill
+2. Use opencode-skill-creation skill to create `opentofu-provisioning-workflow` skill
+3. Ensure each skill follows SKILL.md format with proper frontmatter
 
-### Phase 4: Integration
-- Test skill auditor in workflow
-- Validate audit results
-- Implement feedback mechanisms
+### Phase 3: Testing and Validation
+1. Test skill invocation with `opencode` command
+2. Verify reference URLs are accessible and accurate
+3. Validate skills follow existing SKILL.md format
+4. Test setup.sh with OpenTofu dependencies
+
+### Phase 4: Documentation Updates
+1. Update README.md to include new OpenTofu skills in the overview
+2. Update setup.sh to check for OpenTofu CLI (tofu)
+3. Add examples to README showing skill usage
 
 ## Success Criteria
-- [ ] Skill auditor implementation is complete and functional
-- [ ] Skill audit identifies at least 3 areas for modularization
-- [ ] Documentation is updated with skill auditor usage
-- [ ] All existing skills pass audit validation
-- [ ] Skill auditor follows OpenCode framework guidelines
+
+- [ ] At least 2-3 skills created for OpenTofu workflows
+- [ ] Each skill includes a reference URL to provider documentation
+- [ ] Skills follow the existing SKILL.md format (see skills/jira-git-workflow/SKILL.md)
+- [ ] Skills are tested and documented in the repository
+- [ ] Setup.sh includes any necessary OpenTofu dependencies (if applicable)
+- [ ] README.md updated with new skills documentation
 
 ## Notes
-This is part of a broader initiative to improve the OpenCode skill ecosystem. The skill auditor will help maintain clean, modular, and reusable skill architecture following DRY principles.
 
-## Dependencies
-- OpenCode framework v2.0+
-- Existing skills in skills/ directory
-- Valid config.json schema compliance
-
-## Risks
-- Risk: Skill auditor may generate false positives for redundancy
-  Mitigation: Include manual review process in audit workflow
-- Risk: Modularization may break existing skill dependencies
-  Mitigation: Implement backward compatibility testing before refactoring
-
-## Next Steps
-1. Review skill auditor implementation
-2. Execute audit on existing skills
-3. Create modularization plan
-4. Implement identified improvements
-5. Update documentation
+- OpenTofu maintains API compatibility with Terraform 1.5.x
+- Provider documentation can be sourced from both Terraform Registry and OpenTofu docs
+- Focus on common providers (AWS, Azure, GCP, etc.) initially
+- Ensure skills are vendor-agnostic where possible
+- Reference URLs:
+  - OpenTofu Documentation: https://opentofu.org/docs/
+  - Terraform Registry: https://registry.terraform.io/

--- a/skills/opentofu-aws-explorer/SKILL.md
+++ b/skills/opentofu-aws-explorer/SKILL.md
@@ -1,0 +1,1159 @@
+---
+name: opentofu-aws-explorer
+description: Explore and manage AWS cloud infrastructure resources using OpenTofu/Terraform
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: cloud-infrastructure
+---
+
+# OpenTofu AWS Explorer
+
+## What I do
+
+I guide you through managing Amazon Web Services (AWS) infrastructure using the AWS provider for OpenTofu/Terraform. I help you:
+
+- **Compute Resources**: Manage EC2, Lambda, ECS, and container resources
+- **Networking**: Create VPCs, subnets, route tables, and security groups
+- **Storage**: Configure S3, EBS, EFS, and file systems
+- **Databases**: Setup RDS, DynamoDB, ElastiCache, and Redshift
+- **Security**: Implement IAM, KMS, Security Groups, and WAF
+- **Best Practices**: Follow AWS Well-Architected Framework and provider documentation
+
+## When to use me
+
+Use this skill when you need to:
+- Provision AWS infrastructure as code
+- Automate AWS resource creation and management
+- Implement multi-tier architectures (web, app, data)
+- Setup secure networking and VPC configurations
+- Manage IAM roles, policies, and security groups
+- Configure AWS services for production workloads
+- Implement AWS best practices and governance
+
+**Note**: OpenTofu and Terraform are used interchangeably throughout this skill. OpenTofu is an open-source implementation of Terraform and maintains full compatibility with Terraform providers.
+
+## Prerequisites
+
+- **OpenTofu CLI installed**: Install from https://opentofu.org/docs/intro/install/
+- **AWS Account**: Valid AWS account with appropriate permissions
+- **AWS Credentials**: Access keys or IAM role for authentication
+- **Basic AWS Knowledge**: Understanding of AWS services and concepts
+
+## Provider Documentation
+
+- **Terraform Registry (AWS Provider)**: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+- **Latest Provider Version**: hashicorp/aws ~> 5.0.0
+- **Provider Source**: https://github.com/hashicorp/terraform-provider-aws
+- **AWS Well-Architected Framework**: https://docs.aws.amazon.com/wellarchitected/
+
+## Steps
+
+### Step 1: Install and Configure OpenTofu
+
+```bash
+# Verify OpenTofu installation
+tofu version
+
+# Initialize project
+mkdir aws-terraform
+cd aws-terraform
+tofu init
+```
+
+### Step 2: Configure AWS Provider
+
+Create `versions.tf`:
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0.0"
+    }
+  }
+  required_version = ">= 1.0"
+
+  # Remote state backend
+  backend "s3" {
+    bucket         = "terraform-state"
+    key            = "prod/terraform.tfstate"
+    region         = "ap-southeast-1"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}
+```
+
+### Step 3: Configure AWS Authentication
+
+Create `provider.tf`:
+
+```hcl
+provider "aws" {
+  region = var.aws_region
+
+  # Method 1: Access Keys (environment variables)
+  # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+  # Best for development and testing
+
+  # Method 2: Shared Credentials File
+  # ~/.aws/credentials with profiles
+  # Best for multiple AWS accounts
+
+  # Method 3: IAM Role (recommended for production)
+  # assume_role {
+  #   role_arn = "arn:aws:iam::123456789012:role/TerraformRole"
+  #   session_name = "terraform-session"
+  #   external_id = "external-id"
+  # }
+
+  # Method 4: Assume Role with MFA
+  # assume_role {
+  #   role_arn = "arn:aws:iam::123456789012:role/TerraformRole"
+  #   mfa_serial = "arn:aws:iam::123456789012:mfa/user"
+  # }
+
+  # Default tags (applied to all resources)
+  default_tags {
+    tags = {
+      ManagedBy  = "Terraform"
+      Project    = var.project_name
+      Environment = var.environment
+    }
+  }
+}
+```
+
+### Step 4: Configure Environment Variables
+
+```bash
+# Method 1: Environment variables (recommended)
+export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+export AWS_DEFAULT_REGION="ap-southeast-1"
+
+# Method 2: AWS CLI profile
+export AWS_PROFILE="my-profile"
+
+# Method 3: Using AWS Vault (best for security)
+# https://github.com/99designs/aws-vault
+aws-vault exec terraform-role -- tofu plan
+```
+
+### Step 5: Create VPC Networking
+
+Create `networking.tf`:
+
+```hcl
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# Public Subnets (2 AZs for HA)
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-public-subnet-${count.index + 1}"
+    Type = "Public"
+  }
+}
+
+# Private Subnets (2 AZs for HA)
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 2)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${var.project_name}-private-subnet-${count.index + 1}"
+    Type = "Private"
+  }
+}
+
+# Database Subnets (2 AZs for HA)
+resource "aws_subnet" "database" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 4)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${var.project_name}-database-subnet-${count.index + 1}"
+    Type = "Database"
+  }
+}
+
+# EIP for NAT Gateway
+resource "aws_eip" "nat" {
+  count = 2
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.project_name}-nat-eip-${count.index + 1}"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# NAT Gateways
+resource "aws_nat_gateway" "public" {
+  count         = 2
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = {
+    Name = "${var.project_name}-nat-gw-${count.index + 1}"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Route Tables
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+resource "aws_route_table" "private" {
+  count  = 2
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.public[count.index].id
+  }
+
+  tags = {
+    Name = "${var.project_name}-private-rt-${count.index + 1}"
+  }
+}
+
+# Route Table Associations
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+resource "aws_route_table_association" "database" {
+  count          = 2
+  subnet_id      = aws_subnet.database[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+# Data source for availability zones
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+```
+
+### Step 6: Create Security Groups
+
+Create `security.tf`:
+
+```hcl
+# Web Server Security Group
+resource "aws_security_group" "web" {
+  name        = "${var.project_name}-web-sg"
+  description = "Security group for web servers"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS from anywhere"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "SSH from specific IP"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.ssh_allowed_cidr]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-web-sg"
+  }
+}
+
+# Application Server Security Group
+resource "aws_security_group" "app" {
+  name        = "${var.project_name}-app-sg"
+  description = "Security group for application servers"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "HTTP from web servers"
+    from_port      = 8080
+    to_port        = 8080
+    protocol       = "tcp"
+    security_groups = [aws_security_group.web.id]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-app-sg"
+  }
+}
+
+# Database Security Group
+resource "aws_security_group" "database" {
+  name        = "${var.project_name}-db-sg"
+  description = "Security group for databases"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "MySQL from app servers"
+    from_port      = 3306
+    to_port        = 3306
+    protocol       = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-db-sg"
+  }
+}
+
+# Load Balancer Security Group
+resource "aws_security_group" "lb" {
+  name        = "${var.project_name}-lb-sg"
+  description = "Security group for load balancer"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS from anywhere"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-lb-sg"
+  }
+}
+```
+
+### Step 7: Create EC2 Instances
+
+Create `compute.tf`:
+
+```hcl
+# Launch Template
+resource "aws_launch_template" "web" {
+  name_prefix   = "${var.project_name}-web-"
+  image_id      = data.aws_ami.amazon_linux_2.id
+  instance_type = var.web_instance_type
+  key_name      = var.ssh_key_name
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.web.id]
+  }
+
+  user_data = base64encode(templatefile("${path.module}/user_data.sh", {
+    name = "Web Server"
+  }))
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "${var.project_name}-web"
+      Type = "Web"
+    }
+  }
+
+  monitoring {
+    enabled = true
+  }
+}
+
+# Auto Scaling Group
+resource "aws_autoscaling_group" "web" {
+  vpc_zone_identifier = aws_subnet.public[*].id
+  desired_capacity    = 2
+  max_size           = 4
+  min_size           = 2
+
+  target_group_arns = [aws_lb_target_group.web.arn]
+
+  launch_template {
+    id      = aws_launch_template.web.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.project_name}-web"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Type"
+    value               = "Web"
+    propagate_at_launch = true
+  }
+}
+
+# Application Load Balancer
+resource "aws_lb" "web" {
+  name               = "${var.project_name}-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.lb.id]
+  subnets           = aws_subnet.public[*].id
+
+  enable_deletion_protection = false
+
+  tags = {
+    Name = "${var.project_name}-lb"
+  }
+}
+
+# Target Group
+resource "aws_lb_target_group" "web" {
+  name        = "${var.project_name}-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path                = "/health"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = {
+    Name = "${var.project_name}-tg"
+  }
+}
+
+# Listener
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = aws_lb.web.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.web.arn
+  }
+}
+
+# Data source for latest AMI
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+```
+
+### Step 8: Create RDS Database
+
+Create `database.tf`:
+
+```hcl
+# RDS Subnet Group
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-db-subnet-group"
+  subnet_ids = aws_subnet.database[*].id
+
+  tags = {
+    Name = "${var.project_name}-db-subnet-group"
+  }
+}
+
+# RDS Parameter Group
+resource "aws_db_parameter_group" "main" {
+  name        = "${var.project_name}-db-parameter-group"
+  family      = "mysql8.0"
+  description = "Custom parameter group for MySQL"
+
+  parameter {
+    name  = "max_connections"
+    value = "100"
+  }
+}
+
+# RDS Instance
+resource "aws_db_instance" "main" {
+  identifier             = "${var.project_name}-db"
+  engine                 = "mysql"
+  engine_version          = "8.0"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  storage_type          = "gp2"
+  storage_encrypted     = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.database.id]
+  multi_az               = true
+
+  backup_retention_period = 7
+  backup_window         = "03:00-04:00"
+  maintenance_window     = "Mon:04:00-Mon:05:00"
+
+  parameter_group_name = aws_db_parameter_group.main.name
+  skip_final_snapshot = false
+  final_snapshot_identifier = "${var.project_name}-db-final-snapshot"
+
+  tags = {
+    Name = "${var.project_name}-db"
+  }
+}
+```
+
+### Step 9: Create S3 Bucket
+
+Create `storage.tf`:
+
+```hcl
+# S3 Bucket
+resource "aws_s3_bucket" "data" {
+  bucket_prefix = "${var.project_name}-data-"
+  force_destroy = var.environment == "dev" ? true : false
+
+  tags = {
+    Name = "${var.project_name}-data"
+  }
+}
+
+# S3 Bucket Versioning
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# S3 Bucket Server-Side Encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# S3 Bucket Public Access Block
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# S3 Bucket Lifecycle
+resource "aws_s3_bucket_lifecycle_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    id     = "cleanup"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+```
+
+### Step 10: Create IAM Roles
+
+Create `iam.tf`:
+
+```hcl
+# IAM Role for EC2
+resource "aws_iam_role" "ec2_role" {
+  name = "${var.project_name}-ec2-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.project_name}-ec2-role"
+  }
+}
+
+# IAM Policy for EC2
+resource "aws_iam_role_policy" "ec2_policy" {
+  name = "${var.project_name}-ec2-policy"
+  role = aws_iam_role.ec2_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket"
+        ]
+        Effect = "Allow"
+        Resource = [
+          "${aws_s3_bucket.data.arn}/*",
+          aws_s3_bucket.data.arn
+        ]
+      },
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Effect = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# IAM Instance Profile
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name = "${var.project_name}-ec2-profile"
+  role = aws_iam_role.ec2_role.name
+}
+```
+
+### Step 11: Create CloudWatch Alarms
+
+Create `monitoring.tf`:
+
+```hcl
+# CPU Utilization Alarm
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = "${var.project_name}-cpu-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period             = "300"
+  statistic           = "Average"
+  threshold          = "80"
+  alarm_description   = "This metric monitors EC2 CPU utilization"
+
+  dimensions {
+    AutoScalingGroupName = aws_autoscaling_group.web.name
+  }
+}
+
+# Disk Space Alarm
+resource "aws_cloudwatch_metric_alarm" "disk_space_low" {
+  alarm_name          = "${var.project_name}-disk-low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DiskSpaceUtilization"
+  namespace           = "CWAgent"
+  period             = "300"
+  statistic           = "Average"
+  threshold          = "20"
+  alarm_description   = "This metric monitors disk space"
+}
+```
+
+### Step 12: Define Variables
+
+Create `variables.tf`:
+
+```hcl
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-southeast-1"
+}
+
+variable "project_name" {
+  description = "Project name used for tagging"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "web_instance_type" {
+  description = "Instance type for web servers"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "ssh_key_name" {
+  description = "SSH key name"
+  type        = string
+}
+
+variable "ssh_allowed_cidr" {
+  description = "CIDR block allowed for SSH access"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+}
+
+variable "db_username" {
+  description = "Database username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true
+}
+```
+
+### Step 13: Create Outputs
+
+Create `outputs.tf`:
+
+```hcl
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "database_subnet_ids" {
+  description = "Database subnet IDs"
+  value       = aws_subnet.database[*].id
+}
+
+output "lb_dns_name" {
+  description = "Load balancer DNS name"
+  value       = aws_lb.web.dns_name
+}
+
+output "db_endpoint" {
+  description = "Database endpoint"
+  value       = aws_db_instance.main.endpoint
+  sensitive   = true
+}
+
+output "s3_bucket_arn" {
+  description = "S3 bucket ARN"
+  value       = aws_s3_bucket.data.arn
+}
+```
+
+### Step 14: Initialize and Apply
+
+```bash
+# Initialize providers
+tofu init
+
+# Plan changes
+tofu plan -out=tfplan
+
+# Apply changes
+tofu apply tfplan
+
+# Show outputs
+tofu output
+```
+
+## Best Practices
+
+### Security
+
+1. **Least Privilege**: Grant minimal permissions in IAM roles and policies
+2. **Encryption**: Enable encryption at rest and in transit
+3. **Security Groups**: Restrict access to necessary IPs and security groups
+4. **KMS**: Use AWS KMS for encryption key management
+5. **MFA**: Enable MFA for root and privileged IAM users
+
+### High Availability
+
+1. **Multi-AZ Deployments**: Spread resources across availability zones
+2. **Auto Scaling**: Use auto scaling groups for compute resources
+3. **Load Balancing**: Distribute traffic with load balancers
+4. **Database HA**: Enable multi-AZ for RDS instances
+5. **Health Checks**: Configure proper health checks for all services
+
+### Cost Optimization
+
+1. **Right-Sizing**: Choose appropriate instance types and storage
+2. **Reserved Instances**: Use reserved instances for predictable workloads
+3. **S3 Lifecycle**: Implement S3 lifecycle policies for cost savings
+4. **Spot Instances**: Use spot instances for fault-tolerant workloads
+5. **Monitor Costs**: Use AWS Cost Explorer and Budgets
+
+### Networking
+
+1. **VPC Best Practices**: Use separate subnets for tiers (web, app, db)
+2. **NAT Gateways**: Use NAT gateways in each AZ for outbound internet
+3. **Route Tables**: Separate route tables for public and private subnets
+4. **DNS**: Use Route 53 for DNS management
+5. **VPC Peering**: Use VPC peering for inter-VPC communication
+
+### State Management
+
+1. **Remote State**: Use S3 or other remote backends for state
+2. **State Locking**: Enable DynamoDB for state locking
+3. **State Encryption**: Encrypt state files
+4. **State Versioning**: Enable versioning on state bucket
+5. **State Backup**: Regularly backup state files
+
+## Common Issues
+
+### Issue: Provider Not Found
+
+**Symptom**: Error `Error: Failed to query available provider packages`
+
+**Solution**:
+```bash
+# Update provider versions
+tofu init -upgrade
+
+# Check internet connectivity
+curl https://registry.terraform.io/
+
+# Verify provider source and version
+```
+
+### Issue: Authentication Failed
+
+**Symptom**: Error `Error: error configuring Terraform AWS Provider`
+
+**Solution**:
+```bash
+# Verify credentials
+aws sts get-caller-identity
+
+# Check environment variables
+echo $AWS_ACCESS_KEY_ID
+echo $AWS_SECRET_ACCESS_KEY
+echo $AWS_DEFAULT_REGION
+
+# Test credentials
+aws s3 ls
+
+# Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
+```
+
+### Issue: Resource Already Exists
+
+**Symptom**: Error `Error: ... already exists`
+
+**Solution**:
+```bash
+# Import existing resource
+tofu import aws_vpc.main vpc-12345678
+
+# Or use -target to create specific resources
+tofu apply -target=aws_s3_bucket.data
+```
+
+### Issue: State Lock Error
+
+**Symptom**: Error `Error: Error acquiring the state lock`
+
+**Solution**:
+```bash
+# Check who has the lock
+tofu state pull
+
+# Force unlock (caution!)
+tofu force-unlock <LOCK_ID>
+
+# Or wait for other operation to complete
+```
+
+### Issue: Invalid IAM Policy
+
+**Symptom**: Error `Error: Error creating IAM policy`
+
+**Solution**:
+```hcl
+# Validate JSON syntax
+jq . policy.json
+
+# Use jsonencode for policies
+policy = jsonencode({
+  Version = "2012-10-17"
+  Statement = [...]
+})
+```
+
+### Issue: Security Group Rule Conflict
+
+**Symptom**: Error `Error: Error creating Security Group`
+
+**Solution**:
+```bash
+# Check existing security group rules
+aws ec2 describe-security-groups --group-ids sg-12345678
+
+# Ensure no overlapping rules
+# Use security_group_rule resource if needed
+```
+
+## Reference Documentation
+
+- **Terraform Registry (AWS Provider)**: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+- **AWS Documentation**: https://docs.aws.amazon.com/
+- **AWS Well-Architected Framework**: https://docs.aws.amazon.com/wellarchitected/
+- **OpenTofu Documentation**: https://opentofu.org/docs/
+- **AWS CLI**: https://docs.aws.amazon.com/cli/
+
+## Examples
+
+### Complete 3-Tier Architecture
+
+```hcl
+# VPC and Networking
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "web" {
+  count = 2
+  vpc_id = aws_vpc.main.id
+  cidr_block = cidrsubnet("10.0.0.0/16", 8, count.index)
+}
+
+# Security Groups
+resource "aws_security_group" "web" {
+  name = "web-sg"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# EC2 with ALB
+resource "aws_lb" "web" {
+  name               = "web-lb"
+  load_balancer_type = "application"
+  subnets           = aws_subnet.web[*].id
+}
+
+resource "aws_autoscaling_group" "web" {
+  vpc_zone_identifier = aws_subnet.web[*].id
+  desired_capacity    = 2
+  max_size           = 4
+  min_size           = 2
+
+  launch_template {
+    id = aws_launch_template.web.id
+  }
+}
+```
+
+### RDS Database Setup
+
+```hcl
+resource "aws_db_instance" "main" {
+  identifier             = "production-db"
+  engine                 = "mysql"
+  instance_class         = "db.t3.medium"
+  allocated_storage      = 100
+  storage_encrypted     = true
+  multi_az               = true
+  backup_retention_period = 30
+
+  db_name  = "appdb"
+  username = "admin"
+  password = var.db_password
+
+  parameter_group_name = aws_db_parameter_group.main.name
+}
+```
+
+### S3 with Lifecycle
+
+```hcl
+resource "aws_s3_bucket" "data" {
+  bucket = "my-app-data"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    id     = "archive"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+```
+
+## Tips and Tricks
+
+- **Use Data Sources**: Reference existing resources with data sources
+- **Use Outputs**: Export important values for other configurations
+- **Use Modules**: Create reusable infrastructure components
+- **Use Workspaces**: Manage multiple environments
+- **Import Resources**: Import existing resources into state
+- **Validate Configuration**: Run `tofu validate` before applying
+- **Use Remote State**: Share state across configurations
+
+## Next Steps
+
+After mastering AWS provider, explore:
+- **opentofu-kubernetes-explorer**: Kubernetes deployment provider
+- **AWS Services**: Explore advanced AWS services (Lambda, ECS, EKS)
+- **AWS Well-Architected**: Implement AWS best practices
+- **Cost Management**: Use AWS Cost Explorer and Budgets

--- a/skills/opentofu-keycloak-explorer/SKILL.md
+++ b/skills/opentofu-keycloak-explorer/SKILL.md
@@ -1,0 +1,830 @@
+---
+name: opentofu-keycloak-explorer
+description: Explore and manage Keycloak identity and access management resources using OpenTofu/Terraform
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: identity-management
+---
+
+# OpenTofu Keycloak Explorer
+
+## What I do
+
+I guide you through managing Keycloak identity and access management (IAM) resources using the Keycloak provider for OpenTofu/Terraform. I help you:
+
+- **Realm Management**: Create and configure Keycloak realms
+- **Client Configuration**: Setup OAuth2/OpenID Connect clients
+- **User and Role Management**: Manage users, groups, and roles
+- **Authentication Flows**: Configure authentication flows and mappers
+- **Best Practices**: Follow Keycloak provider documentation patterns
+
+## When to use me
+
+Use this skill when you need to:
+- Automate Keycloak infrastructure as code
+- Manage identity providers (GitHub, Google, Azure AD, etc.)
+- Setup authentication and authorization flows
+- Manage users, groups, and roles programmatically
+- Configure client applications with OAuth2/OpenID Connect
+- Implement fine-grained access control
+
+**Note**: OpenTofu and Terraform are used interchangeably throughout this skill. OpenTofu is an open-source implementation of Terraform and maintains full compatibility with Terraform providers.
+
+## Prerequisites
+
+- **OpenTofu CLI installed**: Install from https://opentofu.org/docs/intro/install/
+- **Keycloak Server**: Running Keycloak instance (managed or self-hosted)
+- **Keycloak Admin Account**: Credentials with admin privileges
+- **Basic IAM Knowledge**: Understanding of OAuth2, OpenID Connect, and SAML
+
+## Provider Documentation
+
+- **Terraform Registry**: https://registry.terraform.io/providers/keycloak/keycloak/latest/docs
+- **Latest Provider Version**: keycloak/keycloak ~> 5.0.0
+- **Provider Source**: https://github.com/mrparkers/terraform-provider-keycloak
+
+## Steps
+
+### Step 1: Install and Configure OpenTofu
+
+```bash
+# Verify OpenTofu installation
+tofu version
+
+# Initialize project
+mkdir keycloak-terraform
+cd keycloak-terraform
+tofu init
+```
+
+### Step 2: Configure Keycloak Provider
+
+Create `versions.tf`:
+
+```hcl
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "keycloak/keycloak"
+      version = "~> 5.0.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+# State backend configuration
+backend "s3" {
+  bucket = "keycloak-state"
+  key    = "terraform.tfstate"
+  region = "us-east-1"
+}
+```
+
+### Step 3: Configure Provider Connection
+
+Create `provider.tf`:
+
+```hcl
+provider "keycloak" {
+  # Method 1: Direct URL (local development)
+  url       = "http://localhost:8080"
+  client_id = "admin-cli"
+  username  = "admin"
+  password  = "admin"
+
+  # Method 2: Managed Keycloak (e.g., Red Hat SSO)
+  url       = "https://sso.example.com/auth"
+  client_id = "terraform"
+  username  = var.keycloak_admin_username
+  password  = var.keycloak_admin_password
+
+  # Method 3: Client Credentials (recommended for production)
+  url       = "https://keycloak.example.com"
+  client_id = "terraform"
+  # Read from environment variable: KEYCLOAK_CLIENT_SECRET
+}
+```
+
+### Step 4: Configure Environment Variables
+
+```bash
+# For production usage, use environment variables
+export KEYCLOAK_CLIENT_SECRET="your-client-secret"
+
+# Or use variable file
+cat > terraform.tfvars <<EOF
+keycloak_admin_username = "admin"
+keycloak_admin_password = "secure-password"
+EOF
+```
+
+### Step 5: Create Keycloak Realm
+
+Create `realm.tf`:
+
+```hcl
+resource "keycloak_realm" "example" {
+  realm        = "example"
+  enabled      = true
+
+  # Display settings
+  display_name = "Example Realm"
+  display_name_html = "<div class='kc-logo-text'><span>Example</span></div>"
+
+  # Security settings
+  ssl_required = "external"
+
+  # User registration
+  registration_allowed = true
+  registration_email_as_username = true
+
+  # Reset password
+  reset_password_allowed = true
+  edit_username_allowed = true
+  brute_force_protected = true
+
+  # Internationalization
+  internationalization_enabled = true
+  supported_locales = ["en", "es", "fr"]
+  default_locale = "en"
+
+  # Login theme
+  login_theme = "keycloak"
+  account_theme = "keycloak"
+
+  # SMTP settings (optional)
+  smtp_server {
+    host = "smtp.gmail.com"
+    port = 587
+    from = "noreply@example.com"
+    starttls = true
+    ssl = false
+    auth {
+      username = var.smtp_username
+      password = var.smtp_password
+    }
+  }
+
+  # Browser security headers
+  browser_security_headers {
+    content_security_policy_report_only = false
+    x_content_type_options = "nosniff"
+    x_robots_tag = "none"
+    x_frame_options = "SAMEORIGIN"
+    content_security_policy = "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
+    x_xss_protection = "1; mode=block"
+    strict_transport_security = "max-age=31536000; includeSubDomains"
+  }
+}
+```
+
+### Step 6: Create Identity Providers
+
+Create `identity_providers.tf`:
+
+```hcl
+# GitHub OAuth2
+resource "keycloak_identity_provider" "github" {
+  realm             = keycloak_realm.example.realm
+  alias             = "github"
+  display_name      = "GitHub"
+  provider_id       = "github"
+  enabled           = true
+  trust_email       = true
+  first_broker_login_flow_alias = keycloak_authentication_flow.github.id
+  store_token      = true
+  add_read_token_role_on_create = false
+
+  config {
+    client_id      = var.github_client_id
+    client_secret  = var.github_client_secret
+    use_jwks_url  = true
+  }
+}
+
+# Google OAuth2
+resource "keycloak_identity_provider" "google" {
+  realm             = keycloak_realm.example.realm
+  alias             = "google"
+  display_name      = "Google"
+  provider_id       = "google"
+  enabled           = true
+  store_token      = false
+  trust_email       = true
+  first_broker_login_flow_alias = keycloak_authentication_flow.google.id
+
+  config {
+    client_id         = var.google_client_id
+    client_secret     = var.google_client_secret
+    hosted_domain     = "example.com"
+    use_jwks_url    = true
+  }
+}
+
+# Azure AD / Microsoft
+resource "keycloak_identity_provider" "azure" {
+  realm             = keycloak_realm.example.realm
+  alias             = "azure"
+  display_name      = "Microsoft"
+  provider_id       = "azure"
+  enabled           = true
+  trust_email       = true
+
+  config {
+    client_id           = var.azure_client_id
+    client_secret       = var.azure_client_secret
+    tenant_id           = var.azure_tenant_id
+    gui_order           = 10
+    hide_on_login_page  = false
+  }
+}
+```
+
+### Step 7: Create Authentication Flows
+
+Create `authentication.tf`:
+
+```hcl
+# Browser flow
+resource "keycloak_authentication_flow" "browser" {
+  realm_id    = keycloak_realm.example.id
+  alias       = "browser"
+  description = "Browser based authentication"
+  provider_id = "basic-flow"
+  top_level   = true
+}
+
+# GitHub flow
+resource "keycloak_authentication_flow" "github" {
+  realm_id    = keycloak_realm.example.id
+  alias       = "github"
+  description = "GitHub authentication"
+  provider_id = "basic-flow"
+  top_level   = true
+}
+
+# Reset credentials flow
+resource "keycloak_authentication_flow" "reset_credentials" {
+  realm_id    = keycloak_realm.example.id
+  alias       = "reset credentials"
+  description = "Reset credentials for a user if they forgot their password or something"
+  provider_id = "basic-flow"
+  top_level   = true
+}
+```
+
+### Step 8: Create User and Group
+
+Create `users.tf`:
+
+```hcl
+# Group
+resource "keycloak_group" "developers" {
+  realm_id = keycloak_realm.example.id
+  name     = "developers"
+  attributes = {
+    department = "engineering"
+    team = "platform"
+  }
+}
+
+# Subgroup
+resource "keycloak_group" "frontend" {
+  realm_id = keycloak_realm.example.id
+  parent_id = keycloak_group.developers.id
+  name     = "frontend"
+}
+
+# Role
+resource "keycloak_role" "developer" {
+  realm_id    = keycloak_realm.example.id
+  name        = "developer"
+  description = "Developer role with API access"
+  attributes = {
+    access_level = "full"
+  }
+}
+
+# User
+resource "keycloak_user" "admin_user" {
+  realm_id = keycloak_realm.example.id
+  username = "johndoe"
+  enabled  = true
+  email    = "john.doe@example.com"
+  first_name = "John"
+  last_name  = "Doe"
+
+  # User attributes
+  attributes = {
+    job_title  = "Senior Developer"
+    department = "Engineering"
+  }
+
+  # Initial password
+  initial_password {
+    value     = var.user_password
+    temporary = false
+  }
+
+  # Add user to group
+  groups = [
+    keycloak_group.developers.id
+  ]
+
+  # Assign roles
+  realm_roles = [
+    keycloak_role.developer.name
+  ]
+}
+
+# Role mapping
+resource "keycloak_group_roles" "developers_roles" {
+  realm_id = keycloak_realm.example.id
+  group_id = keycloak_group.developers.id
+
+  realm_roles = [
+    keycloak_role.developer.name
+  ]
+}
+```
+
+### Step 9: Create Client Application
+
+Create `clients.tf`:
+
+```hcl
+# Web application (confidential client)
+resource "keycloak_openid_client" "web_app" {
+  realm_id                    = keycloak_realm.example.id
+  client_id                   = "my-web-app"
+  name                        = "My Web Application"
+  enabled                     = true
+
+  # Access type
+  access_type                 = "CONFIDENTIAL"
+  client_authenticator_type     = "client-secret"
+  standard_flow_enabled        = true
+  direct_access_grants_enabled = true
+  service_accounts_enabled     = true
+  valid_redirect_uris        = [
+    "https://app.example.com/callback",
+    "https://app.example.com/silent-callback"
+  ]
+  web_origins               = ["https://app.example.com"]
+
+  # Logout settings
+  frontchannel_logout         = true
+  frontchannel_logout_url     = "https://app.example.com/logout"
+  backchannel_logout_url     = "https://app.example.com/backchannel-logout"
+
+  # Token settings
+  access_token_lifespan     = "3600"
+  client_session_idle       = "1800"
+  client_session_max       = "3600"
+
+  # Fine grain OpenID Connect configuration
+  consent_required         = false
+
+  # Protocol mappers
+  protocol_mappers {
+    name                   = "username"
+    protocol               = "openid-connect"
+    protocol_mapper        = "user-attribute-mapper"
+    user_attribute         = "username"
+    claim_name             = "preferred_username"
+    json_type_label        = "String"
+    add_to_id_token       = true
+    add_to_access_token   = true
+  }
+
+  protocol_mappers {
+    name                   = "email"
+    protocol               = "openid-connect"
+    protocol_mapper        = "user-attribute-mapper"
+    user_attribute         = "email"
+    claim_name             = "email"
+    json_type_label        = "String"
+    add_to_id_token       = true
+    add_to_access_token   = true
+  }
+}
+
+# SPA application (public client)
+resource "keycloak_openid_client" "spa_app" {
+  realm_id               = keycloak_realm.example.id
+  client_id              = "my-spa-app"
+  name                   = "My SPA Application"
+  enabled                = true
+
+  access_type            = "PUBLIC"
+  standard_flow_enabled   = true
+  implicit_flow_enabled   = false
+  direct_access_grants_enabled = false
+  service_accounts_enabled = false
+
+  # SPA settings
+  web_origins          = ["+"]
+  valid_redirect_uris   = [
+    "https://spa.example.com/callback"
+  ]
+
+  # PKCE settings (recommended for SPAs)
+  pkce_code_challenge_method = "S256"
+}
+
+# Machine-to-Machine client
+resource "keycloak_openid_client" "api_service" {
+  realm_id               = keycloak_realm.example.id
+  client_id              = "api-service"
+  name                   = "API Service"
+  enabled                = true
+
+  access_type            = "CONFIDENTIAL"
+  service_accounts_enabled = true
+  client_authenticator_type = "client-secret"
+
+  # No user interaction
+  standard_flow_enabled   = false
+  direct_access_grants_enabled = false
+}
+```
+
+### Step 10: Configure Client Scopes
+
+Create `scopes.tf`:
+
+```hcl
+# Custom scope
+resource "keycloak_openid_client_scope" "api_scope" {
+  realm_id            = keycloak_realm.example.id
+  name                = "api:read"
+  description         = "API read access scope"
+}
+
+# Protocol mapper in scope
+resource "keycloak_generic_protocol_mapper" "api_scope_mapper" {
+  realm_id         = keycloak_realm.example.id
+  name            = "api-read-mapper"
+  protocol         = "openid-connect"
+  protocol_mapper = "user-attribute-mapper"
+
+  # Scope configuration
+  add_to_id_token  = true
+  add_to_access_token = true
+  claim_name       = "api_read"
+  user_attribute   = "api_read"
+
+  # Add to scope
+  client_scope_id = keycloak_openid_client_scope.api_scope.id
+}
+```
+
+### Step 11: Define Variables
+
+Create `variables.tf`:
+
+```hcl
+variable "keycloak_admin_username" {
+  description = "Keycloak admin username"
+  type        = string
+  sensitive   = true
+}
+
+variable "keycloak_admin_password" {
+  description = "Keycloak admin password"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_client_id" {
+  description = "GitHub OAuth2 client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_client_secret" {
+  description = "GitHub OAuth2 client secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "google_client_id" {
+  description = "Google OAuth2 client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "google_client_secret" {
+  description = "Google OAuth2 client secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "smtp_username" {
+  description = "SMTP username"
+  type        = string
+  sensitive   = true
+}
+
+variable "smtp_password" {
+  description = "SMTP password"
+  type        = string
+  sensitive   = true
+}
+```
+
+### Step 12: Initialize and Apply
+
+```bash
+# Initialize providers
+tofu init
+
+# Plan changes
+tofu plan -out=tfplan
+
+# Apply changes
+tofu apply tfplan
+```
+
+## Best Practices
+
+### Security
+
+1. **Use Service Accounts**: For production, use service account credentials instead of admin credentials
+2. **Least Privilege**: Grant only necessary permissions to service accounts
+3. **Secure Secrets**: Store sensitive data in environment variables or secret managers
+4. **Enable SSL/TLS**: Always use HTTPS in production environments
+5. **Session Management**: Set appropriate session timeouts
+
+### Organization
+
+1. **Modular Configuration**: Split resources into logical files (realm.tf, clients.tf, users.tf)
+2. **Terraform Modules**: Create reusable modules for common patterns
+3. **State Management**: Use remote backend with encryption and locking
+4. **Environment Separation**: Use workspaces or separate state files for dev/staging/prod
+
+### Authentication Flows
+
+1. **Customize for Your Needs**: Modify authentication flows based on requirements
+2. **Multi-Factor Authentication**: Enable MFA for sensitive applications
+3. **Social Login**: Configure identity providers (GitHub, Google, etc.)
+4. **Password Policies**: Set strong password policies
+
+### Client Configuration
+
+1. **Use PKCE for SPAs**: Recommended security practice for single-page applications
+2. **Set Appropriate Scopes**: Only request necessary scopes
+3. **Configure Redirect URIs**: Only allow trusted redirect URIs
+4. **Logout Configuration**: Implement proper logout flows (frontchannel and backchannel)
+
+## Common Issues
+
+### Issue: Provider Connection Failed
+
+**Symptom**: Error `Error: Failed to GET: http://localhost:8080/auth/realms/master/protocol/openid-connect/token`
+
+**Solution**:
+```bash
+# Verify Keycloak is running
+curl http://localhost:8080/health/ready
+
+# Check provider configuration
+# Ensure URL includes /auth/ for Keycloak < 18
+# Omit /auth/ for Keycloak >= 18
+
+# Test credentials manually
+curl -X POST http://localhost:8080/auth/realms/master/protocol/openid-connect/token \
+  -d "client_id=admin-cli" \
+  -d "username=admin" \
+  -d "password=admin" \
+  -d "grant_type=password"
+```
+
+### Issue: Authentication Flow Not Found
+
+**Symptom**: Error `Error: Could not execute: Authentication flow not found`
+
+**Solution**:
+```bash
+# Ensure authentication flow is created before assigning
+# Check flow existence:
+tofu state list | grep authentication_flow
+
+# Verify flow alias matches exactly
+```
+
+### Issue: Client Registration Fails
+
+**Symptom**: Error `Error: Error creating client: HTTP 409 Conflict`
+
+**Solution**:
+```bash
+# Check if client already exists
+tofu import keycloak_openid_client.web_app my-realm/my-web-app
+
+# Or use import block in configuration
+import {
+  to = keycloak_openid_client.web_app
+  id = "my-realm/my-web-app"
+}
+```
+
+### Issue: Identity Provider Configuration
+
+**Symptom**: Error `Error: Failed to configure identity provider`
+
+**Solution**:
+```bash
+# Verify OAuth2 credentials
+# Check client ID and secret from provider console
+# Ensure redirect URI matches in Keycloak
+
+# Reference provider documentation:
+# GitHub: https://docs.github.com/en/developers/apps/building-oauth-apps
+# Google: https://developers.google.com/identity/protocols/oauth2
+# Azure: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
+```
+
+### Issue: User Creation with Password
+
+**Symptom**: Password not set or temporary password not working
+
+**Solution**:
+```hcl
+# Ensure initial_password block is correctly configured
+resource "keycloak_user" "user" {
+  username = "testuser"
+  enabled  = true
+
+  initial_password {
+    value     = "SecurePassword123!"
+    temporary = false
+  }
+}
+```
+
+### Issue: Protocol Mapper Not Working
+
+**Symptom**: Claims not appearing in token
+
+**Solution**:
+```hcl
+# Check mapper configuration
+# Verify claim_name and user_attribute match
+# Ensure add_to_id_token or add_to_access_token is true
+protocol_mappers {
+  name                 = "email"
+  protocol             = "openid-connect"
+  protocol_mapper      = "user-attribute-mapper"
+  user_attribute       = "email"
+  claim_name           = "email"
+  add_to_id_token     = true
+  add_to_access_token = true
+}
+```
+
+## Reference Documentation
+
+- **Terraform Registry (Keycloak Provider)**: https://registry.terraform.io/providers/keycloak/keycloak/latest/docs
+- **Provider GitHub**: https://github.com/mrparkers/terraform-provider-keycloak
+- **Keycloak Documentation**: https://www.keycloak.org/documentation.html
+- **OpenTofu Documentation**: https://opentofu.org/docs/
+- **OAuth2 Best Practices**: https://datatracker.ietf.org/doc/html/rfc6749
+
+## Examples
+
+### Complete Realm Setup
+
+```hcl
+# versions.tf
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "keycloak/keycloak"
+      version = "~> 5.0.0"
+    }
+  }
+}
+
+# provider.tf
+provider "keycloak" {
+  url       = "https://keycloak.example.com"
+  client_id = "terraform"
+  client_secret = var.keycloak_client_secret
+}
+
+# realm.tf
+resource "keycloak_realm" "production" {
+  realm   = "production"
+  enabled = true
+  ssl_required = "external"
+
+  smtp_server {
+    host = "smtp.example.com"
+    port = 587
+    from = "noreply@example.com"
+    starttls = true
+  }
+}
+
+# clients.tf
+resource "keycloak_openid_client" "dashboard" {
+  realm_id              = keycloak_realm.production.id
+  client_id             = "dashboard"
+  name                  = "Dashboard Application"
+  enabled               = true
+  access_type           = "PUBLIC"
+  standard_flow_enabled  = true
+
+  valid_redirect_uris    = ["https://dashboard.example.com/callback"]
+  web_origins          = ["https://dashboard.example.com"]
+
+  protocol_mappers {
+    name                  = "email"
+    protocol              = "openid-connect"
+    protocol_mapper       = "user-attribute-mapper"
+    user_attribute        = "email"
+    claim_name            = "email"
+    add_to_id_token      = true
+    add_to_access_token  = true
+  }
+}
+```
+
+### Social Login Setup
+
+```hcl
+# identity_providers.tf
+resource "keycloak_identity_provider" "github" {
+  realm  = keycloak_realm.production.id
+  alias  = "github"
+  provider_id = "github"
+  enabled = true
+
+  config {
+    client_id = var.github_client_id
+    client_secret = var.github_client_secret
+  }
+}
+
+resource "keycloak_identity_provider" "google" {
+  realm  = keycloak_realm.production.id
+  alias  = "google"
+  provider_id = "google"
+  enabled = true
+
+  config {
+    client_id = var.google_client_id
+    client_secret = var.google_client_secret
+  }
+}
+```
+
+### User and Role Management
+
+```hcl
+# users.tf
+resource "keycloak_group" "admins" {
+  realm_id = keycloak_realm.production.id
+  name     = "admins"
+}
+
+resource "keycloak_role" "admin" {
+  realm_id = keycloak_realm.production.id
+  name     = "admin"
+}
+
+resource "keycloak_user" "alice" {
+  realm_id = keycloak_realm.production.id
+  username = "alice"
+  enabled  = true
+  email    = "alice@example.com"
+
+  initial_password {
+    value     = "SecurePassword!"
+    temporary = false
+  }
+
+  realm_roles = [keycloak_role.admin.name]
+  groups     = [keycloak_group.admins.id]
+}
+```
+
+## Tips and Tricks
+
+- **Use tofu import**: Import existing Keycloak resources into state
+- **Validate Configuration**: Run `tofu validate` before applying
+- **Use Workspaces**: Manage multiple environments (dev, staging, prod)
+- **Backup State**: Regularly backup Terraform state
+- **Monitor Changes**: Use `tofu plan` to review changes before applying
+- **Use Modules**: Create reusable modules for common patterns
+
+## Next Steps
+
+After mastering Keycloak provider, explore:
+- **opentofu-aws-explorer**: AWS cloud provider
+- **opentofu-kubernetes-explorer**: Kubernetes deployment provider
+- **Keycloak Admin Console**: Learn more about Keycloak features
+- **Advanced Authentication**: Configure advanced authentication flows and MFA

--- a/skills/opentofu-kubernetes-explorer/SKILL.md
+++ b/skills/opentofu-kubernetes-explorer/SKILL.md
@@ -1,0 +1,1212 @@
+---
+name: opentofu-kubernetes-explorer
+description: Explore and manage Kubernetes clusters and resources using OpenTofu/Terraform
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: container-orchestration
+---
+
+# OpenTofu Kubernetes Explorer
+
+## What I do
+
+I guide you through managing Kubernetes clusters and resources using Kubernetes provider for OpenTofu/Terraform. I help you:
+
+- **Cluster Management**: Deploy and manage Kubernetes clusters
+- **Resource Deployment**: Create pods, deployments, services, and configmaps
+- **Ingress and Networking**: Configure ingress controllers and network policies
+- **Storage**: Create and manage persistent volumes and storage classes
+- **Helm Charts**: Deploy Helm charts for complex applications
+- **Best Practices**: Follow Kubernetes and provider documentation patterns
+
+## When to use me
+
+Use this skill when you need to:
+- Automate Kubernetes resource management as code
+- Deploy applications to Kubernetes clusters
+- Manage Kubernetes configuration (ConfigMaps, Secrets)
+- Configure ingress controllers and load balancers
+- Setup persistent storage and storage classes
+- Deploy Helm charts for application packages
+- Manage multi-cluster Kubernetes deployments
+
+**Note**: OpenTofu and Terraform are used interchangeably throughout this skill. OpenTofu is an open-source implementation of Terraform and maintains full compatibility with Terraform providers.
+
+## Prerequisites
+
+- **OpenTofu CLI installed**: Install from https://opentofu.org/docs/intro/install/
+- **Kubernetes Cluster**: Running Kubernetes cluster (EKS, GKE, AKS, or self-managed)
+- **kubectl**: Kubernetes command-line tool for local testing
+- **kubeconfig**: Valid Kubernetes configuration file
+- **Basic Kubernetes Knowledge**: Understanding of pods, services, deployments, and concepts
+
+## Provider Documentation
+
+- **Terraform Registry (Kubernetes Provider)**: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs
+- **Latest Provider Version**: hashicorp/kubernetes ~> 2.24.0
+- **Provider Source**: https://github.com/hashicorp/terraform-provider-kubernetes
+- **Kubernetes Documentation**: https://kubernetes.io/docs/
+- **Helm Provider**: https://registry.terraform.io/providers/hashicorp/helm/latest/docs
+
+## Steps
+
+### Step 1: Install and Configure OpenTofu
+
+```bash
+# Verify OpenTofu installation
+tofu version
+
+# Initialize project
+mkdir kubernetes-terraform
+cd kubernetes-terraform
+tofu init
+```
+
+### Step 2: Configure Kubernetes Provider
+
+Create `versions.tf`:
+
+```hcl
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11.0"
+    }
+  }
+  required_version = ">= 1.0"
+
+  # Remote state backend
+  backend "s3" {
+    bucket         = "terraform-state"
+    key            = "kubernetes/terraform.tfstate"
+    region         = "ap-southeast-1"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}
+```
+
+### Step 3: Configure Provider Connection
+
+Create `provider.tf`:
+
+```hcl
+provider "kubernetes" {
+  # Method 1: Use default kubeconfig (recommended)
+  # Uses ~/.kube/config by default
+  # Best for local development and single cluster
+
+  # Method 2: Specify kubeconfig path
+  config_path = var.kubeconfig_path
+
+  # Method 3: Use config context
+  config_context = "my-cluster-context"
+
+  # Method 4: Direct cluster configuration (for EKS)
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+
+  # Namespace configuration
+  config_context_auth_info = false
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_path
+  }
+}
+```
+
+### Step 4: Configure Environment Variables
+
+```bash
+# Method 1: Use default kubeconfig
+# Provider automatically uses ~/.kube/config
+
+# Method 2: Specify kubeconfig path
+export KUBECONFIG="/path/to/kubeconfig"
+
+# Method 3: Use config context
+export KUBECONFIG="/path/to/kubeconfig"
+kubectl config use-context my-cluster-context
+
+# Method 4: For EKS with AWS credentials
+# Set AWS environment variables
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_DEFAULT_REGION="ap-southeast-1"
+```
+
+### Step 5: Create Namespace
+
+Create `namespace.tf`:
+
+```hcl
+# Application namespace
+resource "kubernetes_namespace" "app" {
+  metadata {
+    name = var.app_namespace
+    labels = {
+      app       = var.application_name
+      managedBy = "terraform"
+      environment = var.environment
+    }
+  }
+}
+
+# Monitoring namespace
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+    labels = {
+      name   = "monitoring"
+      managedBy = "terraform"
+    }
+  }
+}
+
+# Ingress namespace
+resource "kubernetes_namespace" "ingress" {
+  metadata {
+    name = "ingress-nginx"
+    labels = {
+      app   = "ingress-nginx"
+      managedBy = "terraform"
+    }
+  }
+}
+```
+
+### Step 6: Create ConfigMap and Secret
+
+Create `config.tf`:
+
+```hcl
+# Application ConfigMap
+resource "kubernetes_config_map" "app_config" {
+  metadata {
+    name      = "app-config"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  data = {
+    "application.properties" = <<-EOT
+      server.port=8080
+      database.url=${var.database_url}
+      logging.level=INFO
+      environment=${var.environment}
+    EOT
+
+    "logback.xml" = file("${path.module}/config/logback.xml")
+  }
+}
+
+# Application Secret
+resource "kubernetes_secret" "app_secret" {
+  metadata {
+    name      = "app-secret"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  data = {
+    "database-password" = var.database_password
+    "api-key"          = var.api_key
+  }
+
+  type = "Opaque"
+}
+```
+
+### Step 7: Create Deployment
+
+Create `deployment.tf`:
+
+```hcl
+# Application Deployment
+resource "kubernetes_deployment" "app" {
+  metadata {
+    name      = var.application_name
+    namespace = kubernetes_namespace.app.metadata[0].name
+    labels = {
+      app = var.application_name
+    }
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = {
+        app = var.application_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = var.application_name
+        }
+      }
+
+      spec {
+        container {
+          name  = "app"
+          image = var.container_image
+
+          port {
+            container_port = 8080
+          }
+
+          # Environment variables
+          env {
+            name  = "SERVER_PORT"
+            value = "8080"
+          }
+
+          env {
+            name = "DATABASE_URL"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret.app_secret.metadata[0].name
+                key  = "database-password"
+              }
+            }
+          }
+
+          # Resource limits
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "256Mi"
+            }
+          }
+
+          # Liveness probe
+          liveness_probe {
+            http_get {
+              path = "/health"
+              port = 8080
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds      = 5
+            failure_threshold    = 3
+          }
+
+          # Readiness probe
+          readiness_probe {
+            http_get {
+              path = "/ready"
+              port = 8080
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 5
+            timeout_seconds      = 3
+            failure_threshold    = 2
+          }
+        }
+      }
+    }
+  }
+
+  # Prevent pod disruption during update
+  strategy {
+    type = "RollingUpdate"
+
+    rolling_update {
+      max_surge       = 1
+      max_unavailable = 0
+    }
+  }
+}
+```
+
+### Step 8: Create Service
+
+Create `service.tf`:
+
+```hcl
+# Application Service (ClusterIP)
+resource "kubernetes_service" "app" {
+  metadata {
+    name      = var.application_name
+    namespace = kubernetes_namespace.app.metadata[0].name
+    labels = {
+      app = var.application_name
+    }
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector {
+      app = var.application_name
+    }
+
+    port {
+      name        = "http"
+      protocol    = "TCP"
+      port        = 80
+      target_port = 8080
+    }
+  }
+}
+
+# Application Service (LoadBalancer)
+resource "kubernetes_service" "app_lb" {
+  metadata {
+    name      = "${var.application_name}-lb"
+    namespace = kubernetes_namespace.app.metadata[0].name
+    labels = {
+      app = var.application_name
+    }
+    annotations = {
+      "service.beta.kubernetes.io/aws-load-balancer-type" = "nlb"
+    }
+  }
+
+  spec {
+    type = "LoadBalancer"
+
+    selector {
+      app = var.application_name
+    }
+
+    port {
+      name        = "http"
+      protocol    = "TCP"
+      port        = 80
+      target_port = 8080
+    }
+
+    port {
+      name        = "https"
+      protocol    = "TCP"
+      port        = 443
+      target_port = 8080
+    }
+  }
+}
+
+# Headless Service for StatefulSets
+resource "kubernetes_service" "app_headless" {
+  metadata {
+    name      = "${var.application_name}-headless"
+    namespace = kubernetes_namespace.app.metadata[0].name
+    labels = {
+      app = var.application_name
+    }
+  }
+
+  spec {
+    type = "ClusterIP"
+    cluster_ip = "None"
+
+    selector {
+      app = var.application_name
+    }
+
+    port {
+      name        = "http"
+      protocol    = "TCP"
+      port        = 8080
+      target_port = 8080
+    }
+  }
+}
+```
+
+### Step 9: Create Ingress
+
+Create `ingress.tf`:
+
+```hcl
+# Ingress Controller Deployment (nginx)
+resource "helm_release" "ingress_nginx" {
+  name       = "ingress-nginx"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  namespace  = kubernetes_namespace.ingress.metadata[0].name
+
+  set {
+    name  = "controller.service.type"
+    value = "LoadBalancer"
+  }
+
+  set {
+    name  = "controller.publishService.enabled"
+    value = "true"
+  }
+}
+
+# Application Ingress
+resource "kubernetes_ingress" "app" {
+  metadata {
+    name      = var.application_name
+    namespace = kubernetes_namespace.app.metadata[0].name
+    labels = {
+      app = var.application_name
+    }
+    annotations = {
+      "kubernetes.io/ingress.class"           = "nginx"
+      "cert-manager.io/cluster-issuer"         = "letsencrypt-prod"
+      "nginx.ingress.kubernetes.io/ssl-redirect" = "true"
+    }
+  }
+
+  spec {
+    rule {
+      host = var.ingress_host
+
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.app.metadata[0].name
+            service_port = 80
+          }
+
+          path = "/"
+        }
+      }
+    }
+
+    tls {
+      hosts       = [var.ingress_host]
+      secret_name = kubernetes_secret.tls_cert.metadata[0].name
+    }
+  }
+}
+```
+
+### Step 10: Create Persistent Volume
+
+Create `storage.tf`:
+
+```hcl
+# Storage Class
+resource "kubernetes_storage_class" "gp2" {
+  metadata {
+    name = "gp2"
+  }
+
+  storage_provisioner = "kubernetes.io/aws-ebs"
+  parameters = {
+    type = "gp2"
+  }
+
+  allow_volume_expansion = true
+
+  reclaim_policy = "Retain"
+  volume_binding_mode = "WaitForFirstConsumer"
+}
+
+# Persistent Volume Claim
+resource "kubernetes_persistent_volume_claim" "data" {
+  metadata {
+    name      = "app-data"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = kubernetes_storage_class.gp2.metadata[0].name
+
+    resources {
+      requests = {
+        storage = "10Gi"
+      }
+    }
+  }
+}
+```
+
+### Step 11: Deploy Helm Chart
+
+Create `helm.tf`:
+
+```hcl
+# Redis Deployment
+resource "helm_release" "redis" {
+  name       = "redis"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "redis"
+  namespace  = kubernetes_namespace.app.metadata[0].name
+  version    = "17.11.0"
+
+  set {
+    name  = "auth.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "auth.password"
+    value = var.redis_password
+  }
+
+  set {
+    name  = "persistence.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "persistence.size"
+    value = "8Gi"
+  }
+}
+
+# PostgreSQL Deployment
+resource "helm_release" "postgresql" {
+  name       = "postgresql"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "postgresql"
+  namespace  = kubernetes_namespace.app.metadata[0].name
+  version    = "12.5.0"
+
+  set {
+    name  = "auth.enablePostgresUser"
+    value = "true"
+  }
+
+  set {
+    name  = "auth.password"
+    value = var.postgresql_password
+  }
+
+  set {
+    name  = "auth.database"
+    value = "appdb"
+  }
+
+  set {
+    name  = "primary.persistence.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "primary.persistence.size"
+    value = "20Gi"
+  }
+}
+```
+
+### Step 12: Create Horizontal Pod Autoscaler
+
+Create `autoscaler.tf`:
+
+```hcl
+resource "kubernetes_horizontal_pod_autoscaler" "app" {
+  metadata {
+    name      = "${var.application_name}-hpa"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  spec {
+    scale_target_ref {
+      api_version = "apps/v1"
+      kind       = "Deployment"
+      name       = kubernetes_deployment.app.metadata[0].name
+    }
+
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    target_cpu_utilization_percentage    = 60
+    target_memory_utilization_percentage = 70
+  }
+}
+```
+
+### Step 13: Define Variables
+
+Create `variables.tf`:
+
+```hcl
+variable "kubeconfig_path" {
+  description = "Path to kubeconfig file"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "app_namespace" {
+  description = "Application namespace"
+  type        = string
+  default     = "app"
+}
+
+variable "application_name" {
+  description = "Application name"
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image to deploy"
+  type        = string
+}
+
+variable "replicas" {
+  description = "Number of replicas"
+  type        = number
+  default     = 3
+}
+
+variable "min_replicas" {
+  description = "Minimum replicas for autoscaling"
+  type        = number
+  default     = 2
+}
+
+variable "max_replicas" {
+  description = "Maximum replicas for autoscaling"
+  type        = number
+  default     = 10
+}
+
+variable "database_url" {
+  description = "Database connection URL"
+  type        = string
+  sensitive   = true
+}
+
+variable "database_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true
+}
+
+variable "api_key" {
+  description = "API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "ingress_host" {
+  description = "Ingress host"
+  type        = string
+}
+
+variable "redis_password" {
+  description = "Redis password"
+  type        = string
+  sensitive   = true
+}
+
+variable "postgresql_password" {
+  description = "PostgreSQL password"
+  type        = string
+  sensitive   = true
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+```
+
+### Step 14: Create Outputs
+
+Create `outputs.tf`:
+
+```hcl
+output "namespace" {
+  description = "Application namespace"
+  value       = kubernetes_namespace.app.metadata[0].name
+}
+
+output "deployment_name" {
+  description = "Application deployment name"
+  value       = kubernetes_deployment.app.metadata[0].name
+}
+
+output "service_name" {
+  description = "Application service name"
+  value       = kubernetes_service.app.metadata[0].name
+}
+
+output "load_balancer_url" {
+  description = "Load balancer URL"
+  value       = kubernetes_service.app_lb.status[0].load_balancer[0].ingress[0].hostname
+}
+
+output "ingress_url" {
+  description = "Ingress URL"
+  value       = "https://${var.ingress_host}"
+}
+```
+
+### Step 15: Initialize and Apply
+
+```bash
+# Set kubeconfig
+export KUBECONFIG="/path/to/kubeconfig"
+
+# Initialize providers
+tofu init
+
+# Plan changes
+tofu plan -out=tfplan
+
+# Apply changes
+tofu apply tfplan
+
+# Show outputs
+tofu output
+
+# Verify deployment
+kubectl get all -n $APP_NAMESPACE
+kubectl logs -f deployment/app -n $APP_NAMESPACE
+```
+
+## Best Practices
+
+### Resource Management
+
+1. **Use Namespaces**: Separate resources by namespace for isolation
+2. **Label Everything**: Apply consistent labels to all resources
+3. **Resource Limits**: Set appropriate resource requests and limits
+4. **Probes**: Configure liveness and readiness probes
+5. **Strategy**: Use RollingUpdate for zero-downtime deployments
+
+### Security
+
+1. **Least Privilege**: Use RBAC to restrict permissions
+2. **Secrets Management**: Never store secrets in ConfigMaps; use Kubernetes Secrets
+3. **Network Policies**: Implement network policies for pod-to-pod communication
+4. **Image Security**: Use signed and verified container images
+5. **Pod Security Context**: Define security context for pods and containers
+
+### High Availability
+
+1. **Replicas**: Deploy multiple replicas for critical applications
+2. **Anti-Affinity**: Distribute pods across nodes
+3. **Pod Disruption Budgets**: Configure PDBs to prevent voluntary disruptions
+4. **Health Checks**: Use liveness and readiness probes
+5. **Autoscaling**: Configure HPA for automatic scaling
+
+### Storage
+
+1. **Storage Classes**: Use appropriate storage classes for your use case
+2. **Persistent Volumes**: Use PVCs for stateful applications
+3. **Volume Expansion**: Enable storage expansion when possible
+4. **Backup**: Implement backup strategies for persistent data
+5. **StatefulSets**: Use StatefulSets for databases and stateful apps
+
+### Ingress and Networking
+
+1. **Ingress Controller**: Deploy an ingress controller for external access
+2. **TLS Termination**: Use TLS termination at ingress
+3. **Cert-Manager**: Automate TLS certificate management
+4. **Load Balancer Type**: Choose appropriate LB type (ALB, NLB, etc.)
+5. **DNS**: Configure DNS records for ingress hosts
+
+### Helm Charts
+
+1. **Version Pinning**: Pin chart versions for reproducibility
+2. **Values Override**: Use `set` blocks to override default values
+3. **Namespace Isolation**: Deploy charts in dedicated namespaces
+4. **Release Management**: Use meaningful release names
+5. **Upgrade Strategy**: Understand chart upgrade strategies
+
+## Common Issues
+
+### Issue: Provider Connection Failed
+
+**Symptom**: Error `Error: Failed to configure provider`
+
+**Solution**:
+```bash
+# Verify kubeconfig
+kubectl cluster-info
+kubectl config current-context
+
+# Check kubeconfig path
+ls -la ~/.kube/config
+
+# Test connection
+kubectl get nodes
+
+# Verify KUBECONFIG environment variable
+echo $KUBECONFIG
+
+# For EKS with AWS credentials
+aws eks describe-cluster --name my-cluster --region ap-southeast-1
+```
+
+### Issue: Image Pull Error
+
+**Symptom**: Error `Failed to pull image`
+
+**Solution**:
+```bash
+# Verify image exists
+docker pull <image-name>
+
+# Check image registry access
+docker login <registry-url>
+
+# Use image pull secrets
+kubectl create secret docker-registry regcred \
+  --docker-server=<registry-url> \
+  --docker-username=<username> \
+  --docker-password=<password>
+
+# Reference: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+```
+
+### Issue: Pod Pending State
+
+**Symptom**: Pods stuck in Pending state
+
+**Solution**:
+```bash
+# Describe pod for details
+kubectl describe pod <pod-name>
+
+# Check events
+kubectl get events --sort-by='.lastTimestamp'
+
+# Common issues:
+# - Insufficient resources (check requests/limits)
+# - Node affinity (check node selectors)
+# - Taints and tolerations
+# - Image pull errors
+```
+
+### Issue: Service Not Accessible
+
+**Symptom**: Service is created but not accessible
+
+**Solution**:
+```bash
+# Check service endpoints
+kubectl get endpoints <service-name>
+
+# Verify pod labels match service selector
+kubectl get pods --show-labels
+
+# Check service type
+# ClusterIP: Only accessible within cluster
+# LoadBalancer: External access via LB DNS/URL
+# NodePort: External access via NodeIP:Port
+
+# For LoadBalancer, check firewall/security groups
+# Allow traffic to LB ports
+```
+
+### Issue: Ingress Not Working
+
+**Symptom**: Ingress created but traffic not reaching pods
+
+**Solution**:
+```bash
+# Verify ingress controller is running
+kubectl get pods -n ingress-nginx
+
+# Check ingress class annotation
+kubectl describe ingress <ingress-name>
+
+# Verify TLS secret exists
+kubectl get secret <tls-secret-name>
+
+# Check ingress backend service
+kubectl get svc <backend-service-name>
+
+# Check DNS resolution
+nslookup <ingress-host>
+dig <ingress-host>
+
+# Reference: https://kubernetes.io/docs/concepts/services-networking/ingress/
+```
+
+### Issue: Persistent Volume Not Mounting
+
+**Symptom**: Pod fails with volume mount errors
+
+**Solution**:
+```bash
+# Check PVC status
+kubectl get pvc
+
+# Check storage class
+kubectl get sc
+
+# Verify volume exists
+kubectl get pv
+
+# Check pod events
+kubectl describe pod <pod-name> | grep -A 10 Events
+
+# Ensure storage class supports dynamic provisioning
+# Check reclaim_policy and volume_binding_mode
+```
+
+### Issue: Helm Chart Upgrade Failed
+
+**Symptom**: Error `Error: failed to upgrade release`
+
+**Solution**:
+```bash
+# Check Helm release history
+helm list -n <namespace>
+
+# Get current values
+helm get values <release-name> -n <namespace>
+
+# Dry-run upgrade
+helm upgrade --dry-run <release-name> <chart> -n <namespace>
+
+# Rollback if needed
+helm rollback <release-name> <revision> -n <namespace>
+
+# Check chart compatibility
+# Ensure chart version supports Kubernetes version
+kubectl version
+helm search repo <chart-name> --versions
+```
+
+### Issue: Autoscaling Not Working
+
+**Symptom**: HPA not scaling pods
+
+**Solution**:
+```bash
+# Check HPA status
+kubectl get hpa
+
+# Describe HPA for details
+kubectl describe hpa <hpa-name>
+
+# Check resource requests (required for HPA)
+kubectl describe pod <pod-name> | grep -A 5 Requests
+
+# Verify metrics server is running
+kubectl get pods -n kube-system | grep metrics
+
+# Check metrics availability
+kubectl top nodes
+kubectl top pods
+```
+
+## Reference Documentation
+
+- **Terraform Registry (Kubernetes Provider)**: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs
+- **Kubernetes Documentation**: https://kubernetes.io/docs/
+- **Helm Documentation**: https://helm.sh/docs/
+- **Kubernetes API Reference**: https://kubernetes.io/docs/reference/
+- **OpenTofu Documentation**: https://opentofu.org/docs/
+- **kubectl Documentation**: https://kubernetes.io/docs/reference/kubectl/
+
+## Examples
+
+### Complete Application Deployment
+
+```hcl
+# namespace.tf
+resource "kubernetes_namespace" "app" {
+  metadata {
+    name = "production"
+  }
+}
+
+# config.tf
+resource "kubernetes_config_map" "app_config" {
+  metadata {
+    name      = "app-config"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  data = {
+    "config.json" = jsonencode({
+      port = 8080
+      env  = "production"
+    })
+  }
+}
+
+# deployment.tf
+resource "kubernetes_deployment" "app" {
+  metadata {
+    name      = "webapp"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  spec {
+    replicas = 3
+
+    template {
+      spec {
+        container {
+          name  = "webapp"
+          image = "nginx:1.21"
+
+          port {
+            container_port = 80
+          }
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "256Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Ingress with TLS
+
+```hcl
+# ingress.tf
+resource "kubernetes_ingress" "app" {
+  metadata {
+    name      = "webapp-ingress"
+    namespace = kubernetes_namespace.app.metadata[0].name
+    annotations = {
+      "kubernetes.io/ingress.class" = "nginx"
+      "cert-manager.io/cluster-issuer" = "letsencrypt-prod"
+    }
+  }
+
+  spec {
+    rule {
+      host = "app.example.com"
+
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.webapp.metadata[0].name
+            service_port = 80
+          }
+        }
+      }
+    }
+
+    tls {
+      hosts       = ["app.example.com"]
+      secret_name = kubernetes_secret.tls_cert.metadata[0].name
+    }
+  }
+}
+```
+
+### Helm Chart Deployment
+
+```hcl
+# helm.tf
+resource "helm_release" "redis" {
+  name       = "redis"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "redis"
+  namespace  = kubernetes_namespace.app.metadata[0].name
+
+  set {
+    name  = "auth.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "auth.password"
+    value = var.redis_password
+  }
+
+  set {
+    name  = "master.persistence.size"
+    value = "8Gi"
+  }
+}
+```
+
+### EKS Cluster with Kubernetes Provider
+
+```hcl
+# eks.tf
+resource "aws_eks_cluster" "main" {
+  name     = "my-eks-cluster"
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = "1.27"
+
+  vpc_config {
+    subnet_ids = aws_subnet.public[*].id
+  }
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = aws_eks_cluster.main.name
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = aws_eks_cluster.main.name
+}
+
+# kubernetes.tf
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+resource "kubernetes_deployment" "app" {
+  metadata {
+    name      = "app"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  spec {
+    template {
+      spec {
+        container {
+          name  = "app"
+          image = "my-app:latest"
+        }
+      }
+    }
+  }
+}
+```
+
+## Tips and Tricks
+
+- **Use kubectl**: Verify Terraform-created resources with kubectl
+- **Dry Run**: Use `helm upgrade --dry-run` to test changes
+- **Port Forward**: Use `kubectl port-forward` for local debugging
+- **Logs**: Use `kubectl logs -f` for real-time debugging
+- **Describe Everything**: Use `kubectl describe` for detailed resource information
+- **Events**: Check events for troubleshooting issues
+- **Resource Labels**: Use labels for organization and discovery
+- **Namespace Isolation**: Use namespaces for environment separation
+- **Helm Values**: Use `helm show values` to understand default configuration
+- **Version Control**: Store Helm values files in version control
+- **Import Resources**: Import existing Kubernetes resources into Terraform state
+
+## Next Steps
+
+After mastering Kubernetes provider, explore:
+- **Kubernetes Advanced**: Learn about StatefulSets, DaemonSets, and Jobs
+- **Kubernetes Operators**: Deploy operators for complex applications
+- **Service Mesh**: Implement Istio or Linkerd for service-to-service communication
+- **GitOps**: Use ArgoCD or Flux for GitOps workflows
+- **Monitoring**: Deploy Prometheus and Grafana for observability
+- **Kubernetes Security**: Learn about RBAC, network policies, and security contexts
+- **Kubernetes Best Practices**: Follow K8s best practices for production workloads

--- a/skills/opentofu-neon-explorer/SKILL.md
+++ b/skills/opentofu-neon-explorer/SKILL.md
@@ -1,0 +1,776 @@
+---
+name: opentofu-neon-explorer
+description: Explore and manage Neon Postgres serverless database resources using OpenTofu/Terraform
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: database-management
+---
+
+# OpenTofu Neon Explorer
+
+## What I do
+
+I guide you through managing Neon serverless Postgres database resources using the Neon Terraform provider. I help you:
+
+- **Project Management**: Create and manage Neon Postgres projects
+- **Database Operations**: Create databases, branches, and endpoints
+- **Branching Strategy**: Implement Neon's branch-based database workflow
+- **Connection Management**: Configure database connections and credentials
+- **Best Practices**: Follow Neon provider documentation patterns
+
+## When to use me
+
+Use this skill when you need to:
+- Automate Neon Postgres infrastructure as code
+- Create serverless Postgres databases for applications
+- Implement database branching for development workflows
+- Manage database projects, branches, and endpoints programmatically
+- Configure Neon databases for production workloads
+- Implement Neon's unique branch-based development workflow
+
+**Note**: OpenTofu and Terraform are used interchangeably throughout this skill. OpenTofu is an open-source implementation of Terraform and maintains full compatibility with Terraform providers.
+
+## Prerequisites
+
+- **OpenTofu CLI installed**: Install from https://opentofu.org/docs/intro/install/
+- **Neon Account**: Valid Neon account with API access
+- **Neon API Key**: API key for authentication
+- **Basic Postgres Knowledge**: Understanding of Postgres and database concepts
+- **Neon CLI (Optional)**: For additional operations
+
+## Provider Documentation
+
+- **Terraform Registry (Neon Provider)**: https://registry.terraform.io/providers/kislerdm/neon/latest/docs
+- **Provider Source**: https://github.com/kislerdm/terraform-provider-neon
+- **Latest Provider Version**: kislerdm/neon ~> 0.13.0
+- **Neon Documentation**: https://neon.tech/docs/
+- **Terraform Version**: >= 1.14.x
+
+## Steps
+
+### Step 1: Install and Configure OpenTofu
+
+```bash
+# Verify OpenTofu installation
+tofu version
+
+# Initialize project
+mkdir neon-terraform
+cd neon-terraform
+tofu init
+```
+
+### Step 2: Configure Neon Provider
+
+Create `versions.tf`:
+
+```hcl
+terraform {
+  required_providers {
+    neon = {
+      source  = "kislerdm/neon"
+      version = "~> 0.13.0"
+    }
+  }
+  required_version = ">= 1.14"
+
+  # Remote state backend
+  backend "s3" {
+    bucket = "neon-state"
+    key    = "terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+```
+
+### Step 3: Configure Neon Provider
+
+Create `provider.tf`:
+
+```hcl
+provider "neon" {
+  # Method 1: API Key in provider configuration (not recommended for production)
+  api_key = var.neon_api_key
+
+  # Method 2: Environment variable (recommended)
+  # Set environment variable: NEON_API_KEY
+  # Reference: https://neon.tech/docs/reference/terraform#important-usage-notes
+}
+```
+
+### Step 4: Configure Environment Variables
+
+```bash
+# Set Neon API key (recommended)
+export NEON_API_KEY="your-neon-api-key"
+
+# Or use variable file
+cat > terraform.tfvars <<EOF
+neon_api_key = "your-neon-api-key"
+project_name = "my-app"
+db_name = "appdb"
+EOF
+
+# IMPORTANT: When updating provider version, avoid `tofu init -upgrade` in CI pipelines
+# Use `tofu init` in automated workflows instead
+# Reference: https://neon.tech/docs/reference/terraform#important-usage-notes
+```
+
+### Step 5: Create Neon Project
+
+Create `project.tf`:
+
+```hcl
+resource "neon_project" "main" {
+  name = var.project_name
+
+  # Project configuration
+  # Neon automatically selects the best region
+  # You cannot specify region during project creation
+
+  tags = {
+    Environment = var.environment
+    ManagedBy  = "Terraform"
+  }
+
+  # Project-level settings
+  # Neon automatically configures:
+  # - Autoscaling storage
+  # - Serverless compute
+  # - High availability (based on plan)
+}
+```
+
+### Step 6: Create Database Branch
+
+Create `branch.tf`:
+
+```hcl
+# Main branch (created by default with project)
+# Access via data source
+
+# Development branch
+resource "neon_branch" "dev" {
+  project_id = neon_project.main.id
+  name       = "dev"
+  parent_id  = neon_branch.primary.id
+
+  # Branch inherits parent database schema
+  # Useful for feature development and testing
+}
+
+# Feature branch
+resource "neon_branch" "feature" {
+  project_id = neon_project.main.id
+  name       = "feature-authentication"
+
+  # If parent_id not specified, branches from primary
+  # Ideal for isolated feature development
+}
+```
+
+### Step 7: Create Databases
+
+Create `database.tf`:
+
+```hcl
+# Primary database
+resource "neon_database" "primary" {
+  project_id = neon_project.main.id
+  branch_id  = neon_branch.primary.id
+  name       = var.db_name
+
+  # Database collation
+  collation = "en_US.UTF-8"
+}
+
+# Development database
+resource "neon_database" "dev" {
+  project_id = neon_project.main.id
+  branch_id  = neon_branch.dev.id
+  name       = "appdb"
+}
+
+# Testing database
+resource "neon_database" "test" {
+  project_id = neon_project.main.id
+  branch_id  = neon_branch.feature.id
+  name       = "testdb"
+}
+```
+
+### Step 8: Create Database Endpoints
+
+Create `endpoint.tf`:
+
+```hcl
+# Primary read-write endpoint
+resource "neon_endpoint" "primary" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.primary.id
+  name         = "primary"
+  endpoint_type = "read_write"
+
+  # Endpoint configuration
+  # Automatically managed by Neon
+  # Autoscaling based on workload
+}
+
+# Read-only endpoint (for analytics/reporting)
+resource "neon_endpoint" "read_only" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.primary.id
+  name         = "readonly"
+  endpoint_type = "read_only"
+}
+
+# Development endpoint
+resource "neon_endpoint" "dev" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.dev.id
+  name         = "dev-endpoint"
+  endpoint_type = "read_write"
+}
+```
+
+### Step 9: Create Database Roles/Users
+
+Create `role.tf`:
+
+```hcl
+# Application role
+resource "neon_role" "app_user" {
+  project_id = neon_project.main.id
+  name       = "app_user"
+
+  # Role permissions
+  # Default: Can connect to databases
+}
+
+# Read-only role
+resource "neon_role" "analytics_user" {
+  project_id = neon_project.main.id
+  name       = "analytics_user"
+}
+
+# Admin role (use carefully)
+resource "neon_role" "admin" {
+  project_id = neon_project.main.id
+  name       = "admin_user"
+}
+```
+
+### Step 10: Grant Database Access
+
+Create `grants.tf`:
+
+```hcl
+# Grant access to primary database
+resource "neon_grant" "app_user_primary" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.primary.id
+  database_id  = neon_database.primary.id
+  role_name    = neon_role.app_user.name
+
+  # Grant permissions
+  # Default: CONNECT privilege
+}
+
+# Grant read-only access
+resource "neon_grant" "analytics_user_primary" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.primary.id
+  database_id  = neon_database.primary.id
+  role_name    = neon_role.analytics_user.name
+}
+
+# Grant access to development database
+resource "neon_grant" "app_user_dev" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.dev.id
+  database_id  = neon_database.dev.id
+  role_name    = neon_role.app_user.name
+}
+```
+
+### Step 11: Configure Database Operations
+
+Create `operations.tf`:
+
+```hcl
+# Suspend endpoint (pause compute)
+resource "neon_endpoint" "primary_suspended" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.primary.id
+  name         = "primary-suspended"
+  endpoint_type = "read_write"
+
+  suspend = true
+}
+
+# Delete branch when no longer needed
+resource "neon_branch" "temporary" {
+  project_id = neon_project.main.id
+  name       = "temp-feature"
+  lifecycle {
+    ignore_changes = [suspend]  # Manage suspension manually if needed
+  }
+}
+
+# Note: Use tofu destroy to remove resources
+# Or use terraform state rm to remove from state without destroying
+```
+
+### Step 12: Data Sources for Existing Resources
+
+Create `data_sources.tf`:
+
+```hcl
+# Get existing project
+data "neon_project" "existing" {
+  name = "existing-project-name"
+}
+
+# Get existing branch
+data "neon_branch" "primary" {
+  project_id = data.neon_project.existing.id
+  name       = "primary"
+}
+
+# Get connection details
+output "connection_string" {
+  value = data.neon_branch.primary.connection_uri
+  sensitive = true
+}
+```
+
+### Step 13: Define Variables
+
+Create `variables.tf`:
+
+```hcl
+variable "neon_api_key" {
+  description = "Neon API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "project_name" {
+  description = "Name of the Neon project"
+  type        = string
+}
+
+variable "db_name" {
+  description = "Name of the primary database"
+  type        = string
+  default     = "appdb"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+```
+
+### Step 14: Create Outputs
+
+Create `outputs.tf`:
+
+```hcl
+output "project_id" {
+  description = "Neon project ID"
+  value       = neon_project.main.id
+}
+
+output "project_name" {
+  description = "Neon project name"
+  value       = neon_project.main.name
+}
+
+output "primary_branch_id" {
+  description = "Primary branch ID"
+  value       = neon_branch.primary.id
+}
+
+output "primary_database_id" {
+  description = "Primary database ID"
+  value       = neon_database.primary.id
+}
+
+output "connection_string" {
+  description = "Primary database connection string"
+  value       = neon_branch.primary.connection_uri
+  sensitive   = true
+}
+
+output "host" {
+  description = "Database host"
+  value       = neon_branch.primary.host
+}
+
+output "port" {
+  description = "Database port"
+  value       = neon_branch.primary.port
+}
+
+output "user" {
+  description = "Database user"
+  value       = neon_branch.primary.user
+}
+
+output "password" {
+  description = "Database password"
+  value       = neon_branch.primary.password
+  sensitive   = true
+}
+```
+
+### Step 15: Initialize and Apply
+
+```bash
+# Set API key
+export NEON_API_KEY="your-neon-api-key"
+
+# Initialize providers
+tofu init
+
+# Plan changes
+tofu plan -out=tfplan
+
+# Apply changes
+tofu apply tfplan
+
+# Show outputs (connection details)
+tofu output
+```
+
+## Best Practices
+
+### Security
+
+1. **Use Environment Variables**: Store API keys in environment variables, not in code
+2. **Least Privilege**: Create separate roles for different use cases (app, analytics, admin)
+3. **Secure Connections**: Use SSL/TLS for all database connections
+4. **Secret Management**: Use secret managers for production credentials
+5. **API Key Rotation**: Regularly rotate Neon API keys
+
+### Branching Strategy
+
+1. **Use Branches**: Leverage Neon's branching for development and testing
+2. **Isolate Features**: Create feature branches for isolated development
+3. **Production Primary**: Keep primary branch for production workloads
+4. **Merge and Delete**: Delete feature branches after merging to primary
+5. **Branch Reset**: Reset development branches from primary regularly
+
+### Cost Optimization
+
+1. **Suspend Endpoints**: Suspend compute when not in use
+2. **Use Read-Only Endpoints**: For analytics and reporting workloads
+3. **Monitor Usage**: Track storage and compute usage in Neon console
+4. **Delete Unused Resources**: Remove unused branches and databases
+5. **Autoscaling**: Leverage Neon's autoscaling for variable workloads
+
+### Connection Management
+
+1. **Connection Pooling**: Use connection pooling for high-traffic applications
+2. **Read Replicas**: Use read-only endpoints for analytics workloads
+3. **SSL Required**: Always use SSL/TLS for production connections
+4. **Timeout Configuration**: Configure appropriate connection timeouts
+5. **Retry Logic**: Implement retry logic for transient failures
+
+### Development Workflow
+
+1. **Feature Branches**: Create branches for each feature or bug fix
+2. **Testing**: Test in development branches before merging
+3. **Staging**: Use staging branch for pre-production testing
+4. **Continuous Integration**: Integrate with CI/CD pipelines
+5. **Rollback**: Use branch reset for quick rollbacks
+
+## Common Issues
+
+### Issue: Provider Authentication Failed
+
+**Symptom**: Error `Error: Error configuring provider: authentication failed`
+
+**Solution**:
+```bash
+# Verify API key
+echo $NEON_API_KEY
+
+# Test API key manually
+curl -H "Authorization: Bearer $NEON_API_KEY" \
+  https://console.neon.tech/api/v1/projects
+
+# Ensure environment variable is set correctly
+export NEON_API_KEY="your-api-key"
+```
+
+### Issue: Project Already Exists
+
+**Symptom**: Error `Error: Project with name already exists`
+
+**Solution**:
+```bash
+# Use data source to reference existing project
+data "neon_project" "existing" {
+  name = "existing-project-name"
+}
+
+# Or import existing project into state
+tofu import neon_project.main project-id
+```
+
+### Issue: Branch Creation Failed
+
+**Symptom**: Error `Error: Failed to create branch`
+
+**Solution**:
+```bash
+# Check parent branch exists
+tofu state list | grep neon_branch
+
+# Ensure project is active
+# Check Neon console for project status
+
+# Use data source to verify parent branch
+data "neon_branch" "primary" {
+  project_id = neon_project.main.id
+  name       = "primary"
+}
+```
+
+### Issue: Endpoint Connection Failed
+
+**Symptom**: Cannot connect to database endpoint
+
+**Solution**:
+```bash
+# Check endpoint status
+tofu output connection_string
+
+# Verify endpoint is not suspended
+# Check suspend parameter in resource
+
+# Test connection using psql
+psql $CONNECTION_STRING
+
+# Check firewall settings
+# Ensure your IP is allowed if using IP restrictions
+```
+
+### Issue: Provider Version Conflict
+
+**Symptom**: Error `Error: Provider version constraint`
+
+**Solution**:
+```bash
+# IMPORTANT: Avoid `tofu init -upgrade` in CI pipelines
+# This can lead to unintended resource replacements and data loss
+
+# Use `tofu init` in automated workflows
+tofu init
+
+# Run `tofu init -upgrade` manually and review plans
+tofu init -upgrade
+tofu plan -out=tfplan
+# Review plan carefully before applying
+
+# Reference: https://neon.tech/docs/reference/terraform#important-usage-notes
+```
+
+### Issue: State Lock Error
+
+**Symptom**: Error `Error: Error acquiring the state lock`
+
+**Solution**:
+```bash
+# Check who has the lock
+tofu state pull
+
+# Force unlock (caution!)
+tofu force-unlock <LOCK_ID>
+
+# Ensure only one person is applying changes at a time
+```
+
+### Issue: Role Grant Failed
+
+**Symptom**: Error `Error: Failed to grant database access`
+
+**Solution**:
+```hcl
+# Ensure role exists before granting
+resource "neon_role" "app_user" {
+  project_id = neon_project.main.id
+  name       = "app_user"
+}
+
+# Grant access after role creation
+resource "neon_grant" "app_user_primary" {
+  project_id   = neon_project.main.id
+  branch_id    = neon_branch.primary.id
+  database_id  = neon_database.primary.id
+  role_name    = neon_role.app_user.name
+
+  depends_on = [neon_role.app_user]
+}
+```
+
+## Reference Documentation
+
+- **Terraform Registry (Neon Provider)**: https://registry.terraform.io/providers/kislerdm/neon/latest/docs
+- **Provider GitHub**: https://github.com/kislerdm/terraform-provider-neon
+- **Neon Documentation**: https://neon.tech/docs/
+- **Neon Terraform Guide**: https://neon.tech/docs/reference/terraform
+- **Important Usage Notes**: https://neon.tech/docs/reference/terraform#important-usage-notes
+- **OpenTofu Documentation**: https://opentofu.org/docs/
+
+## Examples
+
+### Complete Neon Project Setup
+
+```hcl
+# versions.tf
+terraform {
+  required_providers {
+    neon = {
+      source  = "kislerdm/neon"
+      version = "~> 0.13.0"
+    }
+  }
+}
+
+# provider.tf
+provider "neon" {
+  # API key from environment variable: NEON_API_KEY
+}
+
+# project.tf
+resource "neon_project" "main" {
+  name = "my-app-production"
+}
+
+# branch.tf
+resource "neon_branch" "dev" {
+  project_id = neon_project.main.id
+  name       = "dev"
+  parent_id  = data.neon_branch.primary.id
+}
+
+# database.tf
+resource "neon_database" "primary" {
+  project_id = neon_project.main.id
+  branch_id  = data.neon_branch.primary.id
+  name       = "appdb"
+}
+
+# endpoint.tf
+resource "neon_endpoint" "primary" {
+  project_id   = neon_project.main.id
+  branch_id    = data.neon_branch.primary.id
+  name         = "primary"
+  endpoint_type = "read_write"
+}
+
+# data_sources.tf
+data "neon_branch" "primary" {
+  project_id = neon_project.main.id
+  name       = "primary"
+}
+```
+
+### Multi-Environment Setup
+
+```hcl
+# Development project
+resource "neon_project" "dev" {
+  name = "my-app-dev"
+}
+
+resource "neon_branch" "dev" {
+  project_id = neon_project.dev.id
+  name       = "dev"
+}
+
+# Staging project
+resource "neon_project" "staging" {
+  name = "my-app-staging"
+}
+
+# Production project
+resource "neon_project" "prod" {
+  name = "my-app-prod"
+}
+
+resource "neon_endpoint" "prod_readonly" {
+  project_id   = neon_project.prod.id
+  branch_id    = data.neon_branch.primary.id
+  name         = "readonly"
+  endpoint_type = "read_only"
+}
+```
+
+### Application User Setup
+
+```hcl
+resource "neon_role" "app_user" {
+  project_id = neon_project.main.id
+  name       = "app_user"
+}
+
+resource "neon_database" "app" {
+  project_id = neon_project.main.id
+  branch_id  = data.neon_branch.primary.id
+  name       = "appdb"
+}
+
+resource "neon_grant" "app_access" {
+  project_id   = neon_project.main.id
+  branch_id    = data.neon_branch.primary.id
+  database_id  = neon_database.app.id
+  role_name    = neon_role.app_user.name
+}
+```
+
+### Connection String Usage
+
+```bash
+# Get connection string from Terraform output
+export DATABASE_URL=$(tofu output -raw connection_string)
+
+# Use in application
+# Node.js example
+const { Pool } = require('pg');
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+# Python example
+import psycopg2
+conn = psycopg2.connect(os.getenv('DATABASE_URL'))
+```
+
+## Tips and Tricks
+
+- **Use Environment Variables**: Always use NEON_API_KEY environment variable
+- **Branch Reset**: Reset development branches from primary regularly
+- **Read-Only Endpoints**: Use for analytics to reduce load on primary
+- **Suspend Unused**: Suspend endpoints when not in use to save costs
+- **Monitor Usage**: Check Neon console for storage and compute usage
+- **Avoid init -upgrade in CI**: Use `tofu init` instead of `tofu init -upgrade`
+- **Import Existing**: Import existing Neon resources into Terraform state
+- **Data Sources**: Use data sources to reference existing projects and branches
+- **Connection Strings**: Treat connection strings as sensitive values
+
+## Next Steps
+
+After mastering Neon provider, explore:
+- **Neon CLI**: https://neon.tech/docs/reference/cli
+- **Neon Branching**: https://neon.tech/docs/introduction/branching
+- **Neon API**: https://neon.tech/api-reference
+- **PostgreSQL**: Learn more about PostgreSQL features and best practices
+- **Integration**: Connect Neon to your application framework (Node.js, Python, Go, etc.)

--- a/skills/opentofu-provider-setup/SKILL.md
+++ b/skills/opentofu-provider-setup/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: opentofu-provider-setup
+description: Configure OpenTofu with cloud providers, manage authentication, and setup state backends
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: infrastructure-provisioning
+---
+
+# OpenTofu Provider Setup
+
+## What I do
+
+I guide you through configuring OpenTofu with various cloud providers by leveraging official OpenTofu and Terraform provider documentation. I help you:
+
+- **Provider Configuration**: Set up provider blocks with required and optional parameters
+- **Authentication**: Configure authentication methods (access keys, service principals, etc.)
+- **State Management**: Configure remote state backends (S3, Azure Storage, GCS, etc.)
+- **Best Practices**: Follow provider-specific configuration patterns from official docs
+
+## When to use me
+
+Use this skill when you need to:
+- Initialize a new OpenTofu project with provider configuration
+- Configure authentication for cloud providers (AWS, Azure, GCP, etc.)
+- Set up remote state backends for team collaboration
+- Understand provider configuration options and best practices
+- Troubleshoot provider connection or authentication issues
+
+## Prerequisites
+
+- **OpenTofu CLI installed**: Install from https://opentofu.org/docs/intro/install/
+- **Cloud Provider Account**: Valid credentials for your target provider
+- **Basic Terraform Knowledge**: Understanding of HCL syntax and configuration structure
+- **Provider Documentation**: Reference to your provider's official documentation
+
+## Steps
+
+### Step 1: Install OpenTofu CLI
+
+```bash
+# Verify OpenTofu installation
+tofu version
+
+# If not installed, install using package manager or download from:
+# https://opentofu.org/docs/intro/install/
+```
+
+### Step 2: Initialize OpenTofu Project
+
+```bash
+# Create new project directory
+mkdir my-opentofu-project
+cd my-opentofu-project
+
+# Initialize OpenTofu
+tofu init
+```
+
+### Step 3: Configure Provider
+
+Create `versions.tf` to specify required provider versions:
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    # Or for Azure:
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    # Or for GCP:
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  # Configure state backend (see Step 4)
+  backend "s3" {
+    bucket = "my-opentofu-state"
+    key    = "prod/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+```
+
+### Step 4: Configure Provider Authentication
+
+#### AWS Provider
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+
+  # Method 1: Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+  # Method 2: Shared credentials file (~/.aws/credentials)
+  # Method 3: Assume role
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/TerraformRole"
+  }
+
+  # Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+}
+```
+
+#### Azure Provider
+
+```hcl
+provider "azurerm" {
+  features {}
+
+  # Method 1: Environment variables (ARM_CLIENT_ID, ARM_CLIENT_SECRET, etc.)
+  # Method 2: Managed Identity
+  # Method 3: Service Principal with Certificate
+
+  # Reference: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+}
+```
+
+#### GCP Provider
+
+```hcl
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+
+  # Method 1: Application Default Credentials
+  # Method 2: Service Account Key (GOOGLE_CREDENTIALS env var)
+  # Method 3: Workload Identity
+
+  # Reference: https://registry.terraform.io/providers/hashicorp/google/latest/docs
+}
+```
+
+### Step 5: Configure State Backend
+
+#### AWS S3 Backend
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}
+```
+
+#### Azure Storage Backend
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "terraform-storage-rg"
+    storage_account_name = "terraformstate123"
+    container_name       = "terraform-state"
+    key                  = "prod.terraform.tfstate"
+  }
+}
+```
+
+#### GCS Backend
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "my-terraform-state"
+    prefix = "prod"
+  }
+}
+```
+
+### Step 6: Initialize and Verify Configuration
+
+```bash
+# Initialize provider and backend
+tofu init
+
+# Verify provider configuration
+tofu init -upgrade
+
+# Test provider connection
+tofu plan -out=tfplan
+```
+
+## Best Practices
+
+### Configuration Best Practices
+
+1. **Use Provider Version Constraints**: Pin provider versions to avoid breaking changes
+2. **Store State Securely**: Use encrypted remote backends with versioning
+3. **Use Environment Variables**: Never hardcode credentials in configuration files
+4. **Enable State Locking**: Use DynamoDB (AWS) or similar for state locking
+5. **Separate State per Environment**: Use different state files for dev/staging/prod
+
+### Security Best Practices
+
+```bash
+# Use AWS Vault for credential management
+# Reference: https://github.com/99designs/aws-vault
+
+# Example with aws-vault
+aws-vault exec my-profile -- tofu plan
+
+# Use environment variables in production
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+tofu apply
+```
+
+### Organization Best Practices
+
+```hcl
+# Organize providers in separate files
+# providers/aws.tf
+provider "aws" {
+  region = var.aws_region
+}
+
+# providers/azure.tf
+provider "azurerm" {
+  features {}
+}
+```
+
+## Common Issues
+
+### Issue: Provider Not Found
+
+**Symptom**: Error `Error: Failed to query available provider packages`
+
+**Solution**:
+```bash
+# Update provider versions
+tofu init -upgrade
+
+# Check provider source and version in versions.tf
+# Reference: https://www.terraform.io/docs/language/providers/requirements.html
+```
+
+### Issue: Authentication Failed
+
+**Symptom**: Error `Error: error configuring Terraform AWS Provider`
+
+**Solution**:
+```bash
+# Verify credentials
+aws sts get-caller-identity
+
+# Check environment variables
+echo $AWS_ACCESS_KEY_ID
+
+# Reference provider authentication docs:
+# AWS: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication
+# Azure: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure
+# GCP: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started
+```
+
+### Issue: State Backend Access Denied
+
+**Symptom**: Error `Error: error acquiring the state lock`
+
+**Solution**:
+```bash
+# Verify IAM/permissions for state bucket
+# AWS: Check S3 bucket policy and IAM user permissions
+# Azure: Check Storage Account access control
+# GCP: Check GCS bucket IAM permissions
+
+# Force unlock if necessary (caution!)
+tofu force-unlock <LOCK_ID>
+```
+
+### Issue: Provider Version Conflict
+
+**Symptom**: Error `Provider "aws" has an inconsistent lock file`
+
+**Solution**:
+```bash
+# Remove lock file and reinitialize
+rm -rf .terraform/
+rm .terraform.lock.hcl
+tofu init -upgrade
+```
+
+## Reference Documentation
+
+- **OpenTofu Documentation**: https://opentofu.org/docs/
+- **Terraform Registry**: https://registry.terraform.io/
+- **AWS Provider**: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+- **Azure Provider**: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+- **GCP Provider**: https://registry.terraform.io/providers/hashicorp/google/latest/docs
+- **State Backends**: https://www.terraform.io/docs/language/settings/backends/index.html
+
+## Examples
+
+### Complete AWS Setup
+
+```bash
+# Create project structure
+mkdir -p aws-infrastructure/{modules,environments/{dev,prod}}
+cd aws-infrastructure
+
+# Create versions.tf
+cat > versions.tf <<EOF
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}
+EOF
+
+# Initialize
+export AWS_PROFILE="my-profile"
+tofu init
+```
+
+### Multi-Provider Setup
+
+```hcl
+# versions.tf
+terraform {
+  required_providers {
+    aws     = { source = "hashicorp/aws", version = "~> 5.0" }
+    azurerm = { source = "hashicorp/azurerm", version = "~> 3.0" }
+  }
+
+  backend "s3" {}
+}
+
+# providers.tf
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "azurerm" {
+  features {}
+}
+```
+
+## Tips and Tricks
+
+- **Use Provider Blocks**: Even for single-provider projects, it improves clarity
+- **Version Constraints**: Use `~>` for minor version updates, `>=` for major versions
+- **State Backups**: Enable versioning on state storage buckets
+- **Workspace Management**: Use Terraform workspaces for multiple environments
+- **Validation**: Use `tofu validate` to check configuration syntax
+
+## Next Steps
+
+After configuring providers, explore:
+- **opentofu-provisioning-workflow**: Create and manage infrastructure resources
+- **terraform-modules**: Create reusable infrastructure components
+- **CI/CD Integration**: Automate infrastructure provisioning in pipelines

--- a/skills/opentofu-provisioning-workflow/SKILL.md
+++ b/skills/opentofu-provisioning-workflow/SKILL.md
@@ -1,0 +1,746 @@
+---
+name: opentofu-provisioning-workflow
+description: Infrastructure as Code development patterns, resource lifecycle management, and state management workflows with OpenTofu
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: infrastructure-provisioning
+---
+
+# OpenTofu Provisioning Workflow
+
+## What I do
+
+I guide you through complete Infrastructure as Code (IaC) development workflows using OpenTofu. I help you:
+
+- **Resource Provisioning**: Create, update, and manage infrastructure resources
+- **Lifecycle Management**: Handle resource creation, modification, and deletion
+- **State Management**: Maintain and troubleshoot Terraform state
+- **Best Practices**: Apply IaC best practices from OpenTofu and Terraform documentation
+- **Dependency Management**: Handle resource dependencies and ordering
+- **Validation and Planning**: Ensure infrastructure changes are safe and predictable
+
+## When to use me
+
+Use this skill when you need to:
+- Create new infrastructure resources (VPCs, EC2, databases, etc.)
+- Update existing infrastructure configurations
+- Plan and preview infrastructure changes before applying
+- Troubleshoot state issues or drift
+- Implement infrastructure best practices and patterns
+- Manage complex resource dependencies
+- Perform safe infrastructure updates and rollbacks
+
+## Prerequisites
+
+- **OpenTofu CLI installed**: Install from https://opentofu.org/docs/intro/install/
+- **Provider Configured**: Complete `opentofu-provider-setup` skill first
+- **Provider Authentication**: Valid credentials for your cloud provider
+- **Understanding of HCL**: HashiCorp Configuration Language basics
+- **State Backend**: Remote state backend configured (S3, Azure Storage, GCS)
+
+## Steps
+
+### Step 1: Define Resources
+
+Create `main.tf` with your infrastructure resources:
+
+```hcl
+# Example: AWS EC2 instance
+resource "aws_instance" "web_server" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+
+  tags = {
+    Name        = "WebServer"
+    Environment = var.environment
+  }
+
+  # User data script
+  user_data = <<-EOF
+              #!/bin/bash
+              yum update -y
+              yum install -y httpd
+              systemctl start httpd
+              EOF
+}
+
+# Example: VPC and Subnet
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  map_public_ip_on_launch = true
+  availability_zone       = var.availability_zone
+
+  tags = {
+    Name = "${var.project_name}-public-subnet"
+  }
+}
+```
+
+### Step 2: Define Variables
+
+Create `variables.tf` for reusability:
+
+```hcl
+variable "ami_id" {
+  description = "ID of AMI to use for EC2 instance"
+  type        = string
+  default     = "ami-0c55b159cbfafe1f0"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "project_name" {
+  description = "Project name used for tagging"
+  type        = string
+}
+```
+
+### Step 3: Define Outputs
+
+Create `outputs.tf` to expose values:
+
+```hcl
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  description = "ID of the public subnet"
+  value       = aws_subnet.public.id
+}
+
+output "instance_public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.web_server.public_ip
+}
+
+output "instance_private_ip" {
+  description = "Private IP of the EC2 instance"
+  value       = aws_instance.web_server.private_ip
+}
+```
+
+### Step 4: Create Terraform Variables File (Optional)
+
+Create `terraform.tfvars` for environment-specific values:
+
+```hcl
+# terraform.tfvars
+ami_id          = "ami-0c55b159cbfafe1f0"
+instance_type   = "t2.micro"
+environment     = "dev"
+vpc_cidr        = "10.0.0.0/16"
+project_name    = "my-project"
+availability_zone = "us-east-1a"
+```
+
+### Step 5: Initialize and Format
+
+```bash
+# Initialize (download providers)
+tofu init
+
+# Format code for consistency
+tofu fmt
+
+# Validate configuration
+tofu validate
+```
+
+### Step 6: Plan Changes
+
+```bash
+# Show execution plan
+tofu plan
+
+# Save plan for review or automation
+tofu plan -out=tfplan
+
+# Review plan in detail
+tofu show tfplan
+```
+
+### Step 7: Apply Changes
+
+```bash
+# Apply changes interactively
+tofu apply
+
+# Apply saved plan
+tofu apply tfplan
+
+# Auto-approve (use with caution in automation)
+tofu apply -auto-approve
+```
+
+### Step 8: Inspect State
+
+```bash
+# List all resources in state
+tofu state list
+
+# Show specific resource details
+tofu state show aws_instance.web_server
+
+# Show current state as JSON
+tofu show -json
+```
+
+### Step 9: Update Resources
+
+```bash
+# Modify configuration and plan changes
+tofu plan -out=tfplan
+
+# Review and apply changes
+tofu apply tfplan
+```
+
+### Step 10: Destroy Resources
+
+```bash
+# Plan destruction
+tofu plan -destroy
+
+# Destroy all resources in configuration
+tofu destroy
+
+# Destroy specific resources
+tofu destroy -target=aws_instance.web_server
+```
+
+## Best Practices
+
+### Resource Management
+
+1. **Use Descriptive Names**: Make resource names self-documenting
+2. **Tag Everything**: Apply consistent tagging for cost tracking and organization
+3. **Use Variables**: Avoid hardcoding values; use variables for flexibility
+4. **Separate Environments**: Use workspaces or separate state files for dev/staging/prod
+5. **Limit Resource Scope**: Keep configurations focused and modular
+
+### State Management
+
+```bash
+# Use remote state backends for team collaboration
+# Reference: https://www.terraform.io/docs/language/settings/backends/index.html
+
+# State best practices:
+# - Enable encryption
+# - Enable versioning
+# - Use state locking
+# - Regular backups
+```
+
+### Dependency Management
+
+```hcl
+# Implicit dependencies (reference attributes)
+resource "aws_security_group" "web" {
+  name = "web-security-group"
+  # ...
+}
+
+resource "aws_instance" "web" {
+  vpc_security_group_ids = [aws_security_group.web.id]
+  # Depends implicitly on security group
+}
+
+# Explicit dependencies
+resource "aws_instance" "db" {
+  depends_on = [aws_instance.web]
+  # ...
+}
+
+# Use for_each and count for multiple resources
+resource "aws_instance" "servers" {
+  count         = 3
+  ami           = var.ami_id
+  instance_type = var.instance_type
+
+  tags = {
+    Name = "Server-${count.index + 1}"
+  }
+}
+```
+
+### Validation and Planning
+
+```bash
+# Always run plan before apply
+tofu plan -out=tfplan
+tofu apply tfplan
+
+# Use targeted plans for specific changes
+tofu plan -target=aws_instance.web_server
+
+# Use refresh-only to detect drift
+tofu apply -refresh-only
+```
+
+### Modularization
+
+```hcl
+# Create reusable modules
+# modules/vpc/main.tf
+resource "aws_vpc" "main" {
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-vpc"
+  })
+}
+
+# modules/vpc/variables.tf
+variable "cidr_block" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+  default = {}
+}
+
+# Use module in main configuration
+module "vpc" {
+  source = "./modules/vpc"
+
+  cidr_block = var.vpc_cidr
+  name       = var.project_name
+  tags       = var.common_tags
+}
+```
+
+### Data Sources
+
+```hcl
+# Use data sources to reference existing resources
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_instance" "web" {
+  ami = data.aws_ami.amazon_linux_2.id
+  # ...
+}
+```
+
+### Lifecycle Management
+
+```hcl
+resource "aws_instance" "web" {
+  # Prevent recreation if tags change
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes = [
+      tags,
+      user_data
+    ]
+  }
+
+  # Prevent accidental destruction
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+## Common Issues
+
+### Issue: State File Lock
+
+**Symptom**: Error `Error: Error acquiring the state lock`
+
+**Solution**:
+```bash
+# Check who has the lock
+tofu state pull
+
+# Force unlock if necessary (caution!)
+tofu force-unlock <LOCK_ID>
+
+# Reference: https://www.terraform.io/docs/language/state/locking.html
+```
+
+### Issue: Resource Already Exists
+
+**Symptom**: Error `Error: Error creating ...: ... already exists`
+
+**Solution**:
+```bash
+# Import existing resource into state
+tofu import aws_instance.web_server i-0123456789abcdef0
+
+# Then remove from configuration if needed
+tofu state rm aws_instance.web_server
+```
+
+### Issue: Plan Shows Destroy and Create
+
+**Symptom**: Plan wants to destroy and recreate resource instead of updating
+
+**Solution**:
+```hcl
+# Use create_before_destroy lifecycle
+resource "aws_instance" "web" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Or ignore changes to certain attributes
+lifecycle {
+  ignore_changes = [tags]
+}
+```
+
+### Issue: State Drift
+
+**Symptom**: Actual infrastructure differs from state
+
+**Solution**:
+```bash
+# Refresh state to detect drift
+tofu refresh
+
+# Apply only to sync state (no changes)
+tofu apply -refresh-only
+
+# For manual drift, use terraform import
+tofu import <resource_type>.<resource_name> <resource_id>
+```
+
+### Issue: Dependency Cycle
+
+**Symptom**: Error `Error: Cycle: ...`
+
+**Solution**:
+```bash
+# Review resource dependencies
+tofu graph | dot -Tpng > graph.png
+
+# Use explicit dependencies or refactor configuration
+resource "aws_instance" "db" {
+  depends_on = [aws_instance.web, aws_security_group.db]
+  # ...
+}
+```
+
+### Issue: Timeout During Apply
+
+**Symptom**: Apply operation hangs or times out
+
+**Solution**:
+```bash
+# Use timeouts in resource configuration
+resource "aws_instance" "web" {
+  timeouts {
+    create = "10m"
+    delete = "15m"
+  }
+  # ...
+}
+
+# Run plan in background
+tofu apply -auto-parallelism=4 &
+```
+
+## Reference Documentation
+
+- **OpenTofu Documentation**: https://opentofu.org/docs/
+- **Terraform Language**: https://www.terraform.io/docs/language/
+- **Terraform State**: https://www.terraform.io/docs/language/state/
+- **Resource Lifecycle**: https://www.terraform.io/docs/language/meta-arguments/lifecycle.html
+- **Data Sources**: https://www.terraform.io/docs/language/data-sources/index.html
+- **Modules**: https://www.terraform.io/docs/language/modules/develop/index.html
+
+## Examples
+
+### Complete Web Application Stack
+
+```hcl
+# main.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Provider configuration
+provider "aws" {
+  region = var.aws_region
+}
+
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# Public Subnet
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  map_public_ip_on_launch = true
+  availability_zone       = var.availability_zone
+
+  tags = {
+    Name = "${var.project_name}-public-subnet"
+  }
+}
+
+# Route Table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+# Route Table Association
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Security Group
+resource "aws_security_group" "web" {
+  name        = "${var.project_name}-web-sg"
+  description = "Allow HTTP/HTTPS inbound"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS from anywhere"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-web-sg"
+  }
+}
+
+# EC2 Instance
+resource "aws_instance" "web_server" {
+  ami           = data.aws_ami.amazon_linux_2.id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.public.id
+
+  vpc_security_group_ids = [aws_security_group.web.id]
+
+  tags = {
+    Name        = "${var.project_name}-web-server"
+    Environment = var.environment
+  }
+
+  user_data = <<-EOF
+              #!/bin/bash
+              yum update -y
+              yum install -y httpd
+              systemctl start httpd
+              systemctl enable httpd
+              echo "<h1>Hello from ${var.project_name}!</h1>" > /var/www/html/index.html
+              EOF
+}
+
+# Data Source for AMI
+data "aws_ami" "amazon_linux_2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+# variables.tf
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  description = "CIDR block for public subnet"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "availability_zone" {
+  description = "Availability zone"
+  type        = string
+  default     = "us-east-1a"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment"
+  type        = string
+}
+
+# outputs.tf
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  description = "Public subnet ID"
+  value       = aws_subnet.public.id
+}
+
+output "instance_public_ip" {
+  description = "Web server public IP"
+  value       = aws_instance.web_server.public_ip
+}
+
+output "instance_public_dns" {
+  description = "Web server public DNS"
+  value       = aws_instance.web_server.public_dns
+}
+```
+
+### Workflow Commands
+
+```bash
+# Complete provisioning workflow
+tofu init           # Initialize
+tofu fmt            # Format
+tofu validate       # Validate
+tofu plan -out=tfplan  # Plan
+tofu apply tfplan    # Apply
+tofu output         # Show outputs
+tofu show           # Show state
+
+# Update workflow
+tofu plan -out=tfplan -refresh=true
+tofu apply tfplan
+
+# Destroy workflow
+tofu plan -destroy
+tofu destroy
+```
+
+## Tips and Tricks
+
+- **Use tofu fmt**: Auto-format code for consistency
+- **Run tofu validate**: Catch syntax errors early
+- **Review plans**: Always review plans before applying
+- **Use workspaces**: Manage multiple environments
+- **Module everything**: Create reusable modules for common patterns
+- **Tag resources**: For cost tracking and organization
+- **Use data sources**: Reference existing infrastructure
+- **Import existing resources**: Bring existing resources under management
+- **State isolation**: Use separate state files for different environments
+- **Version control**: Store configuration in Git (but not state files!)
+
+## Next Steps
+
+After mastering provisioning workflows, explore:
+- **Terraform Modules**: Create reusable infrastructure components
+- **Terraform Workspaces**: Manage multiple environments
+- **CI/CD Integration**: Automate infrastructure provisioning
+- **Terraform Cloud/Enterprise**: Enterprise-grade state management
+- **Infrastructure Testing**: Use tools like terratest for testing


### PR DESCRIPTION
## Summary

This PR adds 4 new OpenTofu/Terraform provider skills to the repository, enabling users to manage Keycloak, AWS, Neon Postgres, and Kubernetes infrastructure as code.

### Changes

#### New Skills Added

1. **opentofu-keycloak-explorer**
   - Manage Keycloak identity and access management
   - Create realms, clients, users, roles, and identity providers
   - Provider: keycloak/keycloak ~> 5.0.0
   - URL: https://registry.terraform.io/providers/keycloak/keycloak/latest/docs

2. **opentofu-aws-explorer**
   - Manage AWS cloud infrastructure
   - Create VPCs, EC2, RDS, S3, IAM, networking, and security
   - Provider: hashicorp/aws ~> 5.0.0
   - Default region: ap-southeast-1 (as requested)
   - URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs

3. **opentofu-neon-explorer**
   - Manage Neon serverless Postgres databases
   - Create projects, branches, databases, endpoints, and roles
   - Latest version: v0.13.0
   - URL: https://github.com/kislerdm/terraform-provider-neon

4. **opentofu-kubernetes-explorer**
   - Manage Kubernetes clusters and resources
   - Deploy applications, services, ingress, storage, and Helm charts
   - Provider: hashicorp/kubernetes ~> 2.24.0
   - URL: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs

#### Additional Skills Created Earlier

5. **opentofu-provider-setup**
   - General provider configuration guidance
   - Provider setup and state management

6. **opentofu-provisioning-workflow**
   - Infrastructure as Code development patterns
   - Resource lifecycle management

### Features

All skills include:
- ✅ Comprehensive documentation with examples
- ✅ Best practices and common issues troubleshooting
- ✅ Reference URLs to official provider documentation
- ✅ Latest provider version information
- ✅ SKILL.md format with proper frontmatter
- ✅ Step-by-step workflows
- ✅ Security and configuration recommendations

### Success Criteria

- ✅ All 4 requested provider skills created
- ✅ Each skill includes reference URL to provider documentation
- ✅ Skills follow SKILL.md format with proper frontmatter
- ✅ Each skill committed to issue-38 branch
- ✅ All changes pushed to remote
- ✅ Skills use latest provider version information
- ✅ AWS skill defaults to ap-southeast-1

### Testing

All skills follow the opencode-skill-creation framework with:
- YAML frontmatter with name, description, license, compatibility
- "What I do" and "When to use me" sections
- Prerequisites and provider documentation links
- Detailed steps with HCL/Terraform examples
- Best practices, common issues, and troubleshooting
- Reference documentation and examples
- Tips and tricks sections

### Files Modified

```
skills/
├── opentofu-provider-setup/SKILL.md
├── opentofu-provisioning-workflow/SKILL.md
├── opentofu-keycloak-explorer/SKILL.md      (new)
├── opentofu-aws-explorer/SKILL.md               (new, updated for ap-southeast-1)
├── opentofu-neon-explorer/SKILL.md            (new)
├── opentofu-kubernetes-explorer/SKILL.md      (new)
└── OPENTOFU_PLAN.md                                   (tracking)
```

### Notes

- OpenTofu and Terraform are used interchangeably as OpenTofu is an open-source implementation of Terraform
- All provider documentation sourced from Terraform Registry (fully compatible with OpenTofu)
- AWS skill uses ap-southeast-1 as default region (as requested)
- Skills ready for use with OpenCode framework

### Issue Reference

Closes #38