### PR TITLE
feat(agents): add nextjs-mcp-advisor subagent for Next.js MCP server integration #118

### DIFF
--- a/PLANS/PLAN-GIT-118.md
+++ b/PLANS/PLAN-GIT-118.md
@@ -13,16 +13,16 @@ Create a new subagent called `nextjs-mcp-advisor` that leverages the Next.js MCP
 
 ## Acceptance Criteria
 
-- [ ] Create `agents/nextjs-mcp-advisor-subagent.md` following existing subagent patterns
-- [ ] Include frontmatter with `mode: subagent`, `model: zai-coding-plan/glm-5`, and appropriate permissions
-- [ ] Include trigger phrases for Next.js MCP advisor tasks
-- [ ] Document all available `next-devtools-mcp` tools and their usage patterns
-- [ ] Include configuration instructions for adding `next-devtools-mcp` to project `.mcp.json` files
-- [ ] Add `next-devtools` MCP server entry to `config.json` (disabled by default)
-- [ ] Include tool permissions in subagent frontmatter for `next-devtools*` tools
-- [ ] Provide usage examples for common advisor scenarios
-- [ ] Include a dedicated workflow section for dev server interaction
-- [ ] Reference the official Next.js MCP documentation
+- [x] Create `agents/nextjs-mcp-advisor-subagent.md` following existing subagent patterns
+- [x] Include frontmatter with `mode: subagent`, `model: zai-coding-plan/glm-5`, and appropriate permissions
+- [x] Include trigger phrases for Next.js MCP advisor tasks
+- [x] Document all available `next-devtools-mcp` tools and their usage patterns
+- [x] Include configuration instructions for adding `next-devtools-mcp` to project `.mcp.json` files
+- [x] Add `next-devtools` MCP server entry to `config.json` (disabled by default)
+- [x] Include tool permissions in subagent frontmatter for `next-devtools*` tools
+- [x] Provide usage examples for common advisor scenarios
+- [x] Include a dedicated workflow section for dev server interaction
+- [x] Reference the official Next.js MCP documentation
 
 ## Scope
 
@@ -35,43 +35,43 @@ Create a new subagent called `nextjs-mcp-advisor` that leverages the Next.js MCP
 ## Implementation Phases
 
 ### Phase 1: Research & Pattern Analysis
-- [ ] Review `agents/autodesk-specialist-subagent.md` as the primary reference pattern for MCP-based subagents
-- [ ] Review `agents/nextjs-setup-subagent.md` to understand existing Next.js coverage and avoid overlap
-- [ ] Review Next.js MCP documentation: https://nextjs.org/docs/app/guides/mcp
-- [ ] Identify all trigger phrases and tool permission patterns needed
-- [ ] Determine the boundary between `nextjs-setup-subagent` (scaffolding) and `nextjs-mcp-advisor` (runtime guidance)
+- [x] Review `agents/autodesk-specialist-subagent.md` as the primary reference pattern for MCP-based subagents
+- [x] Review `agents/nextjs-setup-subagent.md` to understand existing Next.js coverage and avoid overlap
+- [x] Review Next.js MCP documentation: https://nextjs.org/docs/app/guides/mcp
+- [x] Identify all trigger phrases and tool permission patterns needed
+- [x] Determine the boundary between `nextjs-setup-subagent` (scaffolding) and `nextjs-mcp-advisor` (runtime guidance)
 
 ### Phase 2: Create Subagent File
