### PR TITLE
feat(skills): add plan-updater skill and PLAN.md sync to code-implementing subagents

### DIFF
--- a/PLANS/PLAN-GIT-124.md
+++ b/PLANS/PLAN-GIT-124.md
@@ -1,4 +1,4 @@
-# Plan: Update pr-workflow-subagent to sync PLAN.md before PR creation
+# Plan: Add PLAN.md sync habit to all code-implementing subagents
 
 ## Issue Reference
 - **Number**: #124
@@ -7,88 +7,51 @@
 
 ## Overview
 
-Add a PLAN.md synchronization step to the pr-workflow-subagent's workflow so that every PR accurately reflects the planning state of the branch. The subagent should check for branch-specific PLAN.md files, update progress checkboxes based on completed work, and commit changes before PR creation.
+Create a reusable `plan-updater` skill and add PLAN.md synchronization to all code-implementing subagents (pr-workflow-subagent, refactoring-subagent, testing-subagent, ticket-creation-subagent). The skill updates branch-specific PLAN.md files before key workflow milestones.
 
 ## Acceptance Criteria
-- [ ] pr-workflow-subagent checks for `PLANS/PLAN-GIT-{issue-number}.md` before creating a PR
-- [ ] Issue number is extracted from the current branch name (e.g., `issue-123`)
-- [ ] PLAN.md progress checkboxes are updated to reflect completed work on the branch
-- [ ] PLAN.md changes are committed with a semantic commit message (e.g., `docs(plan): update PLAN-GIT-123.md with current progress`)
-- [ ] Workflow skips gracefully when no PLAN.md exists for the branch
-- [ ] The new step is documented in the subagent's workflow section in `agents/pr-workflow-subagent.md`
-- [ ] The implementation approach (rule/skill/subagent) is chosen and implemented consistently
+- [x] `plan-updater` skill created with PLAN detection/update logic
+- [x] pr-workflow-subagent invokes plan-updater before PR creation
+- [x] refactoring-subagent invokes plan-updater after code changes
+- [x] testing-subagent invokes plan-updater after test creation
+- [x] ticket-creation-subagent invokes plan-updater (initial PLAN already handled)
+- [x] All subagents skip gracefully when no PLAN.md exists
+- [x] Skill handles both GitHub (`PLAN-GIT-*`) and JIRA (`PLAN-*`) conventions
 
 ## Scope
-- `agents/pr-workflow-subagent.md` — Primary file to update
-- Potentially: `skills/` — If implemented as a skill
-- Potentially: `agents/` — If implemented as a subagent
+- `skills/plan-updater/SKILL.md` — New skill (primary)
+- `agents/pr-workflow-subagent.md` — Add plan-updater invocation
+- `agents/refactoring-subagent.md` — Add plan-updater invocation
+- `agents/testing-subagent.md` — Add plan-updater invocation
+- `agents/ticket-creation-subagent.md` — Add plan-updater invocation
+- `setup.sh`, `setup.ps1`, `README.md` — Documentation sync
 
 ---
 
 ## Implementation Phases
 
-### Phase 1: Decision & Design
-- [ ] Decide on implementation approach (rule vs skill vs subagent)
-- [ ] If skill: Define skill interface, inputs, and outputs
-- [ ] If subagent: Define subagent scope and permissions
-- [ ] Document decision in issue comments
+### Phase 1: Create plan-updater Skill
+- [x] Create `skills/plan-updater/SKILL.md` with:
+  - Branch name detection (GitHub + JIRA patterns)
+  - PLAN file discovery logic
+  - Progress update workflow
+  - Semantic commit format
+  - Graceful skip behavior
 
-### Phase 2: Implementation
-- [ ] Create plan-updater skill (or inline rule in subagent)
-- [ ] Implement PLAN.md file discovery logic (branch name -> issue number -> PLAN path)
-- [ ] Implement progress update logic (analyze commits, changed files, acceptance criteria)
-- [ ] Implement graceful skip when no PLAN.md exists
-- [ ] Add commit step with semantic message format
+### Phase 2: Update Subagents
+- [x] Add `plan-updater` skill permission to pr-workflow-subagent
+- [x] Add `plan-updater` skill permission to refactoring-subagent
+- [x] Add `plan-updater` skill permission to testing-subagent
+- [x] Add `plan-updater` skill permission to ticket-creation-subagent
+- [x] Update workflow sections to include PLAN.md sync step
 
