### PR TITLE
feat(agents): add built-in subagent task permissions to top 5 agents

### DIFF
--- a/PLANS/PLAN-GIT-167.md
+++ b/PLANS/PLAN-GIT-167.md
@@ -1,0 +1,53 @@
+# PLAN-GIT-167: Add Built-in Subagent Task Permissions to Top 5 Agents
+
+## Overview
+
+Add `task` permissions to the top 5 subagents so they can delegate codebase exploration and multi-step work to OpenCode's built-in `explore` and `general` subagents. This is P0 from the subagent integration analysis.
+
+## Problem
+
+Currently, 0 of 30 agents have `task` permissions configured to use built-in subagents. This means:
+- Agents manually glob/grep for files when `explore` could do it faster
+- Agents run sequential steps when `general` could parallelize them
+- No delegation chain exists between custom agents and built-in capabilities
+
+## Acceptance Criteria
+
+- [ ] Top 5 agents have `task` permissions in their frontmatter
+- [ ] Each agent's instructions reference when to delegate to `explore` or `general`
+- [ ] No breaking changes to existing agent behavior
+- [ ] Permission format follows existing patterns (see `pptx-specialist-subagent`)
+
+## Scope
+
+| File | Agent | Task Permission |
+|------|-------|----------------|
+| `agents/code-review-subagent.md` | Code Review | `explore: allow` |
+| `agents/testing-subagent.md` | Testing | `explore: allow` |
+| `agents/linting-subagent.md` | Linting | `explore: allow` |
+| `agents/pr-workflow-subagent.md` | PR Workflow | `explore: allow`, `general: allow` |
+| `agents/refactoring-subagent.md` | Refactoring | `explore: allow`, `general: allow` |
+
+---
+
+## Phase 1: Add Task Permissions to Agent Frontmatter
+
+- [ ] Update `agents/code-review-subagent.md` - add `task: explore: allow`
+- [ ] Update `agents/testing-subagent.md` - add `task: explore: allow`
+- [ ] Update `agents/linting-subagent.md` - add `task: explore: allow`
+- [ ] Update `agents/pr-workflow-subagent.md` - add `task: explore: allow, general: allow`
+- [ ] Update `agents/refactoring-subagent.md` - add `task: explore: allow, general: allow`
+
+## Phase 2: Add Delegation Instructions to Agent Bodies
+
+- [ ] Add `explore` delegation guidance to `code-review-subagent.md` (delegate codebase scanning)
+- [ ] Add `explore` delegation guidance to `testing-subagent.md` (delegate test discovery)
+- [ ] Add `explore` delegation guidance to `linting-subagent.md` (delegate config detection)
+- [ ] Add `explore` + `general` delegation guidance to `pr-workflow-subagent.md` (parallelize checks)
+- [ ] Add `explore` + `general` delegation guidance to `refactoring-subagent.md` (parallel refactors)
+
+## Phase 3: Validation
+
+- [ ] Verify YAML frontmatter is valid for all 5 files
+- [ ] Verify permission format matches existing patterns
+- [ ] Commit with semantic message

--- a/README.md
+++ b/README.md
@@ -159,36 +159,38 @@ This repository implements **skill modularization** with 53 skills organized acr
 
 #### Subagents
 