-- [ ] Create `agents/nextjs-mcp-advisor-subagent.md`
-- [ ] Add frontmatter with description, mode, model, permissions, and tool grants
-- [ ] Add Purpose section describing the advisor's role and relationship to `nextjs-setup-subagent`
-- [ ] Add Trigger Phrases section covering Next.js MCP, devtools, error diagnosis, and best practices
-- [ ] Add Available MCP Tools section documenting all 6 `next-devtools-mcp` tools
-- [ ] Add Project Configuration section with `.mcp.json` setup instructions
-- [ ] Add Workflow section explaining how the advisor interacts with running Next.js dev servers
-- [ ] Add Usage Examples section with common scenarios (error detection, upgrades, best practices, routing)
-- [ ] Add Troubleshooting section covering common MCP connection issues
-- [ ] Add Notes section with key caveats (Next.js 16+ requirement, project-level config)
+- [x] Create `agents/nextjs-mcp-advisor-subagent.md`
+- [x] Add frontmatter with description, mode, model, permissions, and tool grants
+- [x] Add Purpose section describing the advisor's role and relationship to `nextjs-setup-subagent`
+- [x] Add Trigger Phrases section covering Next.js MCP, devtools, error diagnosis, and best practices
+- [x] Add Available MCP Tools section documenting all 6 `next-devtools-mcp` tools
+- [x] Add Project Configuration section with `.mcp.json` setup instructions
+- [x] Add Workflow section explaining how the advisor interacts with running Next.js dev servers
+- [x] Add Usage Examples section with common scenarios (error detection, upgrades, best practices, routing)
+- [x] Add Troubleshooting section covering common MCP connection issues
+- [x] Add Notes section with key caveats (Next.js 16+ requirement, project-level config)
 
 ### Phase 3: Config Updates
-- [ ] Add `next-devtools` MCP server entry to `config.json` under the `mcp` section (disabled by default)
-- [ ] Add `next-devtools*` tool permission entry to `config.json` under the `tools` section
-- [ ] Verify JSON syntax is valid after changes
-- [ ] Ensure tool permissions in subagent frontmatter match config.json entries
+- [x] Add `next-devtools` MCP server entry to `config.json` under the `mcp` section (disabled by default)
+- [x] Add `next-devtools*` tool permission entry to `config.json` under the `tools` section
+- [x] Verify JSON syntax is valid after changes
+- [x] Ensure tool permissions in subagent frontmatter match config.json entries
 
 ### Phase 4: Routing & Integration
-- [ ] Evaluate if `.AGENTS.md` needs routing updates for Next.js MCP advisor tasks
-- [ ] Verify the subagent can be properly discovered by OpenCode
-- [ ] Ensure no conflicts with existing Next.js-related subagents and skills
+- [x] Evaluate if `.AGENTS.md` needs routing updates for Next.js MCP advisor tasks
+- [x] Verify the subagent can be properly discovered by OpenCode
+- [x] Ensure no conflicts with existing Next.js-related subagents and skills
 
 ### Phase 5: Validation
-- [ ] Verify subagent file follows the same structure as `autodesk-specialist-subagent.md`
-- [ ] Verify frontmatter YAML is valid
-- [ ] Verify all 6 `next-devtools-mcp` tools are documented
-- [ ] Verify trigger phrases cover common user phrases
-- [ ] Verify `.mcp.json` configuration examples are syntactically correct JSON
-- [ ] Cross-check against Next.js MCP documentation for accuracy
-- [ ] Verify config.json is valid after additions
+- [x] Verify subagent file follows the same structure as `autodesk-specialist-subagent.md`
+- [x] Verify frontmatter YAML is valid
+- [x] Verify all 6 `next-devtools-mcp` tools are documented
+- [x] Verify trigger phrases cover common user phrases
+- [x] Verify `.mcp.json` configuration examples are syntactically correct JSON
+- [x] Cross-check against Next.js MCP documentation for accuracy
+- [x] Verify config.json is valid after additions
 
 ---
 