-### Phase 3: Subagent Integration
-- [ ] Update `agents/pr-workflow-subagent.md` workflow section (insert new step between quality checks and PR creation)
-- [ ] Add skill permission to subagent if using skill approach
-- [ ] Update subagent coordination section if applicable
+### Phase 3: Update Documentation
+- [x] Update setup.sh skill count (49 -> 50)
+- [x] Update setup.ps1 skill count (49 -> 50)
+- [x] Update README.md skill categories table
+- [x] Add plan-updater to Git/Workflow category
 
-### Phase 4: Cross-Workflow Consistency
-- [ ] Verify git-issue-plan-workflow skill is compatible with the new plan-updater
-- [ ] Verify jira-ticket-plan-workflow skill is compatible
-- [ ] Ensure PLAN.md naming conventions match existing patterns
-
-### Phase 5: Documentation & Validation
-- [ ] Update pr-workflow-subagent.md with clear documentation of the new step
-- [ ] Test end-to-end: create issue -> branch -> PLAN.md -> make changes -> create PR
-- [ ] Verify PLAN.md is updated before PR is created
-- [ ] Verify workflow skips when no PLAN.md exists
-
----
-
-## Technical Notes
-
-### Implementation Approach Options
-
-| Approach | Pros | Cons |
-|----------|------|------|
-| **Rule** (instruction in subagent) | Lightweight, no extra files, simple to maintain | Limited reusability, logic embedded in subagent |
-| **Skill** (e.g., `plan-updater`) | Reusable across multiple subagents, consistent behavior | Requires skill creation and maintenance, adds indirection |
-| **Subagent** (e.g., `plan-sync-subagent`) | Maximum specialization, isolated behavior | Overkill for this scope, adds complexity |
-
-**Recommendation**: A **skill** (`plan-updater`) is likely the best fit.
-
-### PLAN.md Location Convention
-- GitHub issues: `PLANS/PLAN-GIT-{ISSUE_NUMBER}.md`
-- JIRA tickets: `PLANS/PLAN-{PROJECT_KEY}-{NUMBER}.md`
-
-### Branch Name to Issue Number Parsing
-- Pattern: `issue-{number}` -> extract `{number}`
-- Pattern: `feature/issue-{number}` -> extract `{number}`
-- Pattern: `{PROJECT-KEY}-{number}` -> extract for JIRA
-
-## Dependencies
-- None (self-contained improvement)
-
-## Risks & Mitigation
-- **Risk**: PLAN.md update could fail if file is malformed
-  - **Mitigation**: Validate PLAN.md structure before updating, skip on parse errors
-- **Risk**: Commit step adds noise to PR diff
-  - **Mitigation**: Use dedicated `docs(plan):` commit prefix to keep changes organized
-
-## Success Metrics
-- All PRs created via pr-workflow-subagent include up-to-date PLAN.md when applicable
-- No PRs fail due to missing PLAN.md (graceful skip)
-- PLAN.md updates are consistent and accurate across different project frameworks
+### Phase 4: Verification
+- [ ] Test end-to-end: make changes -> invoke subagent -> verify PLAN updated
+- [ ] Verify graceful skip when no PLAN exists
+- [ ] Verify semantic commit format

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This template implements **skill permissions** to control which skills agents ca
 
 ## Skill Modularization
 
-This repository implements **skill modularization** with 49 skills organized across 9 categories. Skills are designed with clear separation of concerns and explicit dependencies.
+This repository implements **skill modularization** with 50 skills organized across 9 categories. Skills are designed with clear separation of concerns and explicit dependencies.
 
 ### Skill Categories
 
@@ -136,7 +136,7 @@ This repository implements **skill modularization** with 49 skills organized acr
 | **Framework-Specific** (7) | nextjs-pr-workflow, nextjs-unit-test-creator, nextjs-standard-setup, nextjs-complete-setup, nextjs-image-usage, nextjs-tsdoc-documentor, typescript-dry-principle | Next.js and TypeScript workflows |
 | **OpenCode Meta** (4) | opencode-agent-creation, opencode-skill-creation, opencode-skill-auditor, opencode-skills-maintainer | Agent and skill creation/maintenance |
 | **OpenTofu** (7) | opentofu-aws-explorer, opentofu-keycloak-explorer, opentofu-kubernetes-explorer, opentofu-neon-explorer, opentofu-provider-setup, opentofu-provisioning-workflow, opentofu-ecr-provision | Infrastructure as code |
