### PR TITLE
feat(skill): add docx-creation skill and subagent

### DIFF
--- a/.AGENTS.md
+++ b/.AGENTS.md
@@ -18,6 +18,7 @@ When a task matches a subagent's specialization, **ALWAYS delegate** rather than
 | `tdd-subagent` | test-driven development |
 | `image-analyzer` | screenshots, UI analysis |
 | `diagram-subagent` | diagrams, flowcharts |
+| `docx-creation-subagent` | Word documents, .docx files, reports, letters |
 | `error-resolver-subagent` | explicit error diagnosis only |
 
 ## Decision Flow

--- a/PLANS/PLAN-GIT-93.md
+++ b/PLANS/PLAN-GIT-93.md
@@ -1,0 +1,39 @@
+# Plan: Create docx-creation skill and subagent for Word document operations
+
+## Issue Reference
+- **Number**: #93
+- **URL**: https://github.com/darellchua2/opencode-config-template/issues/93
+- **Labels**: enhancement
+
+## Overview
+Create a new OpenCode skill (`docx-creation`) and corresponding subagent (`docx-creation-subagent`) for comprehensive Word document manipulation including creation, reading, editing, tracked changes, comments, and conversions.
+
+## Acceptance Criteria
+- [x] `skills/docx-creation/SKILL.md` created with proper OpenCode format
+- [ ] `docx-creation-subagent` added to `config.json`
+- [ ] `.AGENTS.md` updated with new subagent domain
+
+## Scope
+- `skills/docx-creation/SKILL.md` (new)
+- `config.json` (modify - add subagent)
+- `.AGENTS.md` (modify - add domain entry)
+
+---
+
+## Implementation Phases
+
+### Phase 1: Create Skill Directory and SKILL.md
+- [x] Create `skills/docx-creation/` directory
+- [x] Create `SKILL.md` with proper YAML frontmatter
+
+### Phase 2: Add Subagent to config.json
+- [ ] Add `docx-creation-subagent` entry
+
+### Phase 3: Update .AGENTS.md
+- [ ] Add docx-creation-subagent to subagent domains table
+
+---
+
+## Success Metrics
+- Skill can be loaded by OpenCode
+- Subagent routes docx-related tasks correctly

--- a/config.json
+++ b/config.json
@@ -64,7 +64,6 @@
       },
       "mcp": {}
     },