-| Subagent | Purpose | Skills |
-|----------|---------|--------|
-| **linting-subagent** | Code quality and style (Python, JS/TS, Java Spring Boot, C# .NET) | linting-workflow, python-ruff-linter, javascript-eslint-linter |
-| **testing-subagent** | Test generation and execution | test-generator-framework, python-pytest-creator, nextjs-unit-test-creator |
-| **tdd-subagent** | Test-driven development workflow | tdd-workflow, test-generator-framework |
-| **pr-workflow-subagent** | Pull request creation | pr-creation-workflow, nextjs-pr-workflow |
-| **ticket-creation-subagent** | Issue/ticket creation | ticket-plan-workflow-skill |
-| **documentation-subagent** | Documentation generation | docstring-generator, coverage-readme-workflow |
-| **coverage-subagent** | Coverage reporting | coverage-readme-workflow |
-| **opentofu-explorer-subagent** | Infrastructure as code | 7 OpenTofu skills (AWS, K8s, Keycloak, Neon, ECR) |
-| **code-quality-subagent** | SOLID, clean code, code smells | solid-principles, clean-code, code-smells |
-| **architecture-review-subagent** | Architecture and design patterns | clean-architecture, design-patterns, complexity-management |
-| **code-review-subagent** | Comprehensive code review | All 7 Code Quality skills |
-| **refactoring-subagent** | Code refactoring | solid-principles, code-smells, clean-code |
-| **error-resolver-subagent** | Error diagnosis and resolution | error-resolver-workflow |
-| **nextjs-setup-subagent** | Next.js project setup | nextjs-standard-setup (also see docstring-generator for TSDoc) |
-| **opencode-tooling-subagent** | Skills, agents, and rules creation + doc sync | opencode-skill-creation, opencode-agent-creation, opencode-skills-maintainer, documentation-sync-workflow |
-| **docx-creation-subagent** | Word document creation | docx-creation |
-| **diagram-subagent** | ASCII diagrams and images | ascii-diagram-creator, mermaid-diagram-creator |
-| **mermaid-diagram-subagent** | Mermaid diagrams with PNG conversion | mermaid-diagram-creator |
-| **image-analyzer-subagent** | Image analysis and conversion | (built-in capabilities) |
-| **google-mcp-specialist-subagent** | Google Cloud MCP setup and usage | google-bigquery, google-maps, google-gce, google-gke |
-| **autodesk-specialist-subagent** | Autodesk API integration | autodesk-revit, autodesk-model-data, autodesk-fusion |
-| **civil-3d-specialist-subagent** | Autodesk Civil 3D model modifications and features | (documentation search + version-specific guidance) |
-| **microsoft-m365-specialist-subagent** | Microsoft 365 MCP setup and usage | microsoft-teams, microsoft-mail, microsoft-calendar, microsoft-sharepoint |
-| **open3d-specialist-subagent** | Open3D 3D data processing guidance | (documentation search + version-specific guidance) |
-| **explorer-subagent** | Fast codebase exploration and analysis | (built-in search capabilities) |
-| **nextjs-mcp-advisor-subagent** | Next.js runtime guidance with MCP | nextjs-pr-workflow, nextjs-unit-test-creator |
-| **pptx-specialist-subagent** | PowerPoint presentations (read, create, edit, analyze) | pptx-specialist |
-| **startup-ceo-subagent** | Startup presentations (pitch decks, investor slides, board updates) | pptx-specialist |
+| Subagent | Purpose | Skills | Built-in Delegation |
+|----------|---------|--------|---------------------|
+| **linting-subagent** | Code quality and style (Python, JS/TS, Java Spring Boot, C# .NET) | linting-workflow, python-ruff-linter, javascript-eslint-linter | `explore` |
+| **testing-subagent** | Test generation and execution | test-generator-framework, python-pytest-creator, nextjs-unit-test-creator | `explore` |
+| **tdd-subagent** | Test-driven development workflow | tdd-workflow, test-generator-framework | — |
+| **pr-workflow-subagent** | Pull request creation | pr-creation-workflow, nextjs-pr-workflow | `explore`, `general` |
+| **ticket-creation-subagent** | Issue/ticket creation | ticket-plan-workflow-skill | — |
+| **documentation-subagent** | Documentation generation | docstring-generator, coverage-readme-workflow | — |
+| **coverage-subagent** | Coverage reporting | coverage-readme-workflow | — |
+| **opentofu-explorer-subagent** | Infrastructure as code | 7 OpenTofu skills (AWS, K8s, Keycloak, Neon, ECR) | — |
+| **code-quality-subagent** | SOLID, clean code, code smells | solid-principles, clean-code, code-smells | — |
+| **architecture-review-subagent** | Architecture and design patterns | clean-architecture, design-patterns, complexity-management | — |
+| **code-review-subagent** | Comprehensive code review | All 7 Code Quality skills | `explore` |
+| **refactoring-subagent** | Code refactoring | solid-principles, code-smells, clean-code | `explore`, `general` |
+| **error-resolver-subagent** | Error diagnosis and resolution | error-resolver-workflow | — |
+| **nextjs-setup-subagent** | Next.js project setup | nextjs-standard-setup (also see docstring-generator for TSDoc) | — |
+| **opencode-tooling-subagent** | Skills, agents, and rules creation + doc sync | opencode-skill-creation, opencode-agent-creation, opencode-skills-maintainer, documentation-sync-workflow | — |
+| **docx-creation-subagent** | Word document creation | docx-creation | — |
+| **diagram-subagent** | ASCII diagrams and images | ascii-diagram-creator, mermaid-diagram-creator | — |
+| **mermaid-diagram-subagent** | Mermaid diagrams with PNG conversion | mermaid-diagram-creator | — |
+| **image-analyzer-subagent** | Image analysis and conversion | (built-in capabilities) | — |
+| **google-mcp-specialist-subagent** | Google Cloud MCP setup and usage | google-bigquery, google-maps, google-gce, google-gke | — |
+| **autodesk-specialist-subagent** | Autodesk API integration | autodesk-revit, autodesk-model-data, autodesk-fusion | — |
+| **civil-3d-specialist-subagent** | Autodesk Civil 3D model modifications and features | (documentation search + version-specific guidance) | — |
+| **microsoft-m365-specialist-subagent** | Microsoft 365 MCP setup and usage | microsoft-teams, microsoft-mail, microsoft-calendar, microsoft-sharepoint | — |
+| **open3d-specialist-subagent** | Open3D 3D data processing guidance | (documentation search + version-specific guidance) | — |
+| **explorer-subagent** | Fast codebase exploration and analysis | (built-in search capabilities) | — |
+| **nextjs-mcp-advisor-subagent** | Next.js runtime guidance with MCP | nextjs-pr-workflow, nextjs-unit-test-creator | — |
+| **pptx-specialist-subagent** | PowerPoint presentations (read, create, edit, analyze) | pptx-specialist | — |
+| **startup-ceo-subagent** | Startup presentations (pitch decks, investor slides, board updates) | pptx-specialist | — |
+
+> **Built-in Delegation**: Subagents with `explore` can delegate codebase scanning to the built-in `explore` subagent. Subagents with `general` can delegate parallelizable multi-step work to the built-in `general` subagent. Access is controlled via `task` permissions in each agent's frontmatter (`"*": deny` by default, explicit allowlist).
 
 #### Trigger Phrases
 
@@ -268,18 +270,18 @@ This repository includes 7 new code quality skills for writing senior-engineer q
 ### Code Quality Subagents
 3 new subagents provide specialized code quality analysis:
 
-| Subagent | Purpose | Skills Used |
-|----------|---------|-------------|
-| `code-quality-subagent` | SOLID principles, clean code, code smells | solid-principles, clean-code, code-smells |
-| `architecture-review-subagent` | Architecture review and design patterns | clean-architecture, design-patterns, complexity-management |
-| `code-review-subagent` | Comprehensive code review (all quality skills) | All 7 quality skills |
+| Subagent | Purpose | Skills Used | Built-in Delegation |
+|----------|---------|-------------|---------------------|
+| `code-quality-subagent` | SOLID principles, clean code, code smells | solid-principles, clean-code, code-smells | — |
+| `architecture-review-subagent` | Architecture review and design patterns | clean-architecture, design-patterns, complexity-management | — |
+| `code-review-subagent` | Comprehensive code review (all quality skills) | All 7 quality skills | `explore` |
 
 ### Enhanced Subagent
-The `refactoring-subagent` has been enhanced with new skills:
+The `refactoring-subagent` has been enhanced with new skills and built-in subagent delegation:
 
-| Subagent | New Skills Added |
-|----------|------------------|
-| `refactoring-subagent` | solid-principles, code-smells, clean-code |
+| Subagent | New Skills Added | Built-in Delegation |
+|----------|------------------|---------------------|
+| `refactoring-subagent` | solid-principles, code-smells, clean-code | `explore`, `general` |
 
 ### Related Existing Skills
 | New Skill | Related Existing Skills |

--- a/agents/code-review-subagent.md
+++ b/agents/code-review-subagent.md
@@ -9,6 +9,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  task:
+    "*": deny
+    explore: allow
   skill:
     solid-principles: allow
     clean-code: allow
@@ -78,6 +81,14 @@ Output Format:
 ## Recommended Actions (Priority Order)
 1. ...
 2. ...
+
+Built-in Subagent Delegation:
+- Delegate to `explore` for codebase scanning tasks:
+  - Finding files matching patterns (glob) before review
+  - Searching for specific code patterns (SOLID violations, code smells, design anti-patterns)
+  - Mapping class hierarchies and dependency graphs
+  - Locating related files across the project
+- Use `explore` via Task tool with subagent_type="explore" when initial codebase exploration is needed before focused review
 
 Delegation:
 - Code changes: Request from parent agent (read-only review)

--- a/agents/linting-subagent.md
+++ b/agents/linting-subagent.md
@@ -9,6 +9,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  task:
+    "*": deny
+    explore: allow
   skill:
     linting-workflow: allow
     python-ruff-linter: allow
@@ -22,6 +25,14 @@ You are a linting specialist. Analyze code quality and enforce best practices us
 - Java Spring Boot: Use Checkstyle (style), SpotBugs (bugs), PMD (patterns), and spring-javaformat (Spring conventions)
 - C# .NET 10: Use `dotnet format`, StyleCop analyzers, Roslyn analyzers, and .NET code quality analyzers
 - Generic: Use linting-workflow for cross-language linting with auto-fix
+
+Built-in Subagent Delegation:
+- Delegate to `explore` for language and config detection:
+  - Scanning for linter config files (.eslintrc*, pyproject.toml, ruff.toml, checkstyle.xml, .editorconfig)
+  - Detecting project languages from file extensions and build files
+  - Finding lint-related scripts in package.json, Makefile, pyproject.toml
+  - Identifying monorepo structures with multiple linting configurations
+- Use `explore` via Task tool with subagent_type="explore" for initial project structure analysis before selecting linter
 
 ## Language Detection & Linter Selection
 

--- a/agents/pr-workflow-subagent.md
+++ b/agents/pr-workflow-subagent.md
@@ -10,6 +10,10 @@ permission:
   grep: allow
   bash: allow
   atlassian*: allow
+  task:
+    "*": deny
+    explore: allow
+    general: allow
   skill:
     semantic-release-convention: allow
     pr-creation-workflow: allow
@@ -62,6 +66,17 @@ JIRA Integration:
 JIRA MCP Tools:
 - atlassian_jira_add_comment: Add PR link to ticket
 - atlassian_jira_transitions: Transition ticket to "In Review" / "Done"
+
+Built-in Subagent Delegation:
+- Delegate to `explore` for project analysis:
+  - Detecting project framework, language, and build tools
+  - Finding test runners, lint configs, and CI/CD pipelines
+  - Mapping project structure for PR scope assessment
+- Delegate to `general` for parallelizable quality checks:
+  - Run lint + typecheck in parallel (both are independent reads)
+  - Generate coverage report while preparing PR description
+  - Collect JIRA ticket info while running build checks
+- Use `explore` via Task tool with subagent_type="explore" for discovery, `general` via subagent_type="general" for parallel work
 
 Subagent Coordination:
 - Delegate to linting-subagent for code quality checks

--- a/agents/refactoring-subagent.md
+++ b/agents/refactoring-subagent.md
@@ -9,6 +9,10 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  task:
+    "*": deny
+    explore: allow
+    general: allow
   skill:
     typescript-dry-principle: allow
     solid-principles: allow
@@ -58,6 +62,17 @@ Best Practices:
 - Type safety with generics
 - Extract early
 - Utility-first approach
+
+Built-in Subagent Delegation:
+- Delegate to `explore` for codebase analysis:
+  - Finding duplicate code patterns across files
+  - Mapping class hierarchies and interface implementations
+  - Locating files with similar exports, interfaces, and function signatures
+  - Identifying shared logic that could be consolidated
+- Delegate to `general` for parallel refactoring:
+  - Refactor independent modules simultaneously (e.g., extract utilities from files A-C, D-F in parallel)
+  - Run type-check and lint in parallel after refactoring to verify changes
+- Use `explore` via Task tool with subagent_type="explore" for analysis, `general` via subagent_type="general" for parallel work
 
 Delegation:
 - Build/test commands: Request from parent agent

--- a/agents/testing-subagent.md
+++ b/agents/testing-subagent.md
@@ -9,6 +9,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  task:
+    "*": deny
+    explore: allow
   skill:
     test-generator-framework: allow
     tdd-workflow: allow
@@ -23,6 +26,14 @@ You are a testing specialist. Generate comprehensive tests following industry be
 - Python: Use python-pytest-creator for pytest-based tests with fixtures and parametrization
 - Next.js: Use nextjs-unit-test-creator for App Router, Server Components, API routes, and Server Actions
 - Generic: Use test-generator-framework for cross-language test generation
+
+Built-in Subagent Delegation:
+- Delegate to `explore` for test discovery tasks:
+  - Finding existing test files and test directories
+  - Locating test framework configuration (conftest.py, jest.config, vitest.config, etc.)
+  - Mapping test fixtures and shared test utilities
+  - Identifying untested source files by comparing src/ vs test/ structures
+- Use `explore` via Task tool with subagent_type="explore" when initial test structure analysis is needed
 
 Workflow:
 1. Analyze the code to be tested (functions, classes, components)


### PR DESCRIPTION
## Summary

- Add `task` permissions to the top 5 subagents enabling them to delegate work to OpenCode's built-in `explore` and `general` subagents
- Previously, 0 of 30 agents could delegate to built-in subagents — all codebase scanning and multi-step work was done manually via glob/grep

Closes #167

## Changes

### Agent Frontmatter Permissions (7 files changed, +157 / -39)

| Agent | Task Permissions Added | Delegation Use Case |
|-------|----------------------|---------------------|
| **code-review-subagent** | `explore: allow` | Codebase scanning before focused review — find files, search for SOLID violations, map class hierarchies |
| **testing-subagent** | `explore: allow` | Test discovery — find existing tests, locate framework configs, identify untested source files |
| **linting-subagent** | `explore: allow` | Config detection — scan for linter configs, detect project languages, identify monorepo structures |
| **pr-workflow-subagent** | `explore: allow`, `general: allow` | Project analysis + parallel quality checks (lint + typecheck simultaneously) |
| **refactoring-subagent** | `explore: allow`, `general: allow` | Duplicate code detection + parallel module refactoring |

### Documentation

- **README.md**: Added "Built-in Delegation" column to the Subagents table showing which agents can delegate to built-in subagents, with an explanatory footnote on the permission model
- **PLANS/PLAN-GIT-167.md**: Implementation plan with 3 phases (frontmatter → delegation instructions → validation)

## Permission Format

```yaml
task:
  "*": deny          # Default deny-all
  explore: allow     # Opt-in for codebase exploration
  general: allow     # Opt-in for parallel multi-step work (select agents only)
```

This follows the existing `pptx-specialist-subagent` pattern with explicit allowlist and default deny.

## Semantic Versioning

**`minor`** — New capability (built-in subagent delegation) added to existing agents. No breaking changes; existing agent behavior is fully preserved.

## Commits

1. `900d48a` — `docs(plan): add PLAN-GIT-167 for built-in subagent task permissions`
2. `b76be5e` — `feat(agents): add built-in subagent task permissions to top 5 agents`
3. `0f34c17` — `docs: update README with built-in subagent delegation column`