-| **Git/Workflow** (7) | ascii-diagram-creator, git-issue-creator, git-pr-creator, git-issue-labeler, git-issue-plan-workflow, git-issue-updater, git-semantic-commits | Git operations and workflows |
+| **Git/Workflow** (8) | ascii-diagram-creator, git-issue-creator, git-pr-creator, git-issue-labeler, git-issue-plan-workflow, git-issue-updater, git-semantic-commits, plan-updater | Git operations and workflows |
 | **Documentation** (3) | coverage-readme-workflow, docstring-generator, documentation-sync-workflow | Documentation generation |
 | **JIRA** (4) | jira-ticket-oauth-workflow, jira-ticket-plan-workflow, jira-status-updater, jira-ticket-workflow | JIRA integration workflows |
 | **Code Quality** (7) | solid-principles, clean-code, clean-architecture, design-patterns, object-design, code-smells, complexity-management | Code quality analysis and patterns |

--- a/agents/pr-workflow-subagent.md
+++ b/agents/pr-workflow-subagent.md
@@ -15,6 +15,7 @@ permission:
     nextjs-pr-workflow: allow
     git-pr-creator: allow
     jira-status-updater: allow
+    plan-updater: allow
 ---
 
 You are a pull request workflow specialist. Handle PR creation with framework-specific quality checks.
@@ -71,10 +72,17 @@ Workflow:
 1. Detect project framework (Next.js, Python, or other)
 2. Run framework-specific quality checks (lint, build, test)
 3. Generate coverage badges if applicable
-4. Create PR using appropriate workflow:
+4. Update branch-specific PLAN.md (invoke plan-updater skill)
+5. Create PR using appropriate workflow:
    - Next.js: Use nextjs-pr-workflow
    - Generic: Use pr-creation-workflow with git-pr-creator
-5. Update JIRA ticket with PR link (if applicable)
-6. Coordinate with linting/testing/coverage subagents as needed
+6. Update JIRA ticket with PR link (if applicable)
+7. Coordinate with linting/testing/coverage subagents as needed
+
+PLAN.md Sync:
+- Before creating PR, invoke plan-updater skill
+- Updates PLAN progress checkboxes based on commits
+- Commits PLAN changes with semantic format
+- Skips gracefully if no PLAN file exists
 
 Always ensure all quality gates pass before creating PR.

--- a/agents/refactoring-subagent.md
+++ b/agents/refactoring-subagent.md
@@ -14,6 +14,7 @@ permission:
     solid-principles: allow
     code-smells: allow
     clean-code: allow
+    plan-updater: allow
 ---
 
 You are a code refactoring specialist. Apply DRY principle, SOLID principles, and clean code practices to improve code quality.
@@ -35,6 +36,7 @@ Refactoring Workflow:
 8. Organize folder structure
 9. Replace duplicated code with imports
 10. Verify refactoring (tsc, tests, lint)
+11. Update branch-specific PLAN.md (invoke plan-updater skill)
 
 SOLID Refactoring:
 - SRP: Split classes with multiple responsibilities

--- a/agents/testing-subagent.md
+++ b/agents/testing-subagent.md
@@ -14,6 +14,7 @@ permission:
     tdd-workflow: allow
     python-pytest-creator: allow
     nextjs-unit-test-creator: allow
+    plan-updater: allow
 ---
 
 You are a testing specialist. Generate comprehensive tests following industry best practices:
@@ -34,5 +35,6 @@ Workflow:
    - Integration scenarios
 5. Ensure tests follow project conventions and naming patterns
 6. Provide test execution and coverage guidance
+7. Update branch-specific PLAN.md (invoke plan-updater skill)
 
 For TDD adoption, guide developers through red-green-refactor cycle before generating tests. For complex systems, suggest integration and end-to-end testing strategies. Always prioritize test coverage of critical functionality.

