### PR TITLE
fix(mcp): migrate Atlassian MCP endpoint from /v1/sse to /v1/mcp

### DIFF
--- a/PLANS/PLAN-GIT-148.md
+++ b/PLANS/PLAN-GIT-148.md
@@ -1,0 +1,52 @@
+# Plan: Migrate Atlassian MCP server from deprecated /v1/sse to /v1/mcp endpoint
+
+## Issue Reference
+- **Number**: #148
+- **URL**: https://github.com/darellchua2/opencode-config-template/issues/148
+- **Labels**: enhancement, patch
+
+## Overview
+
+The Atlassian MCP server is currently configured to use the deprecated `/v1/sse` endpoint via `mcp-remote`. Atlassian now recommends using the `/v1/mcp` endpoint instead. This issue migrates the endpoint URL in `config.json` and verifies no other files reference the old URL.
+
+## Acceptance Criteria
+- [ ] Update `config.json` Atlassian MCP entry from `/v1/sse` to `/v1/mcp`
+- [ ] Verify no other files in the repo reference the old `/v1/sse` endpoint
+- [ ] `config.json` remains valid JSON after the change
+- [ ] `setup.sh` and `setup.ps1` do not reference the old endpoint (or are updated if they do)
+
+## Scope
+- `config.json` (line 36) — primary change
+- `setup.sh` / `setup.ps1` — verify no references
+
+---
+
+## Implementation Phases
+
+### Phase 1: Implementation
+- [ ] Update `config.json` Atlassian MCP URL from `https://mcp.atlassian.com/v1/sse` to `https://mcp.atlassian.com/v1/mcp`
+- [ ] Search `setup.sh` and `setup.ps1` for any references to the old endpoint
+- [ ] Update if found
+- [ ] Validate `config.json` is valid JSON
+
+### Phase 2: Validation
+- [ ] Verify `config.json` is valid JSON with `jq`
+- [ ] Confirm no remaining references to `/v1/sse` in the repo
+
+---
+
+## Technical Notes
+
+- Atlassian officially recommends migrating from `/sse` to `/mcp` per their README
+- The proxy command (`npx -y mcp-remote`) remains unchanged
+- No authentication changes required
+- This is a URL-only change
+
+## Dependencies
+None.
+
+## Risks & Mitigation
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Invalid JSON after edit | Low | Validate with `jq` after edit |
+| `/v1/mcp` endpoint not yet supported by `mcp-remote` | Low | Atlassian docs confirm it works with remote MCP clients |

--- a/PLANS/PLAN-GIT-148.md
+++ b/PLANS/PLAN-GIT-148.md
@@ -10,10 +10,10 @@
 The Atlassian MCP server is currently configured to use the deprecated `/v1/sse` endpoint via `mcp-remote`. Atlassian now recommends using the `/v1/mcp` endpoint instead. This issue migrates the endpoint URL in `config.json` and verifies no other files reference the old URL.
 
 ## Acceptance Criteria
-- [ ] Update `config.json` Atlassian MCP entry from `/v1/sse` to `/v1/mcp`
-- [ ] Verify no other files in the repo reference the old `/v1/sse` endpoint
-- [ ] `config.json` remains valid JSON after the change
-- [ ] `setup.sh` and `setup.ps1` do not reference the old endpoint (or are updated if they do)
+- [x] Update `config.json` Atlassian MCP entry from `/v1/sse` to `/v1/mcp`
+- [x] Verify no other files in the repo reference the old `/v1/sse` endpoint
+- [x] `config.json` remains valid JSON after the change
+- [x] `setup.sh` and `setup.ps1` do not reference the old endpoint (or are updated if they do)
 
 ## Scope
 - `config.json` (line 36) — primary change
@@ -24,14 +24,14 @@ The Atlassian MCP server is currently configured to use the deprecated `/v1/sse`
 ## Implementation Phases
 
 ### Phase 1: Implementation
-- [ ] Update `config.json` Atlassian MCP URL from `https://mcp.atlassian.com/v1/sse` to `https://mcp.atlassian.com/v1/mcp`
-- [ ] Search `setup.sh` and `setup.ps1` for any references to the old endpoint
-- [ ] Update if found
-- [ ] Validate `config.json` is valid JSON
+- [x] Update `config.json` Atlassian MCP URL from `https://mcp.atlassian.com/v1/sse` to `https://mcp.atlassian.com/v1/mcp`
+- [x] Search `setup.sh` and `setup.ps1` for any references to the old endpoint
+- [x] Update if found (none found)
+- [x] Validate `config.json` is valid JSON
 
 ### Phase 2: Validation
-- [ ] Verify `config.json` is valid JSON with `jq`
-- [ ] Confirm no remaining references to `/v1/sse` in the repo
+- [x] Verify `config.json` is valid JSON with `jq`
+- [x] Confirm no remaining references to `/v1/sse` in the repo
 
 ---
 

--- a/config.json
+++ b/config.json
@@ -33,7 +33,7 @@
         "npx",
         "-y",
         "mcp-remote",
-        "https://mcp.atlassian.com/v1/sse"
+        "https://mcp.atlassian.com/v1/mcp"
       ],
       "enabled": true
     },


### PR DESCRIPTION
## Summary
- Migrate Atlassian MCP server from deprecated `/v1/sse` to recommended `/v1/mcp` endpoint per [Atlassian's guidance](https://github.com/atlassian/atlassian-mcp-server)
- URL-only change in `config.json`; proxy command and auth remain unchanged

Closes #148