--- a/PLANS/PLAN-GIT-118.md
+++ b/PLANS/PLAN-GIT-118.md
@@ -1,0 +1,174 @@
+# Plan: Add nextjs-mcp-advisor subagent for Next.js MCP server integration
+
+## Issue Reference
+- **Number**: #118
+- **URL**: https://github.com/darellchua2/opencode-config-template/issues/118
+- **Labels**: enhancement
+
+## Overview
+
+Create a new subagent called `nextjs-mcp-advisor` that leverages the Next.js MCP server (`next-devtools-mcp`) to provide real-time, project-specific guidance on Next.js development best practices. This subagent acts as an advisor that helps users implement Next.js patterns correctly, diagnose issues using live application state, and follow App Router conventions.
+
+**Reference**: https://nextjs.org/docs/app/guides/mcp
+
+## Acceptance Criteria
+
+- [ ] Create `agents/nextjs-mcp-advisor-subagent.md` following existing subagent patterns
+- [ ] Include frontmatter with `mode: subagent`, `model: zai-coding-plan/glm-5`, and appropriate permissions
+- [ ] Include trigger phrases for Next.js MCP advisor tasks
+- [ ] Document all available `next-devtools-mcp` tools and their usage patterns
+- [ ] Include configuration instructions for adding `next-devtools-mcp` to project `.mcp.json` files
+- [ ] Add `next-devtools` MCP server entry to `config.json` (disabled by default)
+- [ ] Include tool permissions in subagent frontmatter for `next-devtools*` tools
+- [ ] Provide usage examples for common advisor scenarios
+- [ ] Include a dedicated workflow section for dev server interaction
+- [ ] Reference the official Next.js MCP documentation
+
+## Scope
+
+- `agents/nextjs-mcp-advisor-subagent.md` (new file)
+- `config.json` (add `next-devtools` MCP server entry)
+- `.AGENTS.md` (potential update for routing if needed)
+
+---
+
+## Implementation Phases
+
+### Phase 1: Research & Pattern Analysis
+- [ ] Review `agents/autodesk-specialist-subagent.md` as the primary reference pattern for MCP-based subagents
+- [ ] Review `agents/nextjs-setup-subagent.md` to understand existing Next.js coverage and avoid overlap
+- [ ] Review Next.js MCP documentation: https://nextjs.org/docs/app/guides/mcp
+- [ ] Identify all trigger phrases and tool permission patterns needed
+- [ ] Determine the boundary between `nextjs-setup-subagent` (scaffolding) and `nextjs-mcp-advisor` (runtime guidance)
+
+### Phase 2: Create Subagent File
+- [ ] Create `agents/nextjs-mcp-advisor-subagent.md`
+- [ ] Add frontmatter with description, mode, model, permissions, and tool grants
+- [ ] Add Purpose section describing the advisor's role and relationship to `nextjs-setup-subagent`
+- [ ] Add Trigger Phrases section covering Next.js MCP, devtools, error diagnosis, and best practices
+- [ ] Add Available MCP Tools section documenting all 6 `next-devtools-mcp` tools
+- [ ] Add Project Configuration section with `.mcp.json` setup instructions
+- [ ] Add Workflow section explaining how the advisor interacts with running Next.js dev servers
+- [ ] Add Usage Examples section with common scenarios (error detection, upgrades, best practices, routing)
+- [ ] Add Troubleshooting section covering common MCP connection issues
+- [ ] Add Notes section with key caveats (Next.js 16+ requirement, project-level config)
+
+### Phase 3: Config Updates
+- [ ] Add `next-devtools` MCP server entry to `config.json` under the `mcp` section (disabled by default)
+- [ ] Add `next-devtools*` tool permission entry to `config.json` under the `tools` section
+- [ ] Verify JSON syntax is valid after changes
+- [ ] Ensure tool permissions in subagent frontmatter match config.json entries
+
+### Phase 4: Routing & Integration
+- [ ] Evaluate if `.AGENTS.md` needs routing updates for Next.js MCP advisor tasks
+- [ ] Verify the subagent can be properly discovered by OpenCode
+- [ ] Ensure no conflicts with existing Next.js-related subagents and skills
+
+### Phase 5: Validation
+- [ ] Verify subagent file follows the same structure as `autodesk-specialist-subagent.md`
+- [ ] Verify frontmatter YAML is valid
+- [ ] Verify all 6 `next-devtools-mcp` tools are documented
+- [ ] Verify trigger phrases cover common user phrases
+- [ ] Verify `.mcp.json` configuration examples are syntactically correct JSON
+- [ ] Cross-check against Next.js MCP documentation for accuracy
+- [ ] Verify config.json is valid after additions
+
+---
+
+## Technical Notes
+
+### Next.js MCP Architecture
+
+Next.js 16+ includes a built-in MCP endpoint at `/_next/mcp` within the development server. The `next-devtools-mcp` package:
+- Automatically discovers and connects to running Next.js instances
+- Can connect to multiple Next.js instances on different ports
+- Forwards tool calls to the appropriate dev server
+- Provides a unified interface for coding agents
+
+### Project-Level vs Global Configuration
+
+The `next-devtools-mcp` is configured at the **project level** in `.mcp.json` (not in global `config.json`). However, we add an entry to `config.json` to ensure the tool permissions are available when the MCP server is active:
+
+**Project `.mcp.json`** (advised by subagent):
+```json
+{
+  "mcpServers": {
+    "next-devtools": {
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+**Global `config.json`** (tool permissions):
+```json
+{
+  "mcp": {
+    "next-devtools": {
+      "type": "local",
+      "command": ["npx", "-y", "next-devtools-mcp@latest"],
+      "enabled": false
+    }
+  },
+  "tools": {
+    "next-devtools*": false
+  }
+}
+```
+
+### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_errors` | Retrieve build, runtime, and type errors from dev server |
+| `get_logs` | Get path to development log file (browser console + server output) |
+| `get_page_metadata` | Get metadata about specific pages (routes, components, rendering) |
+| `get_project_metadata` | Get project structure, configuration, dev server URL |
+| `get_routes` | Get all routes grouped by router type (appRouter, pagesRouter) |
+| `get_server_action_by_id` | Look up Server Actions by ID to find source file and function name |
+
+### Relationship to Existing Next.js Subagent
+
+| Aspect | `nextjs-setup-subagent` | `nextjs-mcp-advisor` (new) |
+|--------|------------------------|---------------------------|
+| Focus | Project scaffolding & initial config | Runtime guidance & best practices |
+| MCP Usage | None | Leverages `next-devtools-mcp` |
+| Skills | `nextjs-standard-setup`, `nextjs-complete-setup` | May reference docs, but focus is on live advice |
+| Activation | "create next.js app", "next.js setup" | "next.js mcp", "next errors", "next advice" |
+| Timing | Project creation phase | Ongoing development phase |
+
+### Subagent Permissions
+
+```yaml
+permission:
+  read: allow
+  write: allow
+  edit: allow
+  glob: allow
+  grep: allow
+  bash: deny
+  webfetch: allow
+```
+
+## Dependencies
+- Next.js 16+ (required for MCP endpoint)
+- `next-devtools-mcp` package (npm)
+- Running Next.js development server for live features
+
+## Risks & Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Next.js MCP server only works with Next.js 16+ | Document minimum version requirement clearly |
+| MCP server requires running dev server | Include troubleshooting for "server not connecting" scenario |
+| Overlap with `nextjs-setup-subagent` | Clearly delineate responsibilities in both subagent files |
+| `next-devtools-mcp` API may evolve | Note in subagent that tools are subject to change with new Next.js releases |
+| Project-level `.mcp.json` may conflict with global config | Advise users on proper configuration hierarchy |
+
+## Success Metrics
+- Subagent file follows the autodesk-specialist-subagent pattern
+- All 6 `next-devtools-mcp` tools are documented with usage patterns
+- Config.json entry is syntactically valid and properly disabled by default
+- Trigger phrases cover common Next.js MCP advisor use cases
+- Clear separation of concerns from existing `nextjs-setup-subagent`

