### PR TITLE
feat(agents): update skill-broker steps and explore-primary model

### DIFF
--- a/agents/explore-primary-agent.md
+++ b/agents/explore-primary-agent.md
@@ -1,7 +1,7 @@
 ---
 description: Fast agent specialized for exploring codebases. Find files by patterns, search code for keywords, and answer questions about codebase structure.
 mode: primary
-model: zai-coding-plan/glm-4.7
+model: claude-sonnet-4.5
 permission:
   read: allow
   write: deny

--- a/agents/skill-broker-subagent.md
+++ b/agents/skill-broker-subagent.md
@@ -3,7 +3,7 @@ description: Finds ALL relevant subagents and skills for a task. Returns JSON ar
 mode: subagent
 model: zai-coding-plan/glm-5-turbo
 temperature: 0.1
-steps: 2
+steps: 15
 hidden: true
 permission:
   read:


### PR DESCRIPTION
## Summary
- Increase `skill-broker-subagent` max steps from 2 to 15 for complex discovery scenarios
- Update `explore-primary-agent` model from `glm-4.7` to `claude-sonnet-4.5`

## Changes
| File | Change |
|------|--------|
| `agents/skill-broker-subagent.md` | `steps: 2` → `steps: 15` |
| `agents/explore-primary-agent.md` | `model: glm-4.7` → `model: claude-sonnet-4.5` |

## Related
Closes BT-38