--- a/agents/ticket-creation-subagent.md
+++ b/agents/ticket-creation-subagent.md
@@ -18,6 +18,7 @@ permission:
     jira-ticket-oauth-workflow: allow
     jira-ticket-plan-workflow: allow
     git-issue-plan-workflow: allow
+    plan-updater: allow
 ---
 
 You are a ticket creation specialist. Manage GitHub and JIRA ticket workflows.
@@ -101,6 +102,8 @@ After execution, this subagent provides:
 5. Generate PLAN file in `PLANS/` directory
 6. Commit and push PLAN file
 7. Return ticket details to caller
+
+Note: When returning to work on an existing ticket/branch, invoke plan-updater skill to sync PLAN.md with current progress.
 
 ## Examples
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -301,7 +301,7 @@ USAGE:
     Usage: opencode --agent build 'implement auth feature'
            opencode --agent explore 'find all API routes'
 
-  SKILLS (49):
+   SKILLS (50):
     Framework (7):        test-generator-framework, linting-workflow,
                           pr-creation-workflow, jira-git-integration,
                           error-resolver-workflow, tdd-workflow, docx-creation

--- a/setup.sh
+++ b/setup.sh
@@ -520,7 +520,7 @@ USAGE:
       web-search-prime   Web search capabilities
       zread              GitHub repository search and file reading
 
-   SKILLS (49):
+   SKILLS (50):
      Framework (7):        test-generator-framework, linting-workflow,
                            pr-creation-workflow, jira-git-integration,
                            error-resolver-workflow, tdd-workflow, docx-creation