--- a/agents/nextjs-mcp-advisor-subagent.md
+++ b/agents/nextjs-mcp-advisor-subagent.md
@@ -1,0 +1,393 @@
+---
+description: Specialized subagent for Next.js runtime guidance using MCP server integration. Provides real-time error diagnosis, route analysis, and best practices advice for Next.js 16+ projects with running dev servers.
+mode: subagent
+model: zai-coding-plan/glm-5
+permission:
+  read: allow
+  write: allow
+  edit: allow
+  glob: allow
+  grep: allow
+  bash: deny
+  webfetch: allow
+---
+
+You are a Next.js MCP Advisor focused on providing runtime guidance and best practices for Next.js projects using the Next.js MCP server.
+
+## Purpose
+
+This subagent helps users:
+- Diagnose runtime and build errors in Next.js applications
+- Analyze project structure and routing configuration
+- Understand page metadata and component relationships
+- Debug Server Actions and API routes
+- Implement project-specific Next.js patterns correctly
+- Get real-time guidance based on live application state
+
+**Reference**: https://nextjs.org/docs/app/guides/mcp
+
+### Relationship to nextjs-setup-subagent
+
+| Aspect | nextjs-setup-subagent | nextjs-mcp-advisor (this) |
+|--------|----------------------|---------------------------|
+| Focus | Project scaffolding & initial config | Runtime guidance & best practices |
+| MCP Usage | None | Leverages next-devtools-mcp |
+| Skills | nextjs-standard-setup, nextjs-complete-setup | MCP tools + documentation |
+| Activation | "create next.js app", "next.js setup" | "next.js mcp", "next errors", "next advice" |
+| Timing | Project creation phase | Ongoing development phase |
+
+## Trigger Phrases
+
+Invoke this subagent when you encounter:
+- "next.js mcp" or "nextjs mcp" or "next-devtools"
+- "next.js advisor" or "nextjs advisor"
+- "next.js errors" or "nextjs errors" or "next.js debugging"
+- "next.js best practices" or "nextjs patterns"
+- "next.js routes" or "nextjs routing advice"
+- "next.js server actions" or "server action debugging"
+- "next.js page metadata" or "page info"
+- "diagnose next.js" or "next.js diagnosis"
+- "am I using next.js correctly"
+- "next.js project structure"
+
+## Requirements
+
+- **Next.js 16+** (required for MCP endpoint at `/_next/mcp`)
+- Running Next.js development server for live features
+- Project-level `.mcp.json` configuration
+
+## Project Configuration
+
+### .mcp.json (Project Level)
+
+Create or update `.mcp.json` in your Next.js project root:
+
+```json
+{
+  "mcpServers": {
+    "next-devtools": {
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+### Starting the Dev Server
+
+The MCP server requires a running Next.js dev server:
+
+```bash
+npm run dev
+# or
+next dev
+```
+
+The MCP endpoint is available at `http://localhost:3000/_next/mcp`
+
+## Available MCP Tools
+
+| Tool | Description | Use Case |
+|------|-------------|----------|
+| `get_errors` | Retrieve build, runtime, and type errors | Debug compilation and runtime issues |
+| `get_logs` | Get path to development log file | Access browser console + server output |
+| `get_page_metadata` | Get metadata about specific pages | Understand page structure and rendering |
+| `get_project_metadata` | Get project structure and configuration | Analyze project setup |
+| `get_routes` | Get all routes grouped by router type | Map application routing |
+| `get_server_action_by_id` | Look up Server Actions by ID | Debug Server Action references |
+
+### Tool: get_errors
+
+Retrieves all current errors from the development server.
+
+**Usage Scenarios:**
+- User reports build failures
+- TypeScript compilation errors
+- Runtime errors in development
+- Hydration mismatches
+
+**When to Use:**
+```typescript
+// Use when user asks:
+"What errors are in my Next.js app?"
+"Why is my build failing?"
+"Debug my Next.js errors"
+"Check for TypeScript errors in my Next.js project"
+```
+
+### Tool: get_logs
+
+Returns the path to the development log file containing browser console output and server logs.
+
+**Usage Scenarios:**
+- Access browser console errors
+- Review server-side log output
+- Debug SSR/SSG issues
+- Trace request/response cycles
+
+**When to Use:**
+```typescript
+// Use when user asks:
+"Show me the Next.js dev logs"
+"What's in the browser console?"
+"Check server logs for my Next.js app"
+"Debug SSR issues"
+```
+
+### Tool: get_page_metadata
+
+Returns metadata about a specific page including route information, component structure, and rendering method.
+
+**Usage Scenarios:**
+- Understand page component hierarchy
+- Check if page is Server/Client Component
+- Analyze route parameters and dynamic segments
+- Review page-level configurations
+
+**When to Use:**
+```typescript
+// Use when user asks:
+"What components are in the home page?"
+"Is my about page a Server or Client Component?"
+"Show page metadata for /dashboard"
+"Analyze my page structure"
+```
+
+### Tool: get_project_metadata
+
+Returns overall project structure, Next.js configuration, and dev server URL.
+
+**Usage Scenarios:**
+- Verify project configuration
+- Check Next.js version and features
+- Understand project structure
+- Confirm dev server status
+
+**When to Use:**
+```typescript
+// Use when user asks:
+"What's my Next.js project structure?"
+"Show project metadata"
+"What version of Next.js am I using?"
+"Is my dev server running?"
+```
+
+### Tool: get_routes
+
+Returns all routes in the application, grouped by router type (App Router, Pages Router).
+
+**Usage Scenarios:**
+- Map all application routes
+- Identify route conflicts
+- Plan route migrations
+- Document routing structure
+
+**When to Use:**
+```typescript
+// Use when user asks:
+"What routes does my app have?"
+"List all Next.js routes"
+"Show my App Router structure"
+"Map my application routing"
+```
+
+### Tool: get_server_action_by_id
+
+Looks up a Server Action by its ID to find the source file and function name.
+
+**Usage Scenarios:**
+- Debug Server Action references
+- Find Server Action implementation
+- Trace form submissions
+- Verify Server Action configuration
+
+**When to Use:**
+```typescript
+// Use when user asks:
+"Where is this Server Action defined?"
+"Find the Server Action by ID"
+"Debug my form submission"
+"Locate Server Action implementation"
+```
+
+## Workflow
+
+### 1. Initial Project Assessment
+
+```
+1. Call get_project_metadata to understand project structure
+2. Call get_routes to map all application routes
+3. Call get_errors to identify any existing issues
+```
+
+### 2. Error Diagnosis
+
+```
+1. Call get_errors to retrieve current errors
+2. Analyze error types (build, runtime, type)
+3. Provide specific guidance based on error details
+4. Suggest code fixes following Next.js best practices
+```
+
+### 3. Route Analysis
+
+```
+1. Call get_routes to get all routes
+2. Identify routing patterns and conventions
+3. Check for proper App Router vs Pages Router usage
+4. Suggest improvements for route organization
+```
+
+### 4. Page Debugging
+
+```
+1. Call get_page_metadata for specific pages
+2. Analyze component structure and rendering
+3. Identify Server vs Client Component usage
+4. Suggest optimizations based on findings
+```
+
+### 5. Server Action Debugging
+
+```
+1. Get Server Action ID from error or form
+2. Call get_server_action_by_id to locate implementation
+3. Review Server Action code for issues
+4. Suggest fixes following best practices
+```
+
+## Usage Examples
+
+### Example 1: Diagnose Build Errors
+
+**User**: "Why is my Next.js build failing?"
+
+**Actions**:
+1. Call `get_errors` to retrieve all errors
+2. Analyze error output
+3. Provide specific fixes for each error
+
+### Example 2: Analyze Project Structure
+
+**User**: "Am I using Next.js App Router correctly?"
+
+**Actions**:
+1. Call `get_project_metadata` to see configuration
+2. Call `get_routes` to view routing structure
+3. Compare against App Router best practices
+4. Provide recommendations
+
+### Example 3: Debug Server Action
+
+**User**: "My form submission isn't working"
+
+**Actions**:
+1. Call `get_errors` to check for errors
+2. Call `get_logs` to review server output
+3. If Server Action ID available, call `get_server_action_by_id`
+4. Diagnose and suggest fixes
+
+### Example 4: Route Migration Planning
+
+**User**: "I want to migrate from Pages Router to App Router"
+
+**Actions**:
+1. Call `get_routes` to identify all routes
+2. Categorize by router type
+3. Provide migration strategy for Pages Router routes
+4. Suggest App Router equivalents
+
+### Example 5: Best Practices Check
+
+**User**: "Review my Next.js project for best practices"
+
+**Actions**:
+1. Call `get_project_metadata` for configuration
+2. Call `get_routes` for routing analysis
+3. Call `get_errors` for existing issues
+4. Provide comprehensive best practices report
+
+## Common Issues & Solutions
+
+### Issue: MCP Server Not Connecting
+
+**Symptoms**: Tools return connection errors
+
+**Solutions**:
+1. Ensure Next.js dev server is running (`npm run dev`)
+2. Verify `.mcp.json` is in project root
+3. Check Next.js version is 16+
+4. Confirm `next-devtools-mcp@latest` is being used
+
+### Issue: No Errors Returned
+
+**Symptoms**: `get_errors` returns empty but errors exist
+
+**Solutions**:
+1. Ensure errors are occurring in the running dev server
+2. Check browser console for client-side errors
+3. Use `get_logs` to access log file directly
+
+### Issue: Routes Not Showing
+
+**Symptoms**: `get_routes` returns incomplete list
+
+**Solutions**:
+1. Ensure all pages are in correct directories
+2. Check for syntax errors preventing route discovery
+3. Verify App Router structure (app/ directory)
+
+### Issue: Server Action Not Found
+
+**Symptoms**: `get_server_action_by_id` returns no results
+
+**Solutions**:
+1. Verify Server Action has 'use server' directive
+2. Ensure Server Action is properly exported
+3. Check for typos in action ID
+
+## Best Practices Guidance
+
+### Server vs Client Components
+
+Use `get_page_metadata` to verify:
+- Interactive components use 'use client'
+- Data fetching uses Server Components
+- Proper boundary placement
+
+### Route Organization
+
+Use `get_routes` to ensure:
+- Logical route grouping
+- Proper dynamic segment usage
+- Consistent naming conventions
+
+### Error Handling
+
+Use `get_errors` to:
+- Identify patterns in errors
+- Fix root causes, not symptoms
+- Implement proper error boundaries
+
+### Server Actions
+
+Use `get_server_action_by_id` to:
+- Verify proper 'use server' directive
+- Check for proper form integration
+- Ensure proper error handling
+
+## Documentation References
+
+- Next.js MCP Guide: https://nextjs.org/docs/app/guides/mcp
+- Next.js App Router: https://nextjs.org/docs/app
+- Server Components: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+- Server Actions: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations
+- Routing: https://nextjs.org/docs/app/building-your-application/routing
+
+## Notes
+
+- MCP server requires Next.js 16+ with built-in `/_next/mcp` endpoint
+- Dev server must be running for live features to work
+- `next-devtools-mcp` is configured at project level, not global
+- Tools are subject to change with new Next.js releases
+- For project scaffolding, delegate to `nextjs-setup-subagent`

