### PR TITLE
feat: add PowerShell setup script and fix cross-platform setup scripts

### DIFF
--- a/PLANS/PLAN-GIT-93.md
+++ b/PLANS/PLAN-GIT-93.md
@@ -10,8 +10,8 @@ Create a new OpenCode skill (`docx-creation`) and corresponding subagent (`docx-
 
 ## Acceptance Criteria
 - [x] `skills/docx-creation/SKILL.md` created with proper OpenCode format
-- [ ] `docx-creation-subagent` added to `config.json`
-- [ ] `.AGENTS.md` updated with new subagent domain
+- [x] `docx-creation-subagent` added to `config.json`
+- [x] `.AGENTS.md` updated with new subagent domain
 
 ## Scope
 - `skills/docx-creation/SKILL.md` (new)
@@ -27,10 +27,10 @@ Create a new OpenCode skill (`docx-creation`) and corresponding subagent (`docx-
 - [x] Create `SKILL.md` with proper YAML frontmatter
 
 ### Phase 2: Add Subagent to config.json
-- [ ] Add `docx-creation-subagent` entry
+- [x] Add `docx-creation-subagent` entry
 
 ### Phase 3: Update .AGENTS.md
-- [ ] Add docx-creation-subagent to subagent domains table
+- [x] Add docx-creation-subagent to subagent domains table
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,76 @@
 
 This repository contains a pre-configured OpenCode configuration file with support for local LM Studio, Jira/Confluence integration via Atlassian MCP, and Z.AI services. It also includes reusable workflow skills for common development tasks.
 
-## Prerequisites
+## Installation
 
-- **Node.js v24** and **npm** installed (required for MCP servers)
-  - Node.js v20+ is minimum requirement (setup script installs v24)
-- **LM Studio** running locally on port 1234 (for local LLM)
-- **Z.AI API Key** (required for Z.AI MCP services)
-- **Draw.io Browser Extension** (optional, for diagram creation - see Draw.io Integration section)
+Two setup scripts are provided for different platforms:
 
-### Install Node.js using nvm
+| Script | Platform | Features |
+|--------|----------|----------|
+| `setup.sh` | macOS, Linux, WSL, Git Bash | Full feature set including nvm, PeonPing, JIRA OAuth2 |
+| `setup.ps1` | Windows (PowerShell) | Full feature set, env vars persist to `$PROFILE` |
+
+### macOS / Linux / WSL / Git Bash
 
 ```bash
-# Install nvm (Node Version Manager)
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+# Interactive setup (recommended for first-time)
+./setup.sh
 
-# Reload shell configuration
+# Quick setup - config + skills only (skip dependency checks)
+./setup.sh --quick
+
+# Skills-only deployment (requires opencode-ai installed)
+./setup.sh --skills-only
+
+# Non-interactive mode
+./setup.sh --yes
+
+# Preview actions without making changes
+./setup.sh --dry-run
+
+# Update OpenCode CLI only
+./setup.sh --update
+```
+
+### Windows (PowerShell)
+
+```powershell
+# Interactive setup
+powershell -ExecutionPolicy Bypass -File .\setup.ps1
+
+# Quick setup
+powershell -ExecutionPolicy Bypass -File .\setup.ps1 -Quick
+
+# Non-interactive
+powershell -ExecutionPolicy Bypass -File .\setup.ps1 -Quick -Yes
+
+# Show help with all options
+powershell -ExecutionPolicy Bypass -File .\setup.ps1 -Help
+```
+
+## Prerequisites
+
+- **Node.js v20+** and **npm** (required for MCP servers)
+  - Setup scripts can install Node.js for you on all platforms
+  - On macOS/Linux, nvm is recommended for version management
+- **LM Studio** running locally on port 1234 (for local LLM)
+- **Z.AI API Key** (required for Z.AI MCP services)
+
+### Install Node.js
+
+```bash
+# macOS / Linux - using nvm (recommended)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 source ~/.bashrc
+nvm install 24
+
+# Windows - options:
+# 1. nvm-windows (recommended): https://github.com/coreybutler/nvm-windows/releases
+#    Then: nvm install 24 && nvm use 24
+# 2. winget: winget install OpenJS.NodeJS.LTS
+# 3. chocolatey: choco install nodejs
+# 4. Direct download: https://nodejs.org/
+```
 
 ## Configuration Overview
 
@@ -104,12 +158,21 @@ Skills follow a modular architecture:
 
 ### Configuration Files
 
-The setup script automatically:
+The setup scripts automatically:
 - Copies `.AGENTS.md` to `~/.config/opencode/AGENTS.md` (renaming it)
 - Copies `skills/` folder to `~/.config/opencode/skills/`
 - Copies `config.json` to `~/.config/opencode/config.json`
+- Backs up existing files before overwriting
+
+### Environment Variable Persistence
+
+| Platform | Method | Location |
+|----------|--------|----------|
+| macOS / Linux / WSL | Shell rc file | `~/.bashrc` or `~/.zshrc` |
+| Windows (Git Bash) | `setx` (registry) | Available in new sessions |
+| Windows PowerShell | `$PROFILE` | `~\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` |
 
 ### Template Files
 
-This repository includes inline default configurations in setup.sh. No external template files are required.
+This repository includes inline default configurations in all setup scripts. No external template files are required.
 

--- a/config.json
+++ b/config.json
@@ -10,10 +10,7 @@
     "opencode-pty",
     "opencode-vibeguard"
   ],