--- a/skills/plan-updater/SKILL.md
+++ b/skills/plan-updater/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: plan-updater
+description: Update branch-specific PLAN.md files with progress. Detects branch name, finds matching PLAN file, updates checkboxes, and commits changes. Supports both GitHub (PLAN-GIT-*.md) and JIRA (PLAN-*.md) conventions.
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers, agents, subagents
+  workflow: documentation, progress-tracking
+---
+
+## What I do
+
+I provide automatic PLAN.md synchronization for any workflow that implements developer code:
+
+1. **Detect Branch Reference**: Extract issue/ticket number from current branch name
+2. **Find PLAN File**: Locate matching PLAN file in `PLANS/` directory
+3. **Update Progress**: Mark checkboxes as complete based on recent commits
+4. **Commit Changes**: Commit with semantic message format
+5. **Graceful Skip**: Skip silently when no PLAN file exists
+
+## When to use me
+
+Use this skill when:
+- Your subagent implements code changes (refactoring, testing, features)
+- You're about to create a PR and want PLAN.md to reflect current state
+- You've completed a significant milestone in development
+- You want to maintain traceability between commits and plans
+
+**Trigger phrases**:
+- "update plan"
+- "sync plan"
+- "update PLAN.md"
+- "mark plan progress"
+
+## Subagents That Should Use This Skill
+
+| Subagent | When to Invoke |
+|----------|----------------|
+| pr-workflow-subagent | Before creating PR (step 3.5) |
+| refactoring-subagent | After completing refactoring |
+| testing-subagent | After creating tests |
+| ticket-creation-subagent | After initial PLAN creation |
+
+## Core Workflow
+
+### Step 1: Detect Branch Reference
+
+Extract issue/ticket number from branch name:
+
+```bash
+BRANCH_NAME=$(git branch --show-current)
+
+# GitHub pattern: issue-123 or 123
+if [[ "$BRANCH_NAME" =~ ^issue-([0-9]+)$ ]] || [[ "$BRANCH_NAME" =~ ^([0-9]+)$ ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
+  PLAN_TYPE="github"
+  PLAN_ID="$ISSUE_NUM"
+fi
+
+# JIRA pattern: PROJECT-123
+if [[ "$BRANCH_NAME" =~ ^([A-Z]+)-([0-9]+)$ ]]; then
+  PROJECT_KEY="${BASH_REMATCH[1]}"
+  TICKET_NUM="${BASH_REMATCH[2]}"
+  PLAN_TYPE="jira"
+  PLAN_ID="${PROJECT_KEY}-${TICKET_NUM}"
+fi
+```
+
+### Step 2: Find PLAN File
+
+Locate the matching PLAN file:
+
+```bash
+# GitHub convention
+GITHUB_PLAN="PLANS/PLAN-GIT-${ISSUE_NUM}.md"
+
+# JIRA convention
+JIRA_PLAN="PLANS/PLAN-${PLAN_ID}.md"
+
+# Check which exists
+if [ -f "$GITHUB_PLAN" ]; then
+  PLAN_FILE="$GITHUB_PLAN"
+elif [ -f "$JIRA_PLAN" ]; then
+  PLAN_FILE="$JIRA_PLAN"
+else
+  echo "No PLAN file found for branch: $BRANCH_NAME"
+  echo "Skipping PLAN.md update (graceful skip)"
+  exit 0
+fi
+
+echo "Found PLAN file: $PLAN_FILE"
+```
+
+### Step 3: Analyze Recent Commits
+
+Get commits on this branch to determine completed work:
+
+```bash
+# Get commits specific to this branch (not in base branch)
+BASE_BRANCH="main"  # or detect from origin
+
+# Get commits on current branch not in base
+COMMITS=$(git log ${BASE_BRANCH}..HEAD --oneline)
+
+# Get files changed in this branch
+FILES_CHANGED=$(git diff --name-only ${BASE_BRANCH}...HEAD)
+
+# Get commit count
+COMMIT_COUNT=$(git rev-list --count ${BASE_BRANCH}..HEAD)
+```
+
+### Step 4: Update Progress Checkboxes
+
+Update PLAN.md checkboxes based on completed work:
+
+**Rules for checkbox updates**:
+1. Mark checkbox `[ ]` as `[x]` if related file was modified
+2. Don't uncheck already completed items
+3. Preserve all other content exactly
+
+**Example update logic**:
+
+```markdown
+Before:
+- [ ] Implement user authentication
+- [ ] Add OAuth2 support
+- [ ] Write unit tests
+
+After (if auth and OAuth files were changed):
+- [x] Implement user authentication
+- [x] Add OAuth2 support
+- [ ] Write unit tests
+```
+
+### Step 5: Add Progress Note (Optional)
+
+Add a progress note section if significant work was done:
+
+```markdown
+## Progress Log
+
+### 2024-01-25 - Authentication Implementation
+- Completed OAuth2 integration
+- Added token refresh mechanism
+- Files changed: src/auth/oauth.ts, src/auth/token.ts
+```
+
+### Step 6: Commit PLAN Changes
+
+Commit with semantic format:
+
+```bash
+# Stage PLAN file
+git add "$PLAN_FILE"
+
+# Commit with semantic message
+git commit -m "docs(plan): update ${PLAN_FILE##*/} with current progress"
+
+echo "Committed PLAN update: $PLAN_FILE"
+```
+
+## PLAN File Naming Convention
+
+| Source | Branch Pattern | PLAN File |
+|--------|---------------|-----------|
+| GitHub issue | `issue-123` | `PLANS/PLAN-GIT-123.md` |
+| GitHub issue | `123` | `PLANS/PLAN-GIT-123.md` |
+| JIRA ticket | `IBIS-456` | `PLANS/PLAN-IBIS-456.md` |
+| JIRA ticket | `PROJ-789` | `PLANS/PLAN-PROJ-789.md` |
+
+## Integration Pattern
+
+### For Subagent Developers
+
+Add this to your subagent's workflow:
+
+```markdown
+Workflow:
+1. [Your existing steps...]
+2. [Your existing steps...]
+N. Check for and update branch-specific PLAN.md
+   - Invoke plan-updater skill
+   - If PLAN exists, it will be updated and committed
+   - If no PLAN exists, gracefully skip
+```
+
+### For Skills
+
+Call from other skills:
+
+```markdown
+## After Making Changes
+
+5. Update PLAN.md if it exists
+   - Use plan-updater skill to sync progress
+   - Ensures traceability between commits and planning
+```
+
+## Error Handling
+
+### No PLAN File Found
+
+```bash
+# Graceful skip - not an error
+echo "No PLAN file found for current branch"
+echo "Continuing without PLAN update..."
+```
+
+### PLAN File Malformed
+
+```bash
+# Log warning but don't fail
+if ! grep -q "\- \[" "$PLAN_FILE"; then
+  echo "Warning: PLAN file may not have standard checkbox format"
+  echo "Proceeding with caution..."
+fi
+```
+
+### Branch Name Unparseable
+
+```bash
+# Try to find any PLAN file with recent modification
+RECENT_PLAN=$(find PLANS -name "PLAN-*.md" -mtime -1 | head -1)
+
+if [ -n "$RECENT_PLAN" ]; then
+  echo "Found recently modified PLAN: $RECENT_PLAN"
+  read -p "Update this PLAN file? (y/n): " CONFIRM
+  if [ "$CONFIRM" = "y" ]; then
+    PLAN_FILE="$RECENT_PLAN"
+  fi
+fi
+```
+
+## Best Practices
+
+### When to Update
+
+- **Before PR creation**: Ensure PLAN reflects final state
+- **After milestones**: Mark significant progress
+- **After refactoring**: Update scope if changed
+- **After testing**: Mark test-related tasks complete
+
+### What to Update
+
+- Mark completed tasks as `[x]`
+- Add progress notes for significant changes
+- Update scope if files changed
+- Keep acceptance criteria aligned with actual work
+
+### What NOT to Do
+
+- Don't uncheck already completed items
+- Don't modify the original plan structure
+- Don't remove sections
+- Don't change the issue reference
+
+## Example Usage
+
+### In pr-workflow-subagent
+
+```markdown
+## Workflow
+
+1. Detect project framework
+2. Run quality checks (lint, build, test)
+3. Generate coverage badges
+4. **UPDATE PLAN.md** ← Add this step
+   - Invoke plan-updater skill
+   - Ensures PLAN reflects current state before PR
+5. Create PR
+6. Update JIRA ticket
+```
+
+### In refactoring-subagent
+
+```markdown
+## Refactoring Workflow
+
+1. Analyze codebase for duplication
+2. Apply DRY principle
+3. Consolidate code
+4. Verify with tests
+5. **UPDATE PLAN.md** ← Add this step
+   - Mark refactoring tasks as complete
+   - Add notes about changes made
+6. Report results
+```
+
+### In testing-subagent
+
+```markdown
+## Test Generation Workflow
+
+1. Analyze code to test
+2. Generate comprehensive tests
+3. Run tests to verify
+4. **UPDATE PLAN.md** ← Add this step
+   - Mark test-related tasks complete
+   - Note coverage improvements
+5. Report coverage
+```
+
+## Verification
+
+After updating PLAN:
+
+```bash
+# Verify PLAN was updated
+git log -1 --oneline
+
+# Should show something like:
+# abc1234 docs(plan): update PLAN-GIT-123.md with current progress
+
+# Check PLAN content
+grep "\- \[x\]" "$PLAN_FILE" | wc -l
+echo "Completed tasks in PLAN"
+```
+
+## References
+
+- `git-issue-plan-workflow` - Creates GitHub issue PLAN files
+- `jira-ticket-plan-workflow` - Creates JIRA ticket PLAN files
+- `git-issue-updater` - Updates issues with commit progress
+- `git-semantic-commits` - Commit message formatting