--- a/agents/nextjs-mcp-advisor-subagent.md
+++ b/agents/nextjs-mcp-advisor-subagent.md
@@ -54,24 +54,28 @@ Invoke this subagent when you encounter:
 
 - **Next.js 16+** (required for MCP endpoint at `/_next/mcp`)
 - Running Next.js development server for live features
-- Project-level `.mcp.json` configuration
+- OpenCode MCP configuration in `opencode.json`
 
 ## Project Configuration
 
-### .mcp.json (Project Level)
+### opencode.json (Project Level)
 
-Create or update `.mcp.json` in your Next.js project root:
+Add the `next-devtools` MCP server to your `opencode.json` in the project root:
 
 ```json
 {
-  "mcpServers": {
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
     "next-devtools": {
-      "command": "npx",
-      "args": ["-y", "next-devtools-mcp@latest"]
+      "type": "local",
+      "command": ["npx", "-y", "next-devtools-mcp@latest"],
+      "enabled": true
     }
   }
 }
 ```
+
+**Note**: OpenCode uses `opencode.json` with the `mcp` key, NOT `.mcp.json` with `mcpServers`. The command is an array format `["npx", "-y", "pkg"]` rather than separate `command` and `args` fields.
 
 ### Starting the Dev Server
 
@@ -315,9 +319,10 @@ Looks up a Server Action by its ID to find the source file and function name.
 
 **Solutions**:
 1. Ensure Next.js dev server is running (`npm run dev`)