-  "instructions": [
-    "${env:HOME}/.config/opencode/AGENTS.md",
-    "AGENTS.md"
-  ],
+  "instructions": ["AGENTS.md"],
   "provider": {
     "lmstudio": {
       "npm": "@ai-sdk/openai-compatible",
@@ -41,11 +38,7 @@
       "mcp": {
         "zai-mcp-server": {
           "type": "local",
-          "command": [
-            "npx",
-            "-y",
-            "@z_ai/mcp-server"
-          ],
+          "command": ["npx", "-y", "@z_ai/mcp-server"],
           "environment": {
             "Z_AI_API_KEY": "${env:ZAI_API_KEY}",
             "Z_AI_MODE": "ZAI"
@@ -218,11 +211,7 @@
       "mcp": {
         "zai-mcp-server": {
           "type": "local",
-          "command": [
-            "npx",
-            "-y",
-            "@z_ai/mcp-server"
-          ],
+          "command": ["npx", "-y", "@z_ai/mcp-server"],
           "environment": {
             "Z_AI_API_KEY": "${env:ZAI_API_KEY}",
             "Z_AI_MODE": "ZAI"
@@ -402,11 +391,7 @@
     },
     "zai-mcp-server": {
       "type": "local",
-      "command": [
-        "npx",
-        "-y",
-        "@z_ai/mcp-server"
-      ],
+      "command": ["npx", "-y", "@z_ai/mcp-server"],
       "environment": {
         "Z_AI_API_KEY": "${env:ZAI_API_KEY}",
         "Z_AI_MODE": "ZAI"

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,1649 @@
+<#
+.SYNOPSIS
+    OpenCode Configuration Setup Script for Windows (PowerShell)
+
+.DESCRIPTION
+    Automated setup for OpenCode configuration on Windows with proper error
+    handling, logging, and user experience enhancements.
+
+.EXAMPLE
+    .\setup.ps1                      # Interactive menu (recommended)
+    .\setup.ps1 -Quick               # Quick setup (config + skills only)
+    .\setup.ps1 -SkillsOnly          # Skills deployment only
+    .\setup.ps1 -Update              # Update OpenCode CLI to latest
+    .\setup.ps1 -DryRun              # Preview all actions without changes
+    .\setup.ps1 -Yes                 # Auto-accept all prompts
+    .\setup.ps1 -Help                # Show detailed help
+
+.NOTES
+    Requires PowerShell 5.1+ (ships with Windows 10/11)
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Quick,
+    [switch]$SkillsOnly,
+    [switch]$Update,
+    [switch]$DryRun,
+    [switch]$Yes,
+    [switch]$Help,
+
+    [ValidateSet("daily", "weekly", "monthly", "manual")]
+    [string]$ScheduleUpdate = "manual",
+
+    [switch]$EnableAutoUpdate,
+    [switch]$DisableAutoUpdate,
+    [switch]$CheckUpdate
+)
+
+$ErrorActionPreference = "Continue"
+Set-StrictMode -Version Latest
+
+################################################################################
+# GLOBAL VARIABLES
+################################################################################
+
+$ScriptDir = $PSScriptRoot
+if (-not $ScriptDir) { $ScriptDir = Get-Location }
+
+$VersionFile = Join-Path $ScriptDir "VERSION"
+if (Test-Path $VersionFile) {
+    $ScriptVersion = (Get-Content $VersionFile -Raw).Trim()
+} else {
+    $ScriptVersion = "2.0.0"
+}
+
+$ConfigDir = Join-Path $HOME ".config\opencode"
+$ConfigFile = Join-Path $ConfigDir "config.json"
+$SkillsDir = Join-Path $ConfigDir "skills"
+$BackupDir = Join-Path $HOME ".opencode-backup-$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+$LogFile = Join-Path $HOME ".opencode-setup.log"
+$LastUpdateCheck = Join-Path $ConfigDir ".last-update-check"
+$UpdateLog = Join-Path $ConfigDir "update.log"
+
+$GitHubPAT = $env:GITHUB_PAT
+$ZaiApiKey = $env:ZAI_API_KEY
+$JiraClientId = $env:JIRA_CLIENT_ID
+$JiraClientSecret = $env:JIRA_CLIENT_SECRET
+$JiraAccessToken = $env:JIRA_ACCESS_TOKEN
+$JiraRefreshToken = $env:JIRA_REFRESH_TOKEN
+$JiraCloudId = $env:JIRA_CLOUD_ID
+
+$SkipConfigCopy = $false
+
+################################################################################
+# LOGGING FUNCTIONS
+################################################################################
+
+function Initialize-Logging {
+    $logDir = Split-Path $LogFile -Parent
+    if (-not (Test-Path $logDir)) {
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    }
+    if (-not (Test-Path $LogFile)) {
+        New-Item -ItemType File -Path $LogFile -Force | Out-Null
+    }
+    Write-Log "INFO" "=== OpenCode Setup Started at $(Get-Date) ==="
+    Write-Log "INFO" "Script version: $ScriptVersion"
+    Write-Log "INFO" "User: $env:USERNAME"
+    Write-Log "INFO" "PowerShell version: $($PSVersionTable.PSVersion)"
+    Write-Log "INFO" "Working directory: $(Get-Location)"
+}
+
+function Write-Log {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Level,
+        [Parameter(Mandatory)]
+        [string]$Message
+    )
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $logLine = "[$timestamp] [$Level] $Message"
+
+    try {
+        Add-Content -Path $LogFile -Value $logLine -ErrorAction SilentlyContinue
+    } catch {}
+
+    switch ($Level) {
+        "ERROR"   { Write-Host "[$Level] $Message" -ForegroundColor Red }
+        "WARNING" { Write-Host "[$Level] $Message" -ForegroundColor Yellow }
+        "SUCCESS" { Write-Host "[$Level] $Message" -ForegroundColor Green }
+        "DEBUG"   { if ($VerbosePreference -eq "Continue") { Write-Host "[$Level] $Message" -ForegroundColor Gray } }
+        default   { Write-Host "[$Level] $Message" }
+    }
+}
+
+function Write-LogInfo    { param([string]$Msg) Write-Log "INFO"    $Msg }
+function Write-LogWarn    { param([string]$Msg) Write-Log "WARNING" $Msg }
+function Write-LogError   { param([string]$Msg) Write-Log "ERROR"   $Msg }
+function Write-LogSuccess { param([string]$Msg) Write-Log "SUCCESS" $Msg }
+function Write-LogDebug   { param([string]$Msg) Write-Log "DEBUG"   $Msg }
+
+################################################################################
+# UTILITY FUNCTIONS
+################################################################################
+
+function Test-CommandExists {
+    param([Parameter(Mandatory)][string]$Name)
+    $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Invoke-WithDryRun {
+    param([Parameter(Mandatory)][string]$Command, [string]$Description = $Command)
+
+    Write-LogDebug "Executing: $Command"
+
+    if ($DryRun) {
+        Write-Host "[DRY-RUN] Would execute: $Command" -ForegroundColor Cyan
+        return $true
+    }
+
+    try {
+        $result = Invoke-Expression $Command
+        return $true
+    } catch {
+        Write-LogError "Command failed: $Description"
+        Write-LogError $_.Exception.Message
+        return $false
+    }
+}
+
+function Read-Prompt {
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [string]$Default = ""
+    )
+
+    if ($Yes -and $Default) {
+        Write-LogDebug "Auto-accepting with default: $Default"
+        return $Default
+    }
+
+    $promptText = if ($Default) { "${Message} [${Default}]: " } else { "${Message}: " }
+    $result = Read-Host $promptText
+    if ([string]::IsNullOrWhiteSpace($result) -and $Default) {
+        return $Default
+    }
+    return $result
+}
+
+function Read-YesNo {
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [bool]$DefaultYes = $false
+    )
+
+    if ($Yes) {
+        return $DefaultYes
+    }
+
+    $defaultDisplay = if ($DefaultYes) { "Y/n" } else { "y/N" }
+    $response = Read-Host "$Message [$defaultDisplay]"
+    if ([string]::IsNullOrWhiteSpace($response)) {
+        return $DefaultYes
+    }
+    return $response -match "^[Yy]"
+}
+
+function New-FileBackup {
+    param([Parameter(Mandatory)][string]$FilePath)
+
+    if (-not (Test-Path $BackupDir)) {
+        New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null
+        Write-LogInfo "Created backup directory: $BackupDir"
+    }
+
+    if (Test-Path $FilePath) {
+        $fileName = Split-Path $FilePath -Leaf
+        $backupPath = Join-Path $BackupDir $fileName
+        Copy-Item $FilePath $backupPath -Force
+        Write-LogInfo "Backed up: $FilePath -> $backupPath"
+    }
+}
+
+function Test-ApiKey {
+    param(
+        [string]$Key,
+        [string]$KeyName = "API Key"
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Key)) {
+        Write-LogWarn "No $KeyName provided"
+        return $false
+    }
+    if ($Key.Length -lt 10) {
+        Write-LogWarn "$KeyName seems too short (minimum 10 characters)"
+        return $false
+    }
+    return $true
+}
+
+function Get-MaskedValue {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value) -or $Value.Length -lt 12) { return "<hidden>" }
+    return "$($Value.Substring(0,8))...$($Value.Substring($Value.Length - 4))"
+}
+
+################################################################################
+# SHOW HELP
+################################################################################
+
+function Show-Help {
+    @"
+
+=======================================================================
+                    OpenCode Configuration Setup v$ScriptVersion
+                    (Windows PowerShell Edition)
+=======================================================================
+
+USAGE:
+    .\setup.ps1 [OPTIONS]
+
+=======================================================================
+                            SETUP MODES
+=======================================================================
+
+  MODE                    WHAT IT DOES                          WHEN TO USE
+  ----------------------------------------------------------------------
+  Interactive (default)   Full setup with guided prompts       First-time setup
+                          1. GitHub PAT setup (optional)
+                          2. Z.AI API key setup
+                          3. Node.js check/install
+                          4. opencode-ai installation
+                          5. config.json deployment
+                          6. skills/ deployment
+                          7. Environment variable persistence
+
+  -Quick                  Copy config files only                Already have
+                          1. config.json -> ~/.config/opencode/  dependencies
+                          2. AGENTS.md -> ~/.config/opencode/
+                          3. skills/* -> ~/.config/opencode/skills/
+
+  -SkillsOnly             Deploy skills only                    opencode-ai already
+                          1. Validates opencode-ai installed    installed
+                          2. Copies skills/* to config dir
+
+  -Update                 Update opencode-ai CLI only           Keep CLI current
+
+=======================================================================
+                            OPTIONS
+=======================================================================
+
+  SETUP OPTIONS:
+    -Quick                Quick setup mode (config + skills only)
+    -SkillsOnly           Skills-only deployment mode
+    -Update               Update OpenCode CLI to latest version
+
+  UPDATE MANAGEMENT:
+    -EnableAutoUpdate         Enable automatic opencode-ai updates
+    -DisableAutoUpdate        Disable automatic updates
+    -ScheduleUpdate <sched>   Set update frequency: daily, weekly, monthly, manual
+    -CheckUpdate              Check for updates without installing
+
+  UTILITY OPTIONS:
+    -Help                Show this help message
+    -DryRun              Preview all actions without making changes
+    -Yes                 Auto-accept all prompts (non-interactive)
+
+=======================================================================
+                            REQUIREMENTS
+=======================================================================
+
+  Required:
+    PowerShell 5.1+       Ships with Windows 10/11
+    Node.js v20+          For opencode-ai and MCP servers
+
+  Recommended:
+    nvm-windows            Node version manager (https://github.com/coreybutler/nvm-windows/releases)
+    git                   For version control
+
+  API Keys (prompted during setup):
+    ZAI_API_KEY           Required for web-reader, web-search-prime, zread
+    GITHUB_PAT            Optional for GitHub MCP features
+
+  Local Services:
+    LM Studio             Running on http://127.0.0.1:1234/v1
+
+=======================================================================
+
+For more information: https://opencode.ai
+Report issues: https://github.com/anomalyco/opencode/issues
+
+"@
+}
+
+################################################################################
+# DEPENDENCY CHECKS
+################################################################################
+
+function Test-Dependencies {
+    Write-LogInfo "Checking basic dependencies..."
+
+    $missing = @()
+
+    if (-not (Test-CommandExists "curl.exe")) {
+        if (-not (Test-CommandExists "curl")) {
+            $missing += "curl"
+        }
+    }
+
+    if (-not (Test-CommandExists "git")) {
+        Write-LogWarn "git is not installed (recommended but not required)"
+    }
+
+    if ($missing.Count -gt 0) {
+        Write-LogError "Missing required dependencies: $($missing -join ', ')"
+        Write-LogInfo "Please install missing dependencies and try again"
+        return $false
+    }
+
+    Write-LogSuccess "All required dependencies are installed"
+    return $true
+}
+
+function Test-Network {
+    Write-LogInfo "Checking network connectivity..."
+
+    $urls = @("https://api.github.com", "https://registry.npmjs.org")
+    $ok = $true
+
+    foreach ($url in $urls) {
+        try {
+            $null = Invoke-WebRequest -Uri $url -Method Head -TimeoutSec 5 -UseBasicParsing
+            Write-LogDebug "Connected to: $url"
+        } catch {
+            Write-LogWarn "Cannot reach: $url"
+            $ok = $false
+        }
+    }
+
+    if (-not $ok) {
+        Write-LogError "Network connectivity issues detected"
+        return $false
+    }
+
+    Write-LogSuccess "Network connectivity OK"
+    return $true
+}
+
+################################################################################
+# SETUP: GitHub PAT
+################################################################################
+
+function Set-GitHubPAT {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host "              GitHub Personal Access Token Setup" -ForegroundColor White
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host ""
+    Write-Host "This setup can use a GitHub Personal Access Token (optional)."
+    Write-Host "If you prefer OAuth authentication, you can skip this."
+    Write-Host ""
+
+    if (-not (Read-YesNo "Do you want to use a GitHub PAT?" $false)) {
+        Write-LogInfo "Skipping GitHub PAT setup. You can authenticate later with: opencode mcp auth github"
+        return
+    }
+
+    $patFromRegistry = $null
+    try {
+        $patFromRegistry = (Get-ItemPropertyValue -Path "HKCU:\Environment" -Name "GITHUB_PAT" -ErrorAction SilentlyContinue)
+    } catch {}
+
+    if ($patFromRegistry -and [string]::IsNullOrWhiteSpace($GitHubPAT)) {
+        $GitHubPAT = $patFromRegistry
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($GitHubPAT)) {
+        Write-Host ""
+        Write-Host "GITHUB_PAT is already set in your environment."
+        Write-Host "Current token (masked): $(Get-MaskedValue $GitHubPAT)"
+        Write-Host ""
+
+        if (Read-YesNo "Do you want to use the existing token?" $true) {
+            Write-LogInfo "Using existing GITHUB_PAT"
+            return
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Please enter your GitHub Personal Access Token:"
+    $secureInput = Read-Host -AsSecureString
+    $GitHubPAT = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureInput)
+    )
+    Write-Host ""
+
+    if (Test-ApiKey -Key $GitHubPAT -KeyName "GITHUB_PAT") {
+        Write-LogSuccess "GitHub PAT accepted: $(Get-MaskedValue $GitHubPAT)"
+    } else {
+        Write-LogWarn "Invalid or empty GITHUB_PAT provided"
+        $GitHubPAT = ""
+    }
+}
+
+################################################################################
+# SETUP: Z.AI API Key
+################################################################################
+
+function Set-ZaiApiKey {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host "                  Z.AI API Key Setup" -ForegroundColor White
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host ""
+    Write-Host "This setup requires a Z.AI API Key for MCP services."
+    Write-Host ""
+
+    $keyFromRegistry = $null
+    try {
+        $keyFromRegistry = (Get-ItemPropertyValue -Path "HKCU:\Environment" -Name "ZAI_API_KEY" -ErrorAction SilentlyContinue)
+    } catch {}
+
+    if ($keyFromRegistry -and [string]::IsNullOrWhiteSpace($ZaiApiKey)) {
+        $ZaiApiKey = $keyFromRegistry
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ZaiApiKey)) {
+        Write-Host "ZAI_API_KEY is already set in your environment."
+        Write-Host "Current key (masked): $(Get-MaskedValue $ZaiApiKey)"
+        Write-Host ""
+
+        if (Read-YesNo "Use existing key?" $true) {
+            Write-LogInfo "Using existing ZAI_API_KEY"
+            return
+        }
+    }
+
+    Write-Host "Please enter your Z.AI API Key:"
+    $secureInput = Read-Host -AsSecureString
+    $ZaiApiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureInput)
+    )
+    Write-Host ""
+
+    if (-not (Test-ApiKey -Key $ZaiApiKey -KeyName "ZAI_API_KEY")) {
+        Write-LogError "No valid ZAI_API_KEY provided"
+
+        if (-not (Read-YesNo "Continue without API key? Some MCP services will not work." $false)) {
+            Write-LogError "Setup cancelled. Please run this script again with your API key."
+            exit 1
+        }
+    } else {
+        Write-LogSuccess "API Key accepted: $(Get-MaskedValue $ZaiApiKey)"
+    }
+}
+
+################################################################################
+# SETUP: JIRA OAuth2
+################################################################################
+
+function Set-JiraOAuth {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host "              JIRA OAuth2 Setup" -ForegroundColor White
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Prerequisites:"
+    Write-Host "  1. Create OAuth2 app at: https://developer.atlassian.com/console/myapps/"
+    Write-Host "  2. Add callback URL: http://localhost:8085/callback"
+    Write-Host "  3. Enable scopes: read:jira-work, write:jira-work, offline_access"
+    Write-Host ""
+
+    if (-not [string]::IsNullOrWhiteSpace($JiraClientId) -and -not [string]::IsNullOrWhiteSpace($JiraAccessToken)) {
+        Write-Host "JIRA OAuth2 is already configured."
+        Write-Host "  Client ID: $($JiraClientId.Substring(0, [Math]::Min(8, $JiraClientId.Length)))..."
+        Write-Host "  Access Token: $(Get-MaskedValue $JiraAccessToken)"
+        Write-Host ""
+
+        if (-not (Read-YesNo "Reconfigure?" $false)) {
+            Write-LogInfo "Keeping existing configuration"
+            return
+        }
+    }
+
+    Write-Host "Step 1/4: Enter your OAuth2 Client ID"
+    $JiraClientId = Read-Prompt "JIRA Client ID" ""
+    if ([string]::IsNullOrWhiteSpace($JiraClientId)) {
+        Write-LogWarn "No Client ID provided, skipping"
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Step 2/4: Enter your OAuth2 Client Secret"
+    $secureSecret = Read-Host "JIRA Client Secret" -AsSecureString
+    $JiraClientSecret = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureSecret)
+    )
+    Write-Host ""
+
+    if ([string]::IsNullOrWhiteSpace($JiraClientSecret)) {
+        Write-LogWarn "No Client Secret provided, skipping"
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Step 3/4: Open this URL in your browser and authorize:"
+    Write-Host ""
+    $authUrl = "https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=$JiraClientId&scope=read%3Ajira-work%20write%3Ajira-work%20offline_access&redirect_uri=http%3A%2F%2Flocalhost%3A8085%2Fcallback&response_type=code&prompt=consent"
+    Write-Host "  $authUrl" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "After authorization, browser redirects to localhost:8085/callback?code=XXXXX"
+    Write-Host "Copy the 'code' value from the URL."
+    Write-Host ""
+
+    Write-Host "Step 4/4: Paste the authorization code"
+    $authCode = Read-Prompt "Authorization code" ""
+
+    if ([string]::IsNullOrWhiteSpace($authCode)) {
+        Write-LogError "No authorization code provided"
+        return
+    }
+
+    Write-Host ""
+    Write-LogInfo "Exchanging code for tokens..."
+
+    try {
+        $body = @{
+            grant_type    = "authorization_code"
+            client_id     = $JiraClientId
+            client_secret = $JiraClientSecret
+            code          = $authCode
+            redirect_uri  = "http://localhost:8085/callback"
+        } | ConvertTo-Json
+
+        $tokenResponse = Invoke-RestMethod -Method Post `
+            -Uri "https://auth.atlassian.com/oauth/token" `
+            -ContentType "application/json" `
+            -Body $body
+
+        $JiraAccessToken = $tokenResponse.access_token
+        $JiraRefreshToken = $tokenResponse.refresh_token
+
+        if ([string]::IsNullOrWhiteSpace($JiraAccessToken)) {
+            Write-LogError "Failed to obtain tokens"
+            Write-Host "Response: $($tokenResponse | ConvertTo-Json -Depth 3)"
+            return
+        }
+
+        Write-LogSuccess "Tokens obtained"
+
+        Write-LogInfo "Fetching Cloud ID..."
+        $resources = Invoke-RestMethod -Method Get `
+            -Uri "https://api.atlassian.com/oauth/token/accessible-resources" `
+            -Headers @{ "Authorization" = "Bearer $JiraAccessToken" }
+
+        if ($resources -and $resources.Count -gt 0) {
+            $JiraCloudId = $resources[0].id
+        }
+
+        Write-LogSuccess "JIRA OAuth2 configured"
+        Write-Host ""
+        Write-Host "Summary:"
+        Write-Host "  Client ID: $($JiraClientId.Substring(0, [Math]::Min(8, $JiraClientId.Length)))..."
+        Write-Host "  Access Token: $(Get-MaskedValue $JiraAccessToken)"
+        Write-Host "  Cloud ID: $(if ($JiraCloudId) { $JiraCloudId } else { '<not set>' })"
+        Write-Host ""
+    } catch {
+        Write-LogError "Token exchange failed: $($_.Exception.Message)"
+    }
+}
+
+################################################################################
+# SETUP: PeonPing
+################################################################################
+
+function Set-PeonPing {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host "              PeonPing Sound Notifications Setup" -ForegroundColor White
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host ""
+    Write-Host "PeonPing plays game character voice lines when your AI agent"
+    Write-Host "finishes work or needs permission. Works with Claude Code and OpenCode!"
+    Write-Host ""
+    Write-Host "Features:"
+    Write-Host "  - Voice notifications from Warcraft, StarCraft, Portal, and more"
+    Write-Host "  - Desktop notifications when agent needs attention"
+    Write-Host "  - 160+ sound packs available"
+    Write-Host "  - OpenCode TypeScript plugin for native integration"
+    Write-Host ""
+
+    if (-not (Read-YesNo "Install PeonPing?" $true)) {
+        Write-LogInfo "Skipping PeonPing installation"
+        return
+    }
+
+    $peonInstallDir = Join-Path $env:USERPROFILE ".claude\hooks\peon-ping"
+    if ((Test-Path (Join-Path $peonInstallDir "peon.ps1")) -or (Test-CommandExists "peon")) {
+        Write-LogInfo "PeonPing is already installed"
+        if (-not (Read-YesNo "Reinstall/update PeonPing?" $false)) {
+            Write-LogInfo "Keeping existing PeonPing installation"
+            Write-Host ""
+            if (Read-YesNo "Install/update PeonPing OpenCode plugin?" $true) {
+                Set-PeonPingPlugin
+            }
+            return
+        }
+    }
+
+    Write-LogInfo "Installing PeonPing via native Windows installer..."
+    Write-Host ""
+
+    try {
+        $installerUrl = "https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.ps1"
+
+        if (-not $DryRun) {
+            Write-Host "  Downloading and running Windows installer..." -ForegroundColor Cyan
+            Write-Host "  Source: $installerUrl"
+            Write-Host ""
+
+            $installerTemp = Join-Path $env:TEMP "peon-ping-install.ps1"
+            Invoke-WebRequest -Uri $installerUrl -OutFile $installerTemp -UseBasicParsing
+            Unblock-File -Path $installerTemp -ErrorAction SilentlyContinue
+
+            $peonArgs = @("-NoProfile", "-File", $installerTemp)
+
+            $policy = Get-ExecutionPolicy -Scope CurrentUser
+            if ($policy -eq "Restricted") {
+                Write-Host "  Note: Execution policy is Restricted, using Bypass for installer" -ForegroundColor Yellow
+                $peonArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $installerTemp)
+            }
+
+            & powershell.exe @peonArgs
+            $installExitCode = $LASTEXITCODE
+
+            Remove-Item $installerTemp -Force -ErrorAction SilentlyContinue
+
+            if ($installExitCode -ne 0 -and $installExitCode -ne 0) {
+                Write-LogWarn "PeonPing installer exited with code: $installExitCode"
+            }
+        } else {
+            Write-Host "[DRY-RUN] Would download and run: $installerUrl" -ForegroundColor Cyan
+            Write-Host "[DRY-RUN] Would then install OpenCode TypeScript plugin" -ForegroundColor Cyan
+        }
+
+        if ((Test-Path (Join-Path $peonInstallDir "peon.ps1")) -or (Test-CommandExists "peon")) {
+            Write-LogSuccess "PeonPing installed successfully"
+
+            Write-Host ""
+            Write-Host "Quick commands:"
+            Write-Host "  peon status          - Check if active"
+            Write-Host "  peon preview         - Play test sounds"
+            Write-Host "  peon packs list      - List installed packs"
+            Write-Host "  peon packs install <name>   - Install a pack"
+            Write-Host "  peon volume 0.5      - Set volume (0.0-1.0)"
+            Write-Host "  peon toggle          - Mute/unmute sounds"
+            Write-Host ""
+
+            if (Read-YesNo "Install PeonPing OpenCode plugin?" $true) {
+                Set-PeonPingPlugin
+            }
+        } else {
+            Write-LogWarn "PeonPing installation may not have completed correctly"
+            Write-Host ""
+            Write-Host "Try installing manually:" -ForegroundColor Yellow
+            Write-Host "  Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/PeonPing/peon-ping/main/install.ps1' -UseBasicParsing | Invoke-Expression" -ForegroundColor Yellow
+            Write-Host ""
+        }
+    } catch {
+        Write-LogError "PeonPing installation failed: $($_.Exception.Message)"
+        Write-LogInfo "Install manually: https://github.com/PeonPing/peon-ping"
+    }
+}
+
+function Set-PeonPingPlugin {
+    Write-Host ""
+    Write-LogInfo "Configuring PeonPing OpenCode plugin..."
+
+    $pluginsDir = Join-Path $ConfigDir "plugins"
+    $peonPlugin = Join-Path $pluginsDir "peon-ping.ts"
+    $peonConfigDir = Join-Path $ConfigDir "peon-ping"
+    $peonConfigFile = Join-Path $peonConfigDir "config.json"
+    $pluginUrl = "https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode/peon-ping.ts"
+
+    if ((Test-Path $peonPlugin) -and (Test-Path $peonConfigFile)) {
+        Write-LogInfo "PeonPing OpenCode plugin is already installed"
+        if (-not (Read-YesNo "Reinstall PeonPing plugin?" $false)) {
+            Write-LogInfo "Keeping existing PeonPing plugin"
+            return
+        }
+    }
+
+    if ($DryRun) {
+        Write-Host "[DRY-RUN] Would download peon-ping.ts to: $peonPlugin" -ForegroundColor Cyan
+        Write-Host "[DRY-RUN] Would create config at: $peonConfigFile" -ForegroundColor Cyan
+        return
+    }
+
+    try {
+        if (-not (Test-Path $pluginsDir)) {
+            New-Item -ItemType Directory -Path $pluginsDir -Force | Out-Null
+        }
+
+        Write-LogInfo "Downloading peon-ping.ts OpenCode plugin..."
+        Invoke-WebRequest -Uri $pluginUrl -OutFile $peonPlugin -UseBasicParsing
+        Unblock-File -Path $peonPlugin -ErrorAction SilentlyContinue
+        Write-LogSuccess "Plugin downloaded to: $peonPlugin"
+
+        if (-not (Test-Path $peonConfigDir)) {
+            New-Item -ItemType Directory -Path $peonConfigDir -Force | Out-Null
+        }
+
+        if (-not (Test-Path $peonConfigFile)) {
+            $peonConfig = @{
+                default_pack = "peon"
+                volume = 0.5
+                enabled = $true
+                categories = @{
+                    "session.start" = $true
+                    "session.end" = $true
+                    "task.acknowledge" = $true
+                    "task.complete" = $true
+                    "task.error" = $true
+                    "task.progress" = $true
+                    "input.required" = $true
+                    "resource.limit" = $true
+                    "user.spam" = $true
+                }
+                spam_threshold = 3
+                spam_window_seconds = 10
+                pack_rotation = @()
+                debounce_ms = 500
+            }
+            $prevCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+            try {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
+                $peonConfig | ConvertTo-Json -Depth 3 | Set-Content -Path $peonConfigFile -Encoding UTF8
+            } finally {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = $prevCulture
+            }
+            Write-LogSuccess "Config created at: $peonConfigFile"
+        } else {
+            Write-LogInfo "Config already exists, preserved."
+        }
+
+        Write-LogSuccess "PeonPing OpenCode plugin installed successfully"
+        Write-Host ""
+        Write-Host "Plugin installed to:"
+        Write-Host "  - Plugin: $peonPlugin"
+        Write-Host "  - Config: $peonConfigFile"
+        Write-Host ""
+        Write-Host "Restart OpenCode to activate the plugin."
+        Write-Host ""
+    } catch {
+        Write-LogError "PeonPing plugin installation failed: $($_.Exception.Message)"
+        Write-Host ""
+        Write-Host "Try installing manually:" -ForegroundColor Yellow
+        Write-Host "  1. Download: https://raw.githubusercontent.com/PeonPing/peon-ping/main/adapters/opencode/peon-ping.ts" -ForegroundColor Yellow
+        Write-Host "  2. Save to: $peonPlugin" -ForegroundColor Yellow
+        Write-Host ""
+    }
+}
+
+################################################################################
+# SETUP: Node.js
+################################################################################
+
+function Set-NodeJS {
+    Write-Host ""
+    Write-Host "=== Installing/Updating Node.js ===" -ForegroundColor White
+
+    if (Test-CommandExists "node") {
+        $nodeVersion = & node --version 2>$null
+        Write-LogInfo "Node.js is already installed ($nodeVersion)"
+
+        if (Read-YesNo "Install a newer version of Node.js?" $false) {
+            Install-NodeJS
+        }
+    } else {
+        Write-LogInfo "Node.js is not installed"
+        Install-NodeJS
+    }
+}
+
+function Install-NodeJS {
+    Write-Host ""
+    Write-Host "Node.js installation options:" -ForegroundColor Yellow
+    Write-Host ""
+
+    if (Test-CommandExists "nvm") {
+        Write-LogInfo "nvm-windows is installed"
+        Write-LogInfo "Installing Node.js v24 via nvm..."
+        Invoke-WithDryRun "nvm install 24"
+        Invoke-WithDryRun "nvm use 24"
+
+        if (Test-CommandExists "node") {
+            $nv = & node --version 2>$null
+            Write-LogSuccess "Node.js $nv is now active"
+        }
+        return
+    }
+
+    Write-LogWarn "nvm-windows is not installed"
+    Write-Host ""
+
+    if (Test-CommandExists "winget") {
+        Write-Host "  1. winget install OpenJS.NodeJS.LTS (recommended)"
+    }
+    if (Test-CommandExists "choco") {
+        Write-Host "  2. choco install nodejs"
+    }
+    Write-Host "  3. Download from: https://nodejs.org/"
+    Write-Host "  4. Install nvm-windows: https://github.com/coreybutler/nvm-windows/releases"
+    Write-Host ""
+
+    if (Test-CommandExists "winget") {
+        if (Read-YesNo "Install Node.js via winget?" $true) {
+            Write-LogInfo "Installing Node.js via winget..."
+            Invoke-WithDryRun "winget install OpenJS.NodeJS.LTS --accept-package-agreements --accept-source-agreements"
+            Write-LogSuccess "Node.js installed via winget. Open a new terminal to use it."
+            return
+        }
+    }
+
+    if (Test-CommandExists "choco") {
+        if (Read-YesNo "Install Node.js via chocolatey?" $true) {
+            Write-LogInfo "Installing Node.js via chocolatey..."
+            Invoke-WithDryRun "choco install nodejs -y"
+            Write-LogSuccess "Node.js installed via chocolatey. Open a new terminal to use it."
+            return
+        }
+    }
+
+    Write-LogInfo "Please install Node.js manually from https://nodejs.org/"
+    Write-LogInfo "Or install nvm-windows from https://github.com/coreybutler/nvm-windows/releases"
+    Write-LogInfo "After installing, open a new terminal and run this script again"
+}
+
+################################################################################
+# SETUP: OpenCode CLI
+################################################################################
+
+function Set-OpenCode {
+    Write-Host ""
+    Write-Host "=== Installing/Updating OpenCode ===" -ForegroundColor White
+
+    if (-not (Test-CommandExists "npm")) {
+        Write-LogError "npm is not available. Cannot install opencode-ai."
+        Write-LogInfo "Please install Node.js first via nvm-windows: https://github.com/coreybutler/nvm-windows/releases"
+        return
+    }
+
+    if (Test-CommandExists "opencode") {
+        $currentVersion = & opencode --version 2>$null
+        if ([string]::IsNullOrWhiteSpace($currentVersion)) { $currentVersion = "unknown" }
+
+        Write-LogInfo "opencode-ai is already installed (v$currentVersion)"
+
+        try {
+            $latestVersion = (Invoke-Expression "npm view opencode-ai version" 2>$null).Trim()
+        } catch {
+            $latestVersion = "unknown"
+        }
+
+        Write-LogInfo "Latest version: v$latestVersion"
+
+        if ($currentVersion -ne $latestVersion -and $latestVersion -ne "unknown") {
+            Write-Host ""
+            Write-LogWarn "An update is available for opencode-ai!"
+
+            if (Read-YesNo "Would you like to update to the latest version?" $true) {
+                Write-LogInfo "Updating opencode-ai..."
+                if (Invoke-WithDryRun "npm install -g opencode-ai@latest") {
+                    $newVersion = & opencode --version 2>$null
+                    Write-LogSuccess "opencode-ai updated successfully to $newVersion"
+                } else {
+                    Write-LogError "opencode-ai update failed"
+                }
+            }
+        } else {
+            Write-LogSuccess "opencode-ai is already up to date"
+
+            if (Read-YesNo "Reinstall opencode-ai anyway?" $false) {
+                Write-LogInfo "Reinstalling opencode-ai..."
+                Invoke-WithDryRun "npm install -g opencode-ai"
+                Write-LogSuccess "opencode-ai reinstalled successfully"
+            }
+        }
+    } else {
+        Write-LogInfo "opencode-ai is not installed"
+
+        if (Read-YesNo "Install opencode-ai now?" $true) {
+            Write-LogInfo "Installing opencode-ai..."
+            if (Invoke-WithDryRun "npm install -g opencode-ai") {
+                Write-LogSuccess "opencode-ai installed successfully"
+            } else {
+                Write-LogError "opencode-ai installation failed"
+            }
+        } else {
+            Write-LogWarn "Skipping opencode-ai installation"
+        }
+    }
+}
+
+################################################################################
+# UPDATE: OpenCode CLI only
+################################################################################
+
+function Update-OpenCodeCLI {
+    Write-Host ""
+    Write-Host "=== Updating OpenCode CLI ===" -ForegroundColor White
+    Write-Host ""
+
+    if (-not (Test-CommandExists "npm")) {
+        Write-LogError "npm is not available. Cannot update opencode-ai."
+        return
+    }
+
+    if (-not (Test-CommandExists "opencode")) {
+        Write-LogWarn "opencode-ai is not installed."
+
+        if (Read-YesNo "Would you like to install opencode-ai now?" $true) {
+            Write-LogInfo "Installing opencode-ai..."
+            if (Invoke-WithDryRun "npm install -g opencode-ai") {
+                Write-LogSuccess "opencode-ai installed successfully"
+            }
+        }
+        return
+    }
+
+    $currentVersion = & opencode --version 2>$null
+    if ([string]::IsNullOrWhiteSpace($currentVersion)) { $currentVersion = "unknown" }
+    Write-LogInfo "Current version: v$currentVersion"
+
+    Write-LogInfo "Checking for updates..."
+    try {
+        $latestVersion = (Invoke-Expression "npm view opencode-ai version" 2>$null).Trim()
+    } catch {
+        $latestVersion = "unknown"
+    }
+
+    if ($latestVersion -eq "unknown") {
+        Write-LogError "Could not fetch latest version from npm registry"
+        return
+    }
+
+    Write-LogInfo "Latest version: v$latestVersion"
+
+    if ($currentVersion -eq $latestVersion) {
+        Write-LogSuccess "opencode-ai is already up to date!"
+
+        if (Read-YesNo "Force reinstall anyway?" $false) {
+            Write-LogInfo "Reinstalling opencode-ai..."
+            Invoke-WithDryRun "npm install -g opencode-ai@$latestVersion"
+            Write-LogSuccess "opencode-ai reinstalled successfully"
+        }
+        return
+    }
+
+    Write-Host ""
+    Write-LogInfo "Update available: v$currentVersion -> v$latestVersion"
+
+    if (Read-YesNo "Update opencode-ai to v$latestVersion?" $true) {
+        Write-LogInfo "Updating opencode-ai..."
+        if (Invoke-WithDryRun "npm install -g opencode-ai@latest") {
+            $newVersion = & opencode --version 2>$null
+            Write-LogSuccess "opencode-ai updated successfully to v$newVersion"
+        } else {
+            Write-LogError "Update failed"
+        }
+    }
+}
+
+################################################################################
+# SETUP: Configuration Deployment
+################################################################################
+
+function Set-Configuration {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host "                  Configuration Setup" -ForegroundColor White
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host ""
+
+    if (-not $DryRun) {
+        if (-not (Test-Path $ConfigDir)) {
+            New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
+        }
+    }
+    Write-LogInfo "Config directory: $ConfigDir"
+
+    $agentsSrc = Join-Path $ScriptDir ".AGENTS.md"
+    $agentsDest = Join-Path $ConfigDir "AGENTS.md"
+
+    if (Test-Path $agentsSrc) {
+        if (Test-Path $agentsDest) {
+            Write-LogWarn "AGENTS.md already exists at $agentsDest"
+            if (Read-YesNo "Do you want to overwrite it?" $false) {
+                New-FileBackup $agentsDest
+                if (-not $DryRun) { Copy-Item $agentsSrc $agentsDest -Force }
+                Write-LogSuccess "AGENTS.md copied successfully (renamed from .AGENTS.md)"
+            }
+        } else {
+            if (-not $DryRun) { Copy-Item $agentsSrc $agentsDest -Force }
+            Write-LogSuccess "AGENTS.md copied successfully (renamed from .AGENTS.md)"
+        }
+    } else {
+        Write-LogWarn ".AGENTS.md not found in $ScriptDir"
+    }
+
+    if (Test-Path $ConfigFile) {
+        Write-Host ""
+        Write-LogWarn "config.json already exists at $ConfigFile"
+
+        if (-not (Read-YesNo "Do you want to overwrite it?" $false)) {
+            Write-LogInfo "Skipping config.json copy. Existing configuration preserved."
+            $script:SkipConfigCopy = $true
+            Deploy-Skills
+            return
+        }
+
+        New-FileBackup $ConfigFile
+    } else {
+        $msg = "Copy config.json to $($ConfigDir)?"
+        if (-not (Read-YesNo $msg $true)) {
+            Write-LogInfo "Skipping config.json copy"
+            $script:SkipConfigCopy = $true
+            Deploy-Skills
+            return
+        }
+    }
+
+    if (-not $script:SkipConfigCopy) {
+        $configSrc = Join-Path $ScriptDir "config.json"
+        if (Test-Path $configSrc) {
+            if (-not $DryRun) { Copy-Item $configSrc $ConfigFile -Force }
+            Write-LogSuccess "config.json copied successfully"
+
+            Write-Host ""
+            Write-Host "Configured 5 agents:" -ForegroundColor Green
+            Write-Host "    - build (default) - Full-featured coding agent"
+            Write-Host "    - plan - Planning agent (read-only)"
+            Write-Host "    - explore - Codebase exploration and analysis"
+            Write-Host "    - image-analyzer - Image/screenshot analysis"
+            Write-Host "    - diagram-creator - Diagram creation"
+            Write-Host ""
+            Write-Host "Configured 5 MCP servers:" -ForegroundColor Green
+            Write-Host "    Local (auto-start): atlassian, zai-mcp-server"
+            Write-Host "    Remote (needs key): web-reader, web-search-prime, zread"
+            Write-Host ""
+        } else {
+            Write-LogError "config.json not found in $ScriptDir"
+        }
+    }
+
+    Deploy-Skills
+}
+
+function Deploy-Skills {
+    Write-Host ""
+    Write-LogInfo "Setting up skills directory..."
+
+    $skillsSrc = Join-Path $ScriptDir "skills"
+
+    if (-not $DryRun) {
+        if (-not (Test-Path $SkillsDir)) {
+            New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
+        }
+    }
+    Write-LogInfo "Skills directory: $SkillsDir"
+
+    if (Test-Path $skillsSrc) {
+        $existingSkills = @(Get-ChildItem $SkillsDir -ErrorAction SilentlyContinue)
+        if ($existingSkills.Count -gt 0) {
+            Write-LogWarn "Skills directory already contains files"
+
+            if (Read-YesNo "Do you want to overwrite existing skills?" $false) {
+                $skillsBackup = Join-Path $BackupDir "skills-backup"
+                if (-not $DryRun) {
+                    if (-not (Test-Path $BackupDir)) {
+                        New-Item -ItemType Directory -Path $BackupDir -Force | Out-Null
+                    }
+                    Copy-Item $SkillsDir $skillsBackup -Recurse -Force
+                    Write-LogInfo "Backed up existing skills to $skillsBackup"
+                }
+            } else {
+                Write-LogInfo "Skipping skills deployment. Existing skills preserved."
+                return
+            }
+        }
+
+        if (-not $DryRun) {
+            Copy-Item (Join-Path $skillsSrc "*") $SkillsDir -Recurse -Force
+        }
+        Write-LogSuccess "Skills copied successfully to $SkillsDir"
+
+        $skillCount = @(Get-ChildItem $SkillsDir -Directory -ErrorAction SilentlyContinue).Count
+        Write-Host ""
+        Write-Host "Deployed $skillCount skills to $SkillsDir" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "  Run 'opencode --list-skills' for detailed descriptions"
+        Write-Host ""
+    } else {
+        Write-LogWarn "skills/ folder not found in $ScriptDir"
+    }
+}
+
+################################################################################
+# SETUP: Environment Variables
+################################################################################
+
+function Set-ShellVariables {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host "              Environment Variables Setup" -ForegroundColor White
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host ""
+
+    if (-not (Test-Path $PROFILE)) {
+        $profileDir = Split-Path $PROFILE -Parent
+        if (-not (Test-Path $profileDir)) {
+            New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+        }
+        New-Item -ItemType File -Path $PROFILE -Force | Out-Null
+        Write-LogInfo "Created PowerShell profile: $PROFILE"
+    }
+
+    Write-Host "PowerShell profile: $PROFILE"
+    Write-Host ""
+
+    if (-not [string]::IsNullOrWhiteSpace($ZaiApiKey)) {
+        $profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+        if ($profileContent -match "ZAI_API_KEY") {
+            Write-LogInfo "ZAI_API_KEY already exists in $PROFILE"
+        } else {
+            if (Read-YesNo "Add ZAI_API_KEY to your PowerShell profile for persistent access?" $true) {
+                New-FileBackup $PROFILE
+                if (-not $DryRun) {
+                    Add-Content -Path $PROFILE -Value "`n# Z.AI API Key (added by opencode setup)"
+                    Add-Content -Path $PROFILE -Value "`$env:ZAI_API_KEY = `"$ZaiApiKey`""
+                }
+                Write-LogSuccess "ZAI_API_KEY added to $PROFILE"
+            } else {
+                Write-LogInfo "Skipping profile update for ZAI_API_KEY"
+            }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($GitHubPAT)) {
+        $profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+        if ($profileContent -match "GITHUB_PAT") {
+            Write-LogInfo "GITHUB_PAT already exists in $PROFILE"
+        } else {
+            if (Read-YesNo "Add GITHUB_PAT to your PowerShell profile for persistent access?" $true) {
+                New-FileBackup $PROFILE
+                if (-not $DryRun) {
+                    Add-Content -Path $PROFILE -Value "`n# GitHub PAT (added by opencode setup)"
+                    Add-Content -Path $PROFILE -Value "`$env:GITHUB_PAT = `"$GitHubPAT`""
+                }
+                Write-LogSuccess "GITHUB_PAT added to $PROFILE"
+            } else {
+                Write-LogInfo "Skipping profile update for GITHUB_PAT"
+            }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($JiraClientId)) {
+        $profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+        if ($profileContent -match "JIRA_CLIENT_ID") {
+            Write-LogInfo "JIRA OAuth2 credentials already exist in $PROFILE"
+
+            if (Read-YesNo "Update existing JIRA tokens?" $false) {
+                New-FileBackup $PROFILE
+                if (-not $DryRun) {
+                    $lines = Get-Content $PROFILE | Where-Object { $_ -notmatch "JIRA_" -and $_ -notmatch "JIRA OAuth2" }
+                    Set-Content -Path $PROFILE -Value $lines
+
+                    Add-Content -Path $PROFILE -Value "`n# JIRA OAuth2 Configuration (added by opencode setup)"
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_CLIENT_ID = `"$JiraClientId`""
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_CLIENT_SECRET = `"$JiraClientSecret`""
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_ACCESS_TOKEN = `"$JiraAccessToken`""
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_REFRESH_TOKEN = `"$JiraRefreshToken`""
+                    if ($JiraCloudId) {
+                        Add-Content -Path $PROFILE -Value "`$env:JIRA_CLOUD_ID = `"$JiraCloudId`""
+                    }
+                }
+                Write-LogSuccess "JIRA OAuth2 tokens updated in $PROFILE"
+            }
+        } else {
+            if (Read-YesNo "Add JIRA OAuth2 credentials to your PowerShell profile?" $true) {
+                New-FileBackup $PROFILE
+                if (-not $DryRun) {
+                    Add-Content -Path $PROFILE -Value "`n# JIRA OAuth2 Configuration (added by opencode setup)"
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_CLIENT_ID = `"$JiraClientId`""
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_CLIENT_SECRET = `"$JiraClientSecret`""
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_ACCESS_TOKEN = `"$JiraAccessToken`""
+                    Add-Content -Path $PROFILE -Value "`$env:JIRA_REFRESH_TOKEN = `"$JiraRefreshToken`""
+                    if ($JiraCloudId) {
+                        Add-Content -Path $PROFILE -Value "`$env:JIRA_CLOUD_ID = `"$JiraCloudId`""
+                    }
+                }
+                Write-LogSuccess "JIRA OAuth2 credentials added to $PROFILE"
+            } else {
+                Write-LogInfo "Skipping profile update for JIRA OAuth2"
+            }
+        }
+    }
+}
+
+################################################################################
+# AUTO-UPDATE FUNCTIONS
+################################################################################
+
+function Update-LastCheckTime {
+    $timestamp = [int][double]::Parse((Get-Date -UFormat %s))
+    if (-not $DryRun) {
+        Set-Content -Path $LastUpdateCheck -Value $timestamp
+    }
+    Write-LogDebug "Updated last check time"
+}
+
+function Test-ShouldCheckForUpdate {
+    if (-not (Test-Path $LastUpdateCheck)) {
+        return $true
+    }
+
+    $lastCheck = [int](Get-Content $LastUpdateCheck -Raw -ErrorAction SilentlyContinue)
+    if (-not $lastCheck) { return $true }
+
+    $current = [int][double]::Parse((Get-Date -UFormat %s))
+    $diff = $current - $lastCheck
+
+    switch ($ScheduleUpdate) {
+        "daily"   { return $diff -ge 86400 }
+        "weekly"  { return $diff -ge 604800 }
+        "monthly" { return $diff -ge 2592000 }
+        "manual"  { return $true }
+        default   { return $diff -ge 604800 }
+    }
+}
+
+function Get-OpenCodeVersion {
+    param([switch]$Latest)
+
+    if ($Latest) {
+        try {
+            return (Invoke-Expression "npm view opencode-ai version" 2>$null).Trim()
+        } catch {
+            return "unknown"
+        }
+    }
+
+    if (Test-CommandExists "opencode") {
+        $v = & opencode --version 2>$null
+        if ($v) { return $v.Trim() }
+    }
+    return "unknown"
+}
+
+function Invoke-AutoUpdate {
+    if ($DisableAutoUpdate -and -not $EnableAutoUpdate) {
+        Write-LogInfo "Auto-update is disabled"
+        return
+    }
+
+    if (-not (Test-ShouldCheckForUpdate)) {
+        Write-LogInfo "Skipping auto-update (scheduled time not reached)"
+        return
+    }
+
+    Write-LogInfo "Checking for opencode-ai updates..."
+
+    $current = Get-OpenCodeVersion
+    $latest = Get-OpenCodeVersion -Latest
+
+    if ($latest -eq "unknown") {
+        Write-LogError "Could not fetch latest version from npm registry"
+        return
+    }
+
+    Write-LogInfo "Current version: v$current"
+    Write-LogInfo "Latest version: v$latest"
+
+    if ($current -eq $latest) {
+        Write-LogSuccess "opencode-ai is already up to date!"
+        Update-LastCheckTime
+        return
+    }
+
+    Write-LogInfo "Update available: v$current -> v$latest"
+
+    if ($Yes -or (Read-YesNo "Update opencode-ai to v$latest?" $true)) {
+        $backupDir = Join-Path $HOME ".opencode-update-backup-$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+        if (-not $DryRun) {
+            New-Item -ItemType Directory -Path $backupDir -Force | Out-Null
+            if (Test-Path $ConfigFile) { Copy-Item $ConfigFile (Join-Path $backupDir "config.json") }
+            $agentsDest = Join-Path $ConfigDir "AGENTS.md"
+            if (Test-Path $agentsDest) { Copy-Item $agentsDest (Join-Path $backupDir "AGENTS.md") }
+            if (Test-Path $SkillsDir) { Copy-Item $SkillsDir (Join-Path $backupDir "skills") -Recurse }
+        }
+
+        Write-LogInfo "Auto-updating opencode-ai to v$latest..."
+        Invoke-WithDryRun "npm install -g opencode-ai@$latest"
+
+        $newVersion = Get-OpenCodeVersion
+        if ($newVersion -eq $latest) {
+            Write-LogSuccess "opencode-ai updated successfully to v$newVersion"
+            Update-LastCheckTime
+        } else {
+            Write-LogError "Update failed. Current version: v$newVersion"
+        }
+    }
+}
+
+function Show-CheckUpdate {
+    Write-LogInfo "Checking for opencode-ai updates..."
+
+    if (-not (Test-CommandExists "opencode")) {
+        Write-LogWarn "opencode-ai is not installed"
+        return
+    }
+
+    $current = Get-OpenCodeVersion
+    $latest = Get-OpenCodeVersion -Latest
+
+    if ($latest -eq "unknown") {
+        Write-LogError "Could not fetch latest version from npm registry"
+        return
+    }
+
+    Write-LogInfo "Current version: v$current"
+    Write-LogInfo "Latest version: v$latest"
+
+    if ($current -eq $latest) {
+        Write-LogSuccess "opencode-ai is already up to date!"
+    } else {
+        Write-LogInfo "Update available: v$current -> v$latest"
+        Write-LogInfo "Run: .\setup.ps1 -EnableAutoUpdate -ScheduleUpdate daily"
+    }
+
+    Update-LastCheckTime
+}
+
+################################################################################
+# SUMMARY
+################################################################################
+
+function Show-Summary {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host "                      Setup Summary" -ForegroundColor White
+    Write-Host "=====================================================================" -ForegroundColor White
+    Write-Host ""
+
+    Write-Host "Platform Detection:"
+    Write-Host "  [OK] OS: Windows $($env:OS)"
+    Write-Host "  [OK] PowerShell: $($PSVersionTable.PSVersion)"
+    Write-Host "  [OK] Profile: $PROFILE"
+    Write-Host ""
+
+    if (Test-CommandExists "nvm") {
+        Write-Host "  [OK] nvm-windows: Installed (nvm)"
+    } else {
+        Write-Host "  [ ] nvm-windows: Not detected (install from github.com/coreybutler/nvm-windows/releases)"
+    }
+
+    if (Test-CommandExists "node") {
+        $nv = & node --version 2>$null
+        Write-Host "  [OK] Node.js: $nv"
+    } else {
+        Write-Host "  [X] Node.js: Not installed"
+    }
+
+    if (Test-CommandExists "opencode") {
+        $ov = & opencode --version 2>$null
+        Write-Host "  [OK] opencode-ai: Installed v$ov"
+    } else {
+        Write-Host "  [X] opencode-ai: Not installed"
+    }
+
+    if (Test-Path $ConfigFile) {
+        Write-Host "  [OK] config.json: Copied to $ConfigDir\" -ForegroundColor Green
+    } else {
+        Write-Host "  [X] config.json: Not copied"
+    }
+
+    if (Test-Path (Join-Path $ConfigDir "AGENTS.md")) {
+        Write-Host "  [OK] AGENTS.md: Copied to $ConfigDir\" -ForegroundColor Green
+    } else {
+        Write-Host "  [X] AGENTS.md: Not copied"
+    }
+
+    $skillCount = @(Get-ChildItem $SkillsDir -Directory -ErrorAction SilentlyContinue).Count
+    if ($skillCount -gt 0) {
+        Write-Host "  [OK] skills: $skillCount skills deployed to $SkillsDir\" -ForegroundColor Green
+    } else {
+        Write-Host "  [X] skills: Not deployed"
+    }
+
+    Write-Host ""
+
+    $profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+    if ($profileContent -match "ZAI_API_KEY") {
+        Write-Host "  [OK] ZAI_API_KEY: Added to profile"
+    } elseif (-not [string]::IsNullOrWhiteSpace($ZaiApiKey)) {
+        Write-Host "  [ ] ZAI_API_KEY: Set in current session only"
+    } else {
+        Write-Host "  [X] ZAI_API_KEY: Not configured"
+    }
+
+    if ($profileContent -match "GITHUB_PAT") {
+        Write-Host "  [OK] GITHUB_PAT: Added to profile"
+    } elseif (-not [string]::IsNullOrWhiteSpace($GitHubPAT)) {
+        Write-Host "  [ ] GITHUB_PAT: Set in current session only"
+    } else {
+        Write-Host "  [ ] GITHUB_PAT: Not configured (use OAuth: opencode mcp auth github)"
+    }
+
+    Write-Host ""
+}
+
+function Show-NextSteps {
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor Green
+    Write-Host "                      Setup Complete!" -ForegroundColor Green
+    Write-Host "=====================================================================" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Next Steps:"
+    Write-Host "  1. Restart terminal or run: . $PROFILE"
+    Write-Host "  2. Start LM Studio: http://127.0.0.1:1234/v1"
+    Write-Host "  3. Verify installation: opencode --version"
+    Write-Host ""
+    Write-Host "Agents (5):"
+    Write-Host "  - build (default) - Full-featured coding agent"
+    Write-Host "  - plan - Planning agent (read-only)"
+    Write-Host "  - explore - Fast codebase exploration and analysis"
+    Write-Host "  - image-analyzer - Images/screenshots to code, OCR, error diagnosis"
+    Write-Host "  - diagram-creator - Diagrams (architecture, flowcharts, UML)"
+    Write-Host ""
+    Write-Host "  Usage: opencode --agent <name> `"prompt`""
+    Write-Host "         opencode `"prompt`" (uses build)"
+    Write-Host ""
+    Write-Host "MCP Servers (5):"
+    Write-Host "  Local (auto-start): atlassian, zai-mcp-server"
+    Write-Host "  Remote (needs key): web-reader, web-search-prime, zread"
+    Write-Host ""
+    Write-Host "  Auth: opencode mcp auth atlassian / opencode mcp auth github"
+    Write-Host ""
+    Write-Host "Documentation:"
+    Write-Host "  - Update CLI: .\setup.ps1 -Update"
+    Write-Host "  - Config file: $ConfigFile"
+    Write-Host "  - Log file: $LogFile"
+    Write-Host "  - Full docs: https://opencode.ai"
+    Write-Host ""
+    Write-Host "=====================================================================" -ForegroundColor Green
+    Write-Host ""
+}
+
+################################################################################
+# MAIN
+################################################################################
+
+function Main {
+    if ($Help) {
+        Show-Help
+        return
+    }
+
+    if ($Update) {
+        Write-Host "=== OpenCode CLI Updater v$ScriptVersion ===" -ForegroundColor White
+        Write-Host ""
+        Initialize-Logging
+        Update-OpenCodeCLI
+        Write-Host ""
+        Write-Host "Update complete!"
+        return
+    }
+
+    if ($CheckUpdate) {
+        Initialize-Logging
+        Show-CheckUpdate
+        return
+    }
+
+    if ($SkillsOnly) {
+        Write-Host "=== OpenCode Skills Deployment v$ScriptVersion ===" -ForegroundColor White
+        Write-Host ""
+        Initialize-Logging
+
+        if (-not (Test-CommandExists "opencode")) {
+            Write-LogError "OpenCode CLI is not installed globally"
+            Write-LogInfo "Please install OpenCode first: npm install -g opencode-ai"
+            exit 1
+        }
+        Write-LogSuccess "OpenCode is installed ($(Get-OpenCodeVersion))"
+
+        if (-not (Test-Dependencies)) {
+            Write-LogError "Dependency check failed."
+            exit 1
+        }
+
+        Set-Configuration
+        Show-Summary
+        Write-Host ""
+        Write-Host "Skills deployment complete!"
+        return
+    }
+
+    Write-Host "=== OpenCode Configuration Setup v$ScriptVersion ===" -ForegroundColor White
+    Write-Host ""
+    Initialize-Logging
+
+    if (-not $Quick) {
+        if (-not (Test-Dependencies)) {
+            Write-LogError "Dependency check failed. Please install missing dependencies."
+            exit 1
+        }
+
+        if (-not (Test-Network)) {
+            Write-LogWarn "Network connectivity issues detected. Some features may not work."
+            if (-not (Read-YesNo "Continue anyway?" $false)) {
+                exit 1
+            }
+        }
+
+        if ($EnableAutoUpdate) {
+            Write-LogInfo "Auto-update is enabled (schedule: $ScheduleUpdate)"
+            Invoke-AutoUpdate
+        }
+    }
+
+    if (-not $Quick -and -not $Yes) {
+        Write-Host "=====================================================================" -ForegroundColor White
+        Write-Host "                      Setup Mode Selection" -ForegroundColor White
+        Write-Host "=====================================================================" -ForegroundColor White
+        Write-Host ""
+        Write-Host "  1) Quick setup (config + skills only)"
+        Write-Host "  2) Skills-only setup"
+        Write-Host "  3) Full setup (API keys, Node.js, OpenCode)"
+        Write-Host "  4) Update OpenCode CLI only"
+        Write-Host "  5) Configure JIRA OAuth2"
+        Write-Host "  6) Install PeonPing (sound notifications)"
+        Write-Host ""
+
+        $option = Read-Prompt "Select option" "2"
+
+        switch ($option) {
+            "1" {
+                Write-Host ""
+                Write-LogInfo "Quick Setup: Copy config.json and skills only"
+                $script:Quick = $true
+            }
+            "2" {
+                Write-Host ""
+                Write-LogInfo "Skills-Only Setup: Copy skills folder only"
+
+                if (-not (Test-CommandExists "opencode")) {
+                    Write-LogError "OpenCode CLI is not installed globally"
+                    Write-LogInfo "Please install OpenCode first: npm install -g opencode-ai"
+                    exit 1
+                }
+
+                Set-Configuration
+                Show-Summary
+                Write-Host ""
+                Write-Host "Skills deployment complete!"
+                return
+            }
+            "3" {
+                Write-LogInfo "Running full setup..."
+            }
+            "4" {
+                Write-Host ""
+                Write-LogInfo "Update OpenCode CLI only"
+                Update-OpenCodeCLI
+                Write-Host ""
+                Write-Host "Update complete!"
+                return
+            }
+            "5" {
+                Write-Host ""
+                Write-LogInfo "JIRA OAuth2 Configuration"
+                Set-JiraOAuth
+                Set-ShellVariables
+                Show-Summary
+                Write-Host ""
+                Write-Host "JIRA OAuth2 configuration complete!"
+                return
+            }
+            "6" {
+                Write-Host ""
+                Write-LogInfo "PeonPing Sound Notifications"
+                Set-PeonPing
+                Write-Host ""
+                Write-Host "PeonPing setup complete!"
+                return
+            }
+            default {
+                Write-LogWarn "Invalid option. Running full setup..."
+            }
+        }
+        Write-Host ""
+    }
+
+    if (-not $Quick) {
+        Set-GitHubPAT
+        Set-ZaiApiKey
+        Set-NodeJS
+        Set-OpenCode
+    } else {
+        Write-LogInfo "Running quick setup: config.json and skills deployment only"
+    }
+
+    Set-Configuration
+    Set-ShellVariables
+
+    Show-Summary
+    Show-NextSteps
+
+    Write-Log "INFO" "=== OpenCode Setup Completed at $(Get-Date) ==="
+
+    if (-not $Yes) {
+        Write-Host "Press Enter to exit..."
+        Read-Host
+    }
+}
+
+Main

--- a/setup.sh
+++ b/setup.sh
@@ -119,6 +119,11 @@ detect_platform() {
 DETECTED_OS=$(detect_platform)
 OS_VERSION=$(sw_vers 2>/dev/null || uname -r)
 
+# Check if a command exists (defined early, used by detect_package_manager)
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
 # Detect package manager and distribution based on platform
 detect_package_manager() {
     local platform="$1"
@@ -225,7 +230,7 @@ DISTRIBUTION_NAME=$(get_distribution_name "$PACKAGE_MANAGER")
 
 # Detect shell (bash, zsh, or powershell)
 detect_shell() {
-    if [ -n "$ZSH_VERSION" ]; then
+    if [ -n "${ZSH_VERSION:-}" ]; then
         echo "zsh"
     elif [ -n "$BASH_VERSION" ]; then
         echo "bash"
@@ -326,7 +331,7 @@ init_logging() {
 
     log "INFO" "=== OpenCode Setup Started at $(date) ==="
     log "INFO" "Script version: ${SCRIPT_VERSION}"
-    log "INFO" "User: ${USER}"
+    log "INFO" "User: ${USER:-${LOGNAME:-unknown}}"
     log "INFO" "Working directory: ${PWD}"
 }
 
@@ -498,7 +503,7 @@ USAGE:
     plan                 Planning agent (read-only, edits need approval)
     explore              Fast codebase exploration and analysis
     image-analyzer       Images/screenshots → code, OCR, error diagnosis
-    diagram-creator      Draw.io diagrams (architecture, flowcharts, UML)
+    diagram-creator      Diagrams (architecture, flowcharts, UML)
 
     Usage: opencode --agent build "implement auth feature"
            opencode --agent explore "find all API routes"
@@ -512,9 +517,6 @@ USAGE:
       web-reader         Web page content extraction
       web-search-prime   Web search capabilities
       zread              GitHub repository search and file reading
-
-    Local instance required:
-      drawio             Draw.io MCP server (http://localhost:41033/mcp)
 
   SKILLS (27):
     Framework (5):        test-generator-framework, jira-git-integration,
@@ -566,14 +568,10 @@ USAGE:
 
   Local Services:
     LM Studio             Running on http://127.0.0.1:1234/v1
-                          Local LLM inference server
+                           Local LLM inference server
 
-    Draw.io MCP (optional) For diagram-creator agent
-                          Clone: https://github.com/scholtzm/mcp-drawio
-                          Run on: http://localhost:41033/mcp
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                           FILE LOCATIONS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                            FILE LOCATIONS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   Configuration:        ~/.config/opencode/config.json
@@ -768,11 +766,6 @@ check_network() {
     return 0
 }
 
-# Check if a command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
-
 # Check dependencies
 check_dependencies() {
     log_info "Checking basic dependencies..."
@@ -870,6 +863,15 @@ setup_github_pat() {
     fi
 
     # Check if already set
+    # On Windows, also check the registry for setx-persisted values
+    if is_windows && [ -z "$GITHUB_PAT" ]; then
+        local _reg_pat
+        _reg_pat=$(reg query "HKCU\\Environment" /v GITHUB_PAT 2>/dev/null | grep -oP 'REG_SZ\s+\K.*' || true)
+        if [ -n "$_reg_pat" ]; then
+            GITHUB_PAT="$_reg_pat"
+        fi
+    fi
+
     if [ -n "$GITHUB_PAT" ]; then
         echo ""
         echo "GITHUB_PAT is already set in your environment."
@@ -906,6 +908,15 @@ setup_zai_api_key() {
     echo ""
 
     # Check if already set
+    # On Windows, also check the registry for setx-persisted values
+    if is_windows && [ -z "$ZAI_API_KEY" ]; then
+        local _reg_key
+        _reg_key=$(reg query "HKCU\\Environment" /v ZAI_API_KEY 2>/dev/null | grep -oP 'REG_SZ\s+\K.*' || true)
+        if [ -n "$_reg_key" ]; then
+            ZAI_API_KEY="$_reg_key"
+        fi
+    fi
+
     if [ -n "$ZAI_API_KEY" ]; then
         echo "ZAI_API_KEY is already set in your environment."
         echo "Current key (masked): ${ZAI_API_KEY:0:8}...${ZAI_API_KEY: -4}"
@@ -1288,22 +1299,6 @@ setup_nodejs() {
             # Windows: Check if Node.js is already installed
             if command_exists node; then
                 log_info "Node.js is already installed ($(node --version))"
-                log_info "Node.js v20+ is required for Draw.io MCP server integration"
-                echo ""
-                echo "=== Draw.io MCP Server Setup ==="
-                echo "To use the diagram-creator agent with Draw.io MCP server on Windows:"
-                echo "1. Clone and build Draw.io MCP server:"
-                echo "   git clone https://github.com/scholtzm/mcp-drawio.git"
-                echo "   cd mcp-drawio"
-                echo "   npm install"
-                echo "   npm run build"
-                echo ""
-                echo "2. Start the server:"
-                echo "   npm start"
-                echo ""
-                echo "3. Ensure it's running on: http://localhost:41033/mcp"
-                echo ""
-                log_info "Diagram-creator agent requires Draw.io MCP server for diagram creation"
 
                 if prompt_yes_no "Install a newer version of Node.js?" "n"; then
                     log_info "To install/update Node.js on Windows:"
@@ -1357,29 +1352,12 @@ setup_nodejs() {
 
         if command_exists node; then
             log_success "Node.js $(node --version) installed and active"
-            log_info "Node.js v20+ is required for Draw.io MCP server integration"
-            echo ""
-            echo "=== Draw.io MCP Server Setup ==="
-            echo "To use the diagram-creator agent with Draw.io MCP server:"
-            echo "1. Clone and build Draw.io MCP server:"
-            echo "   git clone https://github.com/scholtzm/mcp-drawio.git"
-            echo "   cd mcp-drawio"
-            echo "   npm install"
-            echo "   npm run build"
-            echo ""
-            echo "2. Start the server:"
-            echo "   npm start"
-            echo ""
-            echo "3. Ensure it's running on: http://localhost:41033/mcp"
-            echo ""
-            log_info "Diagram-creator agent requires Draw.io MCP server for diagram creation"
         else
             log_error "Node.js installation failed"
             return 1
         fi
         else
             log_info "Skipping Node.js v24 installation"
-            log_warn "Node.js v20+ is recommended for Draw.io MCP server integration"
         fi
         ;;
     esac
@@ -1622,11 +1600,11 @@ setup_config() {
             echo "    - plan - Planning agent (read-only)"
             echo "    - explore - Codebase exploration and analysis"
             echo "    - image-analyzer - Image/screenshot analysis"
-            echo "    - diagram-creator - Draw.io diagram creation"
+            echo "    - diagram-creator - Diagram creation"
             echo ""
-            echo "✓ Configured 6 MCP servers:"
+            echo "✓ Configured 5 MCP servers:"
             echo "    Local (auto-start): atlassian, zai-mcp-server"
-            echo "    Remote (needs key): web-reader, web-search-prime, zread, drawio"
+            echo "    Remote (needs key): web-reader, web-search-prime, zread"
             echo ""
         else
             log_error "config.json not found in ${SCRIPT_DIR}"
@@ -1711,6 +1689,35 @@ setup_config() {
     return 0
 }
 
+# Check if running on Windows (native or Git Bash)
+is_windows() {
+    case "$DETECTED_OS" in
+        Windows*|Windows-GitBash) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Set a user-level environment variable on Windows using setx
+# Falls back gracefully if setx is not available
+setx_env() {
+    local key="$1"
+    local value="$2"
+
+    if ! command_exists setx; then
+        log_warn "setx not found - skipping system env var for ${key}"
+        return 1
+    fi
+
+    log_debug "Setting Windows env var: ${key} via setx"
+    setx "$key" "$value" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        log_success "${key} set via setx (available in new terminals)"
+    else
+        log_warn "setx failed for ${key}"
+        return 1
+    fi
+}
+
 # Setup environment variables in shell config (bashrc, zshrc, etc.)
 setup_shell_vars() {
     echo ""
@@ -1720,91 +1727,121 @@ setup_shell_vars() {
     echo ""
     echo "Detected shell: ${DETECTED_SHELL}"
     echo "Config file: ${SHELL_CONFIG_FILE}"
+    if is_windows; then
+        echo "Platform: Windows (using setx for system-wide env vars)"
+    fi
     echo ""
 
-    # Add ZAI_API_KEY to shell config
+    # On Windows, use setx for system-wide access (all shells + opencode)
+    # On non-Windows, use shell config file (bashrc/zshrc)
+    if is_windows; then
+        log_info "Windows detected: setting env vars via setx (available in all terminals)"
+    fi
+
+    # Add ZAI_API_KEY
     if [ -n "$ZAI_API_KEY" ]; then
-        if grep -q "ZAI_API_KEY" "$SHELL_CONFIG_FILE" 2>/dev/null; then
-            log_info "ZAI_API_KEY already exists in ${SHELL_CONFIG_FILE}"
+        if is_windows; then
+            setx_env "ZAI_API_KEY" "${ZAI_API_KEY}"
+            export ZAI_API_KEY="${ZAI_API_KEY}"
         else
-            if prompt_yes_no "Add ZAI_API_KEY to $(basename ${SHELL_CONFIG_FILE}) for persistent access?" "y"; then
-                create_backup "$SHELL_CONFIG_FILE"
-                run_cmd "echo 'export ZAI_API_KEY=\"${ZAI_API_KEY}\"' >> ${SHELL_CONFIG_FILE}"
-                log_success "ZAI_API_KEY added to ${SHELL_CONFIG_FILE}"
+            if grep -q "ZAI_API_KEY" "$SHELL_CONFIG_FILE" 2>/dev/null; then
+                log_info "ZAI_API_KEY already exists in ${SHELL_CONFIG_FILE}"
             else
-                log_info "Skipping shell config update for ZAI_API_KEY"
+                if prompt_yes_no "Add ZAI_API_KEY to $(basename ${SHELL_CONFIG_FILE}) for persistent access?" "y"; then
+                    create_backup "$SHELL_CONFIG_FILE"
+                    run_cmd "echo 'export ZAI_API_KEY=\"${ZAI_API_KEY}\"' >> ${SHELL_CONFIG_FILE}"
+                    log_success "ZAI_API_KEY added to ${SHELL_CONFIG_FILE}"
+                else
+                    log_info "Skipping shell config update for ZAI_API_KEY"
+                fi
             fi
         fi
     fi
 
-    # Add GITHUB_PAT to shell config
+    # Add GITHUB_PAT
     if [ -n "$GITHUB_PAT" ]; then
-        if grep -q "GITHUB_PAT" "$SHELL_CONFIG_FILE" 2>/dev/null; then
-            log_info "GITHUB_PAT already exists in ${SHELL_CONFIG_FILE}"
+        if is_windows; then
+            setx_env "GITHUB_PAT" "${GITHUB_PAT}"
+            export GITHUB_PAT="${GITHUB_PAT}"
         else
-            if prompt_yes_no "Add GITHUB_PAT to $(basename ${SHELL_CONFIG_FILE}) for persistent access?" "y"; then
-                create_backup "$SHELL_CONFIG_FILE"
-                run_cmd "echo 'export GITHUB_PAT=\"${GITHUB_PAT}\"' >> ${SHELL_CONFIG_FILE}"
-                log_success "GITHUB_PAT added to ${SHELL_CONFIG_FILE}"
+            if grep -q "GITHUB_PAT" "$SHELL_CONFIG_FILE" 2>/dev/null; then
+                log_info "GITHUB_PAT already exists in ${SHELL_CONFIG_FILE}"
             else
-                log_info "Skipping shell config update for GITHUB_PAT"
+                if prompt_yes_no "Add GITHUB_PAT to $(basename ${SHELL_CONFIG_FILE}) for persistent access?" "y"; then
+                    create_backup "$SHELL_CONFIG_FILE"
+                    run_cmd "echo 'export GITHUB_PAT=\"${GITHUB_PAT}\"' >> ${SHELL_CONFIG_FILE}"
+                    log_success "GITHUB_PAT added to ${SHELL_CONFIG_FILE}"
+                else
+                    log_info "Skipping shell config update for GITHUB_PAT"
+                fi
             fi
         fi
     fi
 
-    # Add JIRA OAuth2 credentials to shell config
+    # Add JIRA OAuth2 credentials
     if [ -n "$JIRA_CLIENT_ID" ]; then
-        local jira_vars_missing=false
-        
-        # Check if JIRA variables are already configured
-        if ! grep -q "JIRA_CLIENT_ID" "$SHELL_CONFIG_FILE" 2>/dev/null; then
-            jira_vars_missing=true
-        fi
-        
-        if [ "$jira_vars_missing" = true ]; then
-            if prompt_yes_no "Add JIRA OAuth2 credentials to $(basename ${SHELL_CONFIG_FILE})?" "y"; then
-                create_backup "$SHELL_CONFIG_FILE"
-                
-                # Add JIRA OAuth2 section
-                run_cmd "echo '' >> ${SHELL_CONFIG_FILE}"
-                run_cmd "echo '# JIRA OAuth2 Configuration' >> ${SHELL_CONFIG_FILE}"
-                run_cmd "echo 'export JIRA_CLIENT_ID=\"${JIRA_CLIENT_ID}\"' >> ${SHELL_CONFIG_FILE}"
-                run_cmd "echo 'export JIRA_CLIENT_SECRET=\"${JIRA_CLIENT_SECRET}\"' >> ${SHELL_CONFIG_FILE}"
-                run_cmd "echo 'export JIRA_ACCESS_TOKEN=\"${JIRA_ACCESS_TOKEN}\"' >> ${SHELL_CONFIG_FILE}"
-                run_cmd "echo 'export JIRA_REFRESH_TOKEN=\"${JIRA_REFRESH_TOKEN}\"' >> ${SHELL_CONFIG_FILE}"
-                
-                if [ -n "$JIRA_CLOUD_ID" ]; then
-                    run_cmd "echo 'export JIRA_CLOUD_ID=\"${JIRA_CLOUD_ID}\"' >> ${SHELL_CONFIG_FILE}"
-                fi
-                
-                log_success "JIRA OAuth2 credentials added to ${SHELL_CONFIG_FILE}"
-            else
-                log_info "Skipping shell config update for JIRA OAuth2"
+        if is_windows; then
+            setx_env "JIRA_CLIENT_ID" "${JIRA_CLIENT_ID}"
+            setx_env "JIRA_CLIENT_SECRET" "${JIRA_CLIENT_SECRET}"
+            setx_env "JIRA_ACCESS_TOKEN" "${JIRA_ACCESS_TOKEN}"
+            setx_env "JIRA_REFRESH_TOKEN" "${JIRA_REFRESH_TOKEN}"
+            if [ -n "$JIRA_CLOUD_ID" ]; then
+                setx_env "JIRA_CLOUD_ID" "${JIRA_CLOUD_ID}"
             fi
+            export JIRA_CLIENT_ID="${JIRA_CLIENT_ID}"
+            export JIRA_CLIENT_SECRET="${JIRA_CLIENT_SECRET}"
+            export JIRA_ACCESS_TOKEN="${JIRA_ACCESS_TOKEN}"
+            export JIRA_REFRESH_TOKEN="${JIRA_REFRESH_TOKEN}"
+            export JIRA_CLOUD_ID="${JIRA_CLOUD_ID:-}"
         else
-            log_info "JIRA OAuth2 credentials already exist in ${SHELL_CONFIG_FILE}"
+            local jira_vars_missing=false
             
-            # Update tokens if they've changed
-            if prompt_yes_no "Update existing JIRA tokens?" "n"; then
-                create_backup "$SHELL_CONFIG_FILE"
-                
-                # Remove old JIRA exports and add new ones
-                local temp_file="${SHELL_CONFIG_FILE}.tmp"
-                grep -v "^export JIRA_" "$SHELL_CONFIG_FILE" > "$temp_file" 2>/dev/null || true
-                
-                echo '' >> "$temp_file"
-                echo '# JIRA OAuth2 Configuration' >> "$temp_file"
-                echo "export JIRA_CLIENT_ID=\"${JIRA_CLIENT_ID}\"" >> "$temp_file"
-                echo "export JIRA_CLIENT_SECRET=\"${JIRA_CLIENT_SECRET}\"" >> "$temp_file"
-                echo "export JIRA_ACCESS_TOKEN=\"${JIRA_ACCESS_TOKEN}\"" >> "$temp_file"
-                echo "export JIRA_REFRESH_TOKEN=\"${JIRA_REFRESH_TOKEN}\"" >> "$temp_file"
-                
-                if [ -n "$JIRA_CLOUD_ID" ]; then
-                    echo "export JIRA_CLOUD_ID=\"${JIRA_CLOUD_ID}\"" >> "$temp_file"
+            if ! grep -q "JIRA_CLIENT_ID" "$SHELL_CONFIG_FILE" 2>/dev/null; then
+                jira_vars_missing=true
+            fi
+            
+            if [ "$jira_vars_missing" = true ]; then
+                if prompt_yes_no "Add JIRA OAuth2 credentials to $(basename ${SHELL_CONFIG_FILE})?" "y"; then
+                    create_backup "$SHELL_CONFIG_FILE"
+                    
+                    run_cmd "echo '' >> ${SHELL_CONFIG_FILE}"
+                    run_cmd "echo '# JIRA OAuth2 Configuration' >> ${SHELL_CONFIG_FILE}"
+                    run_cmd "echo 'export JIRA_CLIENT_ID=\"${JIRA_CLIENT_ID}\"' >> ${SHELL_CONFIG_FILE}"
+                    run_cmd "echo 'export JIRA_CLIENT_SECRET=\"${JIRA_CLIENT_SECRET}\"' >> ${SHELL_CONFIG_FILE}"
+                    run_cmd "echo 'export JIRA_ACCESS_TOKEN=\"${JIRA_ACCESS_TOKEN}\"' >> ${SHELL_CONFIG_FILE}"
+                    run_cmd "echo 'export JIRA_REFRESH_TOKEN=\"${JIRA_REFRESH_TOKEN}\"' >> ${SHELL_CONFIG_FILE}"
+                    
+                    if [ -n "$JIRA_CLOUD_ID" ]; then
+                        run_cmd "echo 'export JIRA_CLOUD_ID=\"${JIRA_CLOUD_ID}\"' >> ${SHELL_CONFIG_FILE}"
+                    fi
+                    
+                    log_success "JIRA OAuth2 credentials added to ${SHELL_CONFIG_FILE}"
+                else
+                    log_info "Skipping shell config update for JIRA OAuth2"
                 fi
+            else
+                log_info "JIRA OAuth2 credentials already exist in ${SHELL_CONFIG_FILE}"
                 
-                mv "$temp_file" "$SHELL_CONFIG_FILE"
-                log_success "JIRA OAuth2 tokens updated in ${SHELL_CONFIG_FILE}"
+                if prompt_yes_no "Update existing JIRA tokens?" "n"; then
+                    create_backup "$SHELL_CONFIG_FILE"
+                    
+                    local temp_file="${SHELL_CONFIG_FILE}.tmp"
+                    grep -v "^export JIRA_" "$SHELL_CONFIG_FILE" > "$temp_file" 2>/dev/null || true
+                    
+                    echo '' >> "$temp_file"
+                    echo '# JIRA OAuth2 Configuration' >> "$temp_file"
+                    echo "export JIRA_CLIENT_ID=\"${JIRA_CLIENT_ID}\"" >> "$temp_file"
+                    echo "export JIRA_CLIENT_SECRET=\"${JIRA_CLIENT_SECRET}\"" >> "$temp_file"
+                    echo "export JIRA_ACCESS_TOKEN=\"${JIRA_ACCESS_TOKEN}\"" >> "$temp_file"
+                    echo "export JIRA_REFRESH_TOKEN=\"${JIRA_REFRESH_TOKEN}\"" >> "$temp_file"
+                    
+                    if [ -n "$JIRA_CLOUD_ID" ]; then
+                        echo "export JIRA_CLOUD_ID=\"${JIRA_CLOUD_ID}\"" >> "$temp_file"
+                    fi
+                    
+                    mv "$temp_file" "$SHELL_CONFIG_FILE"
+                    log_success "JIRA OAuth2 tokens updated in ${SHELL_CONFIG_FILE}"
+                fi
             fi
         fi
     fi
@@ -2094,14 +2131,13 @@ print_summary() {
         echo "    - plan - Planning agent (read-only)"
         echo "    - explore - Codebase exploration and analysis"
         echo "    - image-analyzer - Image/screenshot analysis"
-        echo "    - diagram-creator - Draw.io diagram creation"
+        echo "    - diagram-creator - Diagram creation"
     fi
 
     # MCP servers configured
     if [ -f "$CONFIG_FILE" ]; then
-        echo "✓ Configured 6 MCP servers:"
+        echo "✓ Configured 5 MCP servers:"
         echo "    - atlassian - JIRA and Confluence integration (auto-start)"
-        echo "    - drawio - Draw.io diagram server (needs local instance)"
         echo "    - web-reader - Web page reading (needs ZAI_API_KEY)"
         echo "    - web-search-prime - Web search (needs ZAI_API_KEY)"
         echo "    - zai-mcp-server - Image analysis (auto-start)"
@@ -2152,7 +2188,13 @@ print_summary() {
     fi
 
     # ZAI_API_KEY status
-    if grep -q "ZAI_API_KEY" "$SHELL_CONFIG_FILE" 2>/dev/null; then
+    if is_windows && command_exists setx; then
+        if [ -n "$ZAI_API_KEY" ]; then
+            echo "✓ ZAI_API_KEY: Set via setx (system-wide)"
+        else
+            echo "✗ ZAI_API_KEY: Not configured"
+        fi
+    elif grep -q "ZAI_API_KEY" "$SHELL_CONFIG_FILE" 2>/dev/null; then
         echo "✓ ZAI_API_KEY: Added to ${SHELL_CONFIG_FILE}"
     elif [ -n "$ZAI_API_KEY" ]; then
         echo "○ ZAI_API_KEY: Set in current session only"
@@ -2161,7 +2203,13 @@ print_summary() {
     fi
 
     # GITHUB_PAT status
-    if grep -q "GITHUB_PAT" "$SHELL_CONFIG_FILE" 2>/dev/null; then
+    if is_windows && command_exists setx; then
+        if [ -n "$GITHUB_PAT" ]; then
+            echo "✓ GITHUB_PAT: Set via setx (system-wide)"
+        else
+            echo "○ GITHUB_PAT: Not configured (use OAuth with: opencode mcp auth github)"
+        fi
+    elif grep -q "GITHUB_PAT" "$SHELL_CONFIG_FILE" 2>/dev/null; then
         echo "✓ GITHUB_PAT: Added to ${SHELL_CONFIG_FILE}"
     elif [ -n "$GITHUB_PAT" ]; then
         echo "○ GITHUB_PAT: Set in current session only"
@@ -2181,6 +2229,9 @@ print_next_steps() {
     echo ""
     echo "📋 Next Steps:"
     echo "  1. Restart terminal or run: source ${SHELL_CONFIG_FILE}"
+    if is_windows; then
+        echo "     (Environment variables were set via setx - open a NEW terminal to use them)"
+    fi
     echo "  2. Start LM Studio: http://127.0.0.1:1234/v1"
     echo "  3. Verify installation: opencode --version"
     echo ""
@@ -2193,7 +2244,7 @@ print_next_steps() {
     echo "  - plan - Planning agent (read-only)"
     echo "  - explore - Fast codebase exploration and analysis"
     echo "  - image-analyzer - Images/screenshots to code, OCR, error diagnosis"
-    echo "  - diagram-creator - Draw.io diagrams (architecture, flowcharts, UML)"
+    echo "  - diagram-creator - Diagrams (architecture, flowcharts, UML)"
     echo ""
     echo "  Usage: opencode --agent <name> \"prompt\""
     echo "         opencode \"prompt\" (uses build)"
@@ -2210,11 +2261,11 @@ print_next_steps() {
     echo "  Run 'opencode --skill <name> \"prompt\"' to use a skill"
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "                     🔌 MCP Servers (6)"
+    echo "                     🔌 MCP Servers (5)"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
     echo "  Local (auto-start): atlassian, zai-mcp-server"
-    echo "  Remote (needs key): web-reader, web-search-prime, zread, drawio"
+    echo "  Remote (needs key): web-reader, web-search-prime, zread"
     echo ""
     echo "  Auth: opencode mcp auth atlassian / opencode mcp auth github"
     echo ""


### PR DESCRIPTION
## Summary
- Add `setup.ps1` for Windows PowerShell with winget/chocolatey Node.js fallbacks, registry-based env var detection, and PeonPing integration
- Fix `setup.sh` runtime errors on Windows/Git Bash (command_exists ordering, ZSH_VERSION/USER unbound vars with `set -o nounset`)
- Replace `.env` file approach with `setx` for Windows env var persistence; use registry detection to find previously-persisted keys
- Remove all Draw.io MCP server references from `setup.sh`, `config.json`, and `README.md`
- Update `README.md` with PowerShell docs, remove `setup.bat` section, add Windows Node.js install options
- Complete PLAN-GIT-93: add `docx-creation-subagent` to `config.json` and `.AGENTS.md`

## Test Plan
- [x] `setup.ps1` runs in PowerShell on Windows (winget fallback for Node.js confirmed)
- [ ] `setup.sh` runs in Git Bash on Windows without runtime errors
- [ ] `setup.sh` runs on macOS/Linux
- [ ] Environment variables detected from Windows registry on re-run

Closes #93