-
     "linting-subagent": {
       "description": "Specialized subagent for code linting and quality checks. Handles Python Ruff, JavaScript/TypeScript ESLint, and generic linting workflows across multiple programming languages and frameworks.",
       "mode": "subagent",
@@ -341,7 +340,7 @@
       "description": "Specialized subagent for ASCII diagram creation and image generation. Creates flowcharts, sequence diagrams, architecture diagrams, and converts them to image files.",
       "mode": "subagent",
       "model": "zai-coding-plan/glm-4.7",
-      "prompt": "You are a diagram creation specialist. Create ASCII diagrams and save them as image files.\n\nSkill:\n- ascii-diagram-creator: Create ASCII diagrams from workflow definitions\n\nDiagram Types:\n- Flowcharts\n- Process flows\n- Sequence diagrams\n- State machines\n- System architecture diagrams\n- Decision trees\n\nWorkflow:\n1. Parse workflow definition from user input\n2. Identify diagram type needed\n3. Extract key elements (start/end, processes, decisions, connections)\n4. Design ASCII diagram with box-drawing characters\n5. Create output directory (diagrams/)\n6. Save ASCII to text file\n7. Convert to image (PNG, SVG, PDF)\n8. Verify and report\n\nBox Drawing Characters:\n- Horizontal: ─ ═ ━\n- Vertical: │ ║ ┃\n- Corners: ┌ ┐ └ ┘\n- Crosses: ┼ ╪ ╬\n- T-junctions: ├ ┤ ┬ ┴\n\nImage Conversion:\n- ImageMagick: convert command\n- Courier font, monospace\n- White background, black fill\n- Appropriate font size (10-14pt)\n\nDelegation:\n- ImageMagick commands: Request from parent agent\n- Directory creation: Request from parent agent\n\nAlways provide both ASCII and image output. Keep diagrams simple and readable.",
+      "prompt": "You are a diagram creation specialist. Create ASCII diagrams and save them as image files.\n\nSkill:\n- ascii-diagram-creator: Create ASCII diagrams from workflow definitions\n\nDiagram Types:\n- Flowcharts\n- Process flows\n- Sequence diagrams\n- State machines\n- System architecture diagrams\n- Decision trees\n\nWorkflow:\n1. Parse workflow definition from user input\n2. Identify diagram type needed\n3. Extract key elements (start/end, processes, decisions, connections)\n4. Design ASCII diagram with box-drawing characters\n5. Create output directory (diagrams/)\n6. Save ASCII to text file\n7. Convert to image (PNG, SVG, PDF)\n8. Verify and report\n\nBox Drawing Characters:\n- Horizontal: \u2500 \u2550 \u2501\n- Vertical: \u2502 \u2551 \u2503\n- Corners: \u250c \u2510 \u2514 \u2518\n- Crosses: \u253c \u256a \u256c\n- T-junctions: \u251c \u2524 \u252c \u2534\n\nImage Conversion:\n- ImageMagick: convert command\n- Courier font, monospace\n- White background, black fill\n- Appropriate font size (10-14pt)\n\nDelegation:\n- ImageMagick commands: Request from parent agent\n- Directory creation: Request from parent agent\n\nAlways provide both ASCII and image output. Keep diagrams simple and readable.",
       "tools": {
         "read": true,
         "write": true,
@@ -351,6 +350,25 @@
       "permission": {
         "skill": {
           "ascii-diagram-creator": "allow"
+        }
+      }
+    },
+    "docx-creation-subagent": {
+      "description": "Specialized subagent for Word document creation and manipulation. Creates, reads, edits, and converts .docx files with professional formatting, tracked changes, comments, and images.",
+      "mode": "subagent",
+      "model": "zai-coding-plan/glm-4.7",
+      "prompt": "You are a Word document specialist. Handle all .docx file operations:\n\nCapabilities:\n- Create new documents with docx-js (professional formatting, tables, images)\n- Read and analyze existing documents using pandoc or XML extraction\n- Edit documents by unpacking, modifying XML, and repacking\n- Handle tracked changes (insertions, deletions, comments)\n- Convert formats (.doc to .docx, .docx to PDF, .docx to images)\n- Add tables, headers, footers, hyperlinks, table of contents\n- Apply page layouts, margins, multi-column layouts\n\nWorkflow for New Documents:\n1. Gather document requirements (type, content, formatting)\n2. Set page size explicitly (US Letter: 12240x15840 DXA)\n3. Use Arial font for compatibility\n4. Create with docx-js following critical rules:\n   - Tables need dual widths (columnWidths AND cell width)\n   - Use ShadingType.CLEAR for table shading\n   - ImageRun requires type parameter\n   - Never use unicode bullets (use LevelFormat.BULLET)\n5. Validate created document\n\nWorkflow for Editing:\n1. Unpack document: python scripts/office/unpack.py doc.docx unpacked/\n2. Edit XML in unpacked/word/\n3. Use smart quote entities (&#x2018;, &#x2019;, &#x201C;, &#x201D;)\n4. Pack: python scripts/office/pack.py unpacked/ output.docx\n5. Validate\n\nCritical Rules:\n- docx-js defaults to A4 - always set page size\n- Tables: use WidthType.DXA, never PERCENTAGE\n- PageBreak must be inside Paragraph\n- Tracked changes: use proper author and timestamps\n- Comments: markers are siblings of <w:r>, never inside\n\nDelegation:\n- Bash commands (pandoc, python scripts): Request from parent agent\n- File operations: Request from parent agent\n\nProvide complete, professional documents. Follow docx-creation skill guidelines.",
+      "tools": {
+        "read": true,
+        "write": true,
+        "edit": true,
+        "glob": true,
+        "grep": true
+      },
+      "mcp": {},
+      "permission": {
+        "skill": {
+          "docx-creation": "allow"
         }
       }
     }

--- a/skills/docx-creation/SKILL.md
+++ b/skills/docx-creation/SKILL.md
@@ -1,0 +1,505 @@
+---
+name: docx-creation
+description: "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation."
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: document-generation
+---
+
+## What I do
+
+- Create new Word documents (.docx) using docx-js with professional formatting
+- Read and analyze existing .docx files using pandoc or raw XML extraction
+- Edit existing documents by unpacking, modifying XML, and repacking
+- Handle tracked changes (insertions, deletions, comments)
+- Convert between formats (.doc to .docx, .docx to PDF, .docx to images)
+- Add images, tables, headers, footers, and hyperlinks to documents
+- Generate tables of contents with proper heading hierarchy
+- Apply page layouts, margins, and multi-column layouts
+
+## When to use me
+
+Use this skill when:
+- User mentions "Word doc", "word document", ".docx", or "Word file"
+- Creating reports, memos, letters, or templates as Word documents
+- Extracting or reorganizing content from .docx files
+- Working with tracked changes, comments, or reviewing documents
+- Converting documents to/from .docx format
+- Adding images, tables, or professional formatting to documents
+- Creating documents with tables of contents, page numbers, or letterheads
+
+Do NOT use for:
+- PDFs (use PDF-specific tools)
+- Spreadsheets (use Excel tools)
+- Google Docs (use Google Workspace tools)
+- General coding tasks unrelated to document generation
+
+## Prerequisites
+
+- **pandoc**: Text extraction from .docx files
+- **docx**: `npm install -g docx` (for creating new documents)
+- **LibreOffice**: PDF conversion (auto-configured via `scripts/office/soffice.py`)
+- **Poppler**: `pdftoppm` for converting PDFs to images
+
+## Quick Reference
+
+| Task | Approach |
+|------|----------|
+| Read/analyze content | `pandoc` or unpack for raw XML |
+| Create new document | Use `docx-js` - see Creating New Documents below |
+| Edit existing document | Unpack -> edit XML -> repack - see Editing Existing Documents below |
+
+### Converting .doc to .docx
+
+Legacy `.doc` files must be converted before editing:
+
+```bash
+python scripts/office/soffice.py --headless --convert-to docx document.doc
+```
+
+### Reading Content
+
+```bash
+# Text extraction with tracked changes
+pandoc --track-changes=all document.docx -o output.md
+
+# Raw XML access
+python scripts/office/unpack.py document.docx unpacked/
+```
+
+### Converting to Images
+
+```bash
+python scripts/office/soffice.py --headless --convert-to pdf document.docx
+pdftoppm -jpeg -r 150 document.pdf page
+```
+
+### Accepting Tracked Changes
+
+To produce a clean document with all tracked changes accepted:
+
+```bash
+python scripts/accept_changes.py input.docx output.docx
+```
+
+---
+
+## Creating New Documents
+
+Generate .docx files with JavaScript, then validate. Install: `npm install -g docx`
+
+### Setup
+```javascript
+const { Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell, ImageRun,
+        Header, Footer, AlignmentType, PageOrientation, LevelFormat, ExternalHyperlink,
+        InternalHyperlink, Bookmark, FootnoteReferenceRun, PositionalTab,
+        PositionalTabAlignment, PositionalTabRelativeTo, PositionalTabLeader,
+        TabStopType, TabStopPosition, Column, SectionType,
+        TableOfContents, HeadingLevel, BorderStyle, WidthType, ShadingType,
+        VerticalAlign, PageNumber, PageBreak } = require('docx');
+
+const doc = new Document({ sections: [{ children: [/* content */] }] });
+Packer.toBuffer(doc).then(buffer => fs.writeFileSync("doc.docx", buffer));
+```
+
+### Validation
+After creating the file, validate it. If validation fails, unpack, fix the XML, and repack.
+```bash
+python scripts/office/validate.py doc.docx
+```
+
+### Page Size
+
+```javascript
+// CRITICAL: docx-js defaults to A4, not US Letter
+// Always set page size explicitly for consistent results
+sections: [{
+  properties: {
+    page: {
+      size: {
+        width: 12240,   // 8.5 inches in DXA
+        height: 15840   // 11 inches in DXA
+      },
+      margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } // 1 inch margins
+    }
+  },
+  children: [/* content */]
+}]
+```
+
+**Common page sizes (DXA units, 1440 DXA = 1 inch):**
+
+| Paper | Width | Height | Content Width (1" margins) |
+|-------|-------|--------|---------------------------|
+| US Letter | 12,240 | 15,840 | 9,360 |
+| A4 (default) | 11,906 | 16,838 | 9,026 |
+
+**Landscape orientation:** docx-js swaps width/height internally, so pass portrait dimensions and let it handle the swap:
+```javascript
+size: {
+  width: 12240,   // Pass SHORT edge as width
+  height: 15840,  // Pass LONG edge as height
+  orientation: PageOrientation.LANDSCAPE  // docx-js swaps them in the XML
+},
+// Content width = 15840 - left margin - right margin (uses the long edge)
+```
+
+### Styles (Override Built-in Headings)
+
+Use Arial as the default font (universally supported). Keep titles black for readability.
+
+```javascript
+const doc = new Document({
+  styles: {
+    default: { document: { run: { font: "Arial", size: 24 } } }, // 12pt default
+    paragraphStyles: [
+      // IMPORTANT: Use exact IDs to override built-in styles
+      { id: "Heading1", name: "Heading 1", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 32, bold: true, font: "Arial" },
+        paragraph: { spacing: { before: 240, after: 240 }, outlineLevel: 0 } }, // outlineLevel required for TOC
+      { id: "Heading2", name: "Heading 2", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 28, bold: true, font: "Arial" },
+        paragraph: { spacing: { before: 180, after: 180 }, outlineLevel: 1 } },
+    ]
+  },
+  sections: [{
+    children: [
+      new Paragraph({ heading: HeadingLevel.HEADING_1, children: [new TextRun("Title")] }),
+    ]
+  }]
+});
+```
+
+### Lists (NEVER use unicode bullets)
+
+```javascript
+// WRONG - never manually insert bullet characters
+new Paragraph({ children: [new TextRun("* Item")] })  // BAD
+
+// CORRECT - use numbering config with LevelFormat.BULLET
+const doc = new Document({
+  numbering: {
+    config: [
+      { reference: "bullets",
+        levels: [{ level: 0, format: LevelFormat.BULLET, text: "*", alignment: AlignmentType.LEFT,
+          style: { paragraph: { indent: { left: 720, hanging: 360 } } } }] },
+      { reference: "numbers",
+        levels: [{ level: 0, format: LevelFormat.DECIMAL, text: "%1.", alignment: AlignmentType.LEFT,
+          style: { paragraph: { indent: { left: 720, hanging: 360 } } } }] },
+    ]
+  },
+  sections: [{
+    children: [
+      new Paragraph({ numbering: { reference: "bullets", level: 0 },
+        children: [new TextRun("Bullet item")] }),
+      new Paragraph({ numbering: { reference: "numbers", level: 0 },
+        children: [new TextRun("Numbered item")] }),
+    ]
+  }]
+});
+
+// Each reference creates INDEPENDENT numbering
+// Same reference = continues (1,2,3 then 4,5,6)
+// Different reference = restarts (1,2,3 then 1,2,3)
+```
+
+### Tables
+
+**CRITICAL: Tables need dual widths** - set both `columnWidths` on the table AND `width` on each cell. Without both, tables render incorrectly on some platforms.
+
+```javascript
+// CRITICAL: Always set table width for consistent rendering
+// CRITICAL: Use ShadingType.CLEAR (not SOLID) to prevent black backgrounds
+const border = { style: BorderStyle.SINGLE, size: 1, color: "CCCCCC" };
+const borders = { top: border, bottom: border, left: border, right: border };
+
+new Table({
+  width: { size: 9360, type: WidthType.DXA }, // Always use DXA (percentages break in Google Docs)
+  columnWidths: [4680, 4680], // Must sum to table width (DXA: 1440 = 1 inch)
+  rows: [
+    new TableRow({
+      children: [
+        new TableCell({
+          borders,
+          width: { size: 4680, type: WidthType.DXA }, // Also set on each cell
+          shading: { fill: "D5E8F0", type: ShadingType.CLEAR }, // CLEAR not SOLID
+          margins: { top: 80, bottom: 80, left: 120, right: 120 }, // Cell padding
+          children: [new Paragraph({ children: [new TextRun("Cell")] })]
+        })
+      ]
+    })
+  ]
+})
+```
+
+**Table width calculation:**
+
+Always use `WidthType.DXA` - `WidthType.PERCENTAGE` breaks in Google Docs.
+
+```javascript
+// Table width = sum of columnWidths = content width
+// US Letter with 1" margins: 12240 - 2880 = 9360 DXA
+width: { size: 9360, type: WidthType.DXA },
+columnWidths: [7000, 2360]  // Must sum to table width
+```
+
+### Images
+
+```javascript
+// CRITICAL: type parameter is REQUIRED
+new Paragraph({
+  children: [new ImageRun({
+    type: "png", // Required: png, jpg, jpeg, gif, bmp, svg
+    data: fs.readFileSync("image.png"),
+    transformation: { width: 200, height: 150 },
+    altText: { title: "Title", description: "Desc", name: "Name" } // All three required
+  })]
+})
+```
+
+### Page Breaks
+
+```javascript
+// CRITICAL: PageBreak must be inside a Paragraph
+new Paragraph({ children: [new PageBreak()] })
+
+// Or use pageBreakBefore
+new Paragraph({ pageBreakBefore: true, children: [new TextRun("New page")] })
+```
+
+### Hyperlinks
+
+```javascript
+// External link
+new Paragraph({
+  children: [new ExternalHyperlink({
+    children: [new TextRun({ text: "Click here", style: "Hyperlink" })],
+    link: "https://example.com",
+  })]
+})
+
+// Internal link (bookmark + reference)
+new Paragraph({ heading: HeadingLevel.HEADING_1, children: [
+  new Bookmark({ id: "chapter1", children: [new TextRun("Chapter 1")] }),
+]})
+new Paragraph({ children: [new InternalHyperlink({
+  children: [new TextRun({ text: "See Chapter 1", style: "Hyperlink" })],
+  anchor: "chapter1",
+})]})
+```
+
+### Table of Contents
+
+```javascript
+// CRITICAL: Headings must use HeadingLevel ONLY - no custom styles
+new TableOfContents("Table of Contents", { hyperlink: true, headingStyleRange: "1-3" })
+```
+
+### Headers/Footers
+
+```javascript
+sections: [{
+  properties: {
+    page: { margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } } // 1440 = 1 inch
+  },
+  headers: {
+    default: new Header({ children: [new Paragraph({ children: [new TextRun("Header")] })] })
+  },
+  footers: {
+    default: new Footer({ children: [new Paragraph({
+      children: [new TextRun("Page "), new TextRun({ children: [PageNumber.CURRENT] })]
+    })] })
+  },
+  children: [/* content */]
+}]
+```
+
+### Critical Rules for docx-js
+
+- **Set page size explicitly** - docx-js defaults to A4; use US Letter (12240 x 15840 DXA) for US documents
+- **Never use `\n`** - use separate Paragraph elements
+- **Never use unicode bullets** - use `LevelFormat.BULLET` with numbering config
+- **PageBreak must be in Paragraph** - standalone creates invalid XML
+- **ImageRun requires `type`** - always specify png/jpg/etc
+- **Always set table `width` with DXA** - never use `WidthType.PERCENTAGE`
+- **Tables need dual widths** - `columnWidths` array AND cell `width`, both must match
+- **Use `ShadingType.CLEAR`** - never SOLID for table shading
+- **TOC requires HeadingLevel only** - no custom styles on heading paragraphs
+- **Override built-in styles** - use exact IDs: "Heading1", "Heading2", etc.
+- **Include `outlineLevel`** - required for TOC (0 for H1, 1 for H2, etc.)
+
+---
+
+## Editing Existing Documents
+
+**Follow all 3 steps in order.**
+
+### Step 1: Unpack
+```bash
+python scripts/office/unpack.py document.docx unpacked/
+```
+Extracts XML, pretty-prints, merges adjacent runs.
+
+### Step 2: Edit XML
+
+Edit files in `unpacked/word/`. See XML Reference below for patterns.
+
+**Use "Claude" as the author** for tracked changes and comments, unless the user explicitly requests use of a different name.
+
+**CRITICAL: Use smart quotes for new content.** When adding text with apostrophes or quotes, use XML entities:
+```xml
+<w:t>Here&#x2019;s a quote: &#x201C;Hello&#x201D;</w:t>
+```
+| Entity | Character |
+|--------|-----------|
+| `&#x2018;` | ' (left single) |
+| `&#x2019;` | ' (right single / apostrophe) |
+| `&#x201C;` | " (left double) |
+| `&#x201D;` | " (right double) |
+
+### Step 3: Pack
+```bash
+python scripts/office/pack.py unpacked/ output.docx --original document.docx
+```
+Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate false` to skip.
+
+---
+
+## XML Reference
+
+### Schema Compliance
+
+- **Element order in `<w:pPr>`**: `<w:pStyle>`, `<w:numPr>`, `<w:spacing>`, `<w:ind>`, `<w:jc>`, `<w:rPr>` last
+- **Whitespace**: Add `xml:space="preserve"` to `<w:t>` with leading/trailing spaces
+- **RSIDs**: Must be 8-digit hex (e.g., `00AB1234`)
+
+### Tracked Changes
+
+**Insertion:**
+```xml
+<w:ins w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+  <w:r><w:t>inserted text</w:t></w:r>
+</w:ins>
+```
+
+**Deletion:**
+```xml
+<w:del w:id="2" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+  <w:r><w:delText>deleted text</w:delText></w:r>
+</w:del>
+```
+
+**Inside `<w:del>`**: Use `<w:delText>` instead of `<w:t>`.
+
+### Comments
+
+**CRITICAL: `<w:commentRangeStart>` and `<w:commentRangeEnd>` are siblings of `<w:r>`, never inside `<w:r>`.**
+
+```xml
+<w:commentRangeStart w:id="0"/>
+<w:r><w:t>text</w:t></w:r>
+<w:commentRangeEnd w:id="0"/>
+<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="0"/></w:r>
+```
+
+### Images
+
+1. Add image file to `word/media/`
+2. Add relationship to `word/_rels/document.xml.rels`:
+```xml
+<Relationship Id="rId5" Type=".../image" Target="media/image1.png"/>
+```
+3. Add content type to `[Content_Types].xml`:
+```xml
+<Default Extension="png" ContentType="image/png"/>
+```
+4. Reference in document.xml:
+```xml
+<w:drawing>
+  <wp:inline>
+    <wp:extent cx="914400" cy="914400"/>  <!-- EMUs: 914400 = 1 inch -->
+    <a:graphic>
+      <a:graphicData uri=".../picture">
+        <pic:pic>
+          <pic:blipFill><a:blip r:embed="rId5"/></pic:blipFill>
+        </pic:pic>
+      </a:graphicData>
+    </a:graphic>
+  </wp:inline>
+</w:drawing>
+```
+
+---
+
+## Dependencies
+
+- **pandoc**: Text extraction
+- **docx**: `npm install -g docx` (new documents)
+- **LibreOffice**: PDF conversion (auto-configured for sandboxed environments)
+- **Poppler**: `pdftoppm` for images
+
+## Best Practices
+
+### Document Creation
+- Always set page size explicitly (docx-js defaults to A4)
+- Use Arial font for universal compatibility
+- Include outlineLevel on headings for TOC support
+- Set table widths with DXA, never percentages
+
+### Editing Workflow
+- Always unpack before editing XML
+- Use smart quote entities for professional typography
+- Preserve formatting when adding tracked changes
+- Validate after packing
+
+## Common Issues
+
+### Invalid XML After Edit
+**Issue**: Document won't open after XML editing
+
+**Solution**:
+- Check element order in `<w:pPr>`
+- Add `xml:space="preserve"` to text with whitespace
+- Validate with `python scripts/office/validate.py doc.docx`
+
+### Tables Render Incorrectly
+**Issue**: Tables look wrong in Google Docs or other viewers
+
+**Solution**:
+- Use `WidthType.DXA` instead of `PERCENTAGE`
+- Ensure `columnWidths` sum equals table width
+- Set `width` on each cell matching `columnWidths`
+
+### Images Not Displaying
+**Issue**: Images appear as broken placeholders
+
+**Solution**:
+- Add image to `word/media/` directory
+- Add relationship entry in `word/_rels/document.xml.rels`
+- Add content type in `[Content_Types].xml`
+- Verify `r:embed` matches relationship ID
+
+## Verification Commands
+
+```bash
+# Validate document structure
+python scripts/office/validate.py document.docx
+
+# Extract text to verify content
+pandoc document.docx -o output.md && cat output.md
+
+# Unpack to inspect XML
+python scripts/office/unpack.py document.docx unpacked/
+ls unpacked/word/
+```
+
+**Verification Checklist**:
+- [ ] Document opens in Word/LibreOffice without errors
+- [ ] Page size is correct (US Letter or A4 as intended)
+- [ ] Tables render correctly with proper widths
+- [ ] Images display properly
+- [ ] Tracked changes appear in review pane
+- [ ] TOC generates correctly from headings
+- [ ] Headers/footers appear on all pages


### PR DESCRIPTION
## Summary
- Add `skills/docx-creation/SKILL.md` - comprehensive Word document manipulation skill with docx-js patterns, XML editing workflows, tracked changes, comments, and conversion guides
- Add `docx-creation-subagent` to `config.json` - specialized subagent for daily document operations
- Update `.AGENTS.md` - register new subagent domain for Word documents

## Changes

### Skill: `skills/docx-creation/SKILL.md`
- Complete docx-js reference (page sizes, styles, lists, tables, images, hyperlinks, TOC)
- XML editing workflow (unpack → edit → pack → validate)
- Tracked changes and comments XML patterns
- Critical rules and best practices
- Verification commands and troubleshooting

### Subagent: `docx-creation-subagent`
- Mode: subagent
- Model: zai-coding-plan/glm-4.7
- Tools: read, write, edit, glob, grep
- Permission: docx-creation skill

### AGENTS.md
- Added domain: `| docx-creation-subagent | Word documents, .docx files, reports, letters |`

## Testing
- [x] JSON config validates
- [x] SKILL.md has proper YAML frontmatter
- [x] .AGENTS.md table updated

Closes #93