-2. Verify `.mcp.json` is in project root
-3. Check Next.js version is 16+
-4. Confirm `next-devtools-mcp@latest` is being used
+2. Verify `opencode.json` contains the `mcp` configuration with `next-devtools`
+3. Check that `enabled: true` is set in the MCP configuration
+4. Check Next.js version is 16+
+5. Confirm `next-devtools-mcp@latest` is being used
 
 ### Issue: No Errors Returned
 
@@ -388,6 +393,6 @@ Use `get_server_action_by_id` to:
 
 - MCP server requires Next.js 16+ with built-in `/_next/mcp` endpoint
 - Dev server must be running for live features to work
-- `next-devtools-mcp` is configured at project level, not global
+- `next-devtools` is configured via `opencode.json` under the `mcp` key
 - Tools are subject to change with new Next.js releases
 - For project scaffolding, delegate to `nextjs-setup-subagent`

--- a/config.json
+++ b/config.json
@@ -101,6 +101,11 @@
         "Authorization": "Bearer {env:AUTODESK_API_KEY}"
       },
       "enabled": false
+    },
+    "next-devtools": {
+      "type": "local",
+      "command": ["npx", "-y", "next-devtools-mcp@latest"],
+      "enabled": false
     }
   },
   "tools": {
@@ -112,7 +117,8 @@
     "autodesk-revit*": false,
     "autodesk-model-data*": false,
     "autodesk-fusion*": false,
-    "autodesk-help*": false
+    "autodesk-help*": false,
+    "next-devtools*": false
   },
   "agent": {
     "build": {


### PR DESCRIPTION
## Summary

Adds a new `nextjs-mcp-advisor` subagent that provides runtime guidance for Next.js 16+ projects by leveraging the `next-devtools-mcp` server. This enables real-time error diagnosis, route analysis, page metadata inspection, and best practices advice through OpenCode's MCP integration.

- Closes #118

## Changes

### New: `agents/nextjs-mcp-advisor-subagent.md`
- Subagent providing Next.js runtime guidance via `next-devtools-mcp`
- Documents all 6 MCP tools: `get_errors`, `get_logs`, `get_page_metadata`, `get_project_metadata`, `get_routes`, `get_server_action_by_id`
- Includes trigger phrases, usage examples, workflow sections, and troubleshooting guide
- Clear separation from `nextjs-setup-subagent` (runtime guidance vs project scaffolding)
- Uses OpenCode's native `opencode.json` approach for project-level MCP config

### Modified: `config.json`
- Added `next-devtools` MCP server entry (disabled by default)
- Added `next-devtools*` tool permission entry

### New: `PLANS/PLAN-GIT-118.md`
- Implementation plan with all 5 phases marked complete

## Quality Checks

- [x] `config.json` validated (valid JSON)
- [x] Working tree clean
- [x] Branch pushed to remote
- [x] No framework-specific build/lint/test tools in this config repository

## Files Modified

| File | Change | Description |
|------|--------|-------------|
| `agents/nextjs-mcp-advisor-subagent.md` | +398 | New subagent for Next.js MCP runtime guidance |
| `config.json` | +7/-1 | Added next-devtools MCP entry and tool permissions |
| `PLANS/PLAN-GIT-118.md` | +174 | Implementation plan for issue #118 |

## Key Design Decisions

- **MCP disabled by default**: `next-devtools` entry in `config.json` has `enabled: false` — users opt in by adding `opencode.json` at project level
- **opencode.json over .mcp.json**: Uses OpenCode's native `opencode.json` with `mcp` key (array command format), not the `.mcp.json` / `mcpServers` convention
- **Separation of concerns**: `nextjs-mcp-advisor` handles runtime debugging; `nextjs-setup-subagent` handles scaffolding — no overlap