### PR DESCRIPTION
## Summary

- **New skill**: `plan-updater` — reusable skill for automatic PLAN.md synchronization that detects branch names, finds matching PLAN files, updates progress checkboxes, and commits changes with semantic format
- **Subagent integration**: Added `plan-updater` skill permission and workflow step to 4 code-implementing subagents:
  - `pr-workflow-subagent` — syncs PLAN before PR creation
  - `refactoring-subagent` — syncs PLAN after refactoring completion
  - `testing-subagent` — syncs PLAN after test creation
  - `ticket-creation-subagent` — syncs PLAN when returning to existing tickets
- **Documentation sync**: Updated skill counts (49 → 50) and Git/Workflow category in `setup.sh`, `setup.ps1`, and `README.md`
- Supports both GitHub (`PLAN-GIT-*.md`) and JIRA (`PLAN-*.md`) naming conventions
- Graceful skip when no PLAN file exists for the current branch

Closes #124

## Test Plan

- [ ] Verify `skills/plan-updater/SKILL.md` is properly structured and deployable
- [ ] Verify all 4 subagents include `plan-updater: allow` in permissions
- [ ] Verify setup.sh and setup.ps1 deploy the new skill correctly
- [ ] Verify README.md reflects 50 skills and includes plan-updater in Git/Workflow category
- [ ] Verify graceful skip behavior when invoked on branches without PLAN files