### PR TITLE
feat(docker): enhance Docker Compose with code execution, persistent volumes, folder passthrough, and git support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,13 @@ GEMINI_API_KEY=
 
 # External port for the OpenCode web endpoint (default: 4097)
 OPENCODE_PORT=4097
+
+# ─── Workspace ─────────────────────────────────────────────────────────────────
+# Primary host directory mounted as /workspace in the container
+# For multiple directories, uncomment extra lines in docker-compose.yml
+WORKSPACE_DIR=~/VSCODE
+
+# ─── Git Identity ──────────────────────────────────────────────────────────────
+# Used for git commits inside the container
+GIT_USER_NAME=
+GIT_USER_EMAIL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,19 @@ services:
     ports:
       - "${OPENCODE_PORT:-4097}:4096"
     volumes:
+      # OpenCode internal state (sessions, history, auth)
       - opencode-data:/home/opencode/.local/share/opencode
+      # Primary workspace — set WORKSPACE_DIR in .env (e.g. ~/VSCODE)
+      - ${WORKSPACE_DIR:-~/Projects}:/workspace
+      # ── Additional workspace mounts (uncomment as needed) ──────────
+      # - ~/other-project:/workspace-extra/project-name
+      # - ~/another-dir:/workspace-extra/another
+      # ───────────────────────────────────────────────────────────────
+      # GitHub SSH keys (read-only staging, copied in entrypoint)
+      - ~/.ssh:/tmp/ssh-host:ro
+      # Persistent tool caches (survive container rebuilds)
+      - npm-cache:/home/opencode/.npm
+      - pip-cache:/home/opencode/.cache/pip
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4096/global/health"]
@@ -18,3 +30,5 @@ services:
 
 volumes:
   opencode-data:
+  npm-cache:
+  pip-cache:

--- a/opencode_app/Dockerfile
+++ b/opencode_app/Dockerfile
@@ -15,10 +15,14 @@ RUN apt-get update \
         python3-venv \
         ca-certificates \
         curl \
+        git \
+        openssh-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g "opencode-ai@${OPENCODE_VERSION}"
+RUN npm install -g "opencode-ai@${OPENCODE_VERSION}" \
+    typescript \
+    ts-node
 
 RUN python3 -m venv /opt/python-env
 ENV PATH="/opt/python-env/bin:${PATH}"
@@ -26,7 +30,10 @@ ENV PATH="/opt/python-env/bin:${PATH}"
 RUN pip install --no-cache-dir \
     "openpyxl>=3.1.0" \
     "pandas>=3.0.0" \
-    "pdfplumber>=0.11.0"
+    "pdfplumber>=0.11.0" \
+    "requests>=2.32.0" \
+    "numpy>=2.0.0" \
+    "fastapi>=0.115.0"
 
 RUN useradd -m -d /home/opencode -s /bin/bash opencode
 

--- a/opencode_app/docker-entrypoint.sh
+++ b/opencode_app/docker-entrypoint.sh
@@ -33,5 +33,46 @@ else:
     print("OpenCode will start but LLM calls will fail without authentication")
 PYEOF
 
+# ── SSH key setup ───────────────────────────────────────────────────────────
+if [ -d /tmp/ssh-host ] && [ "$(ls -A /tmp/ssh-host 2>/dev/null)" ]; then
+    mkdir -p ~/.ssh
+    chmod 700 ~/.ssh
+    cp -r /tmp/ssh-host/* ~/.ssh/ 2>/dev/null || true
+    chmod 600 ~/.ssh/id_* 2>/dev/null || true
+    chmod 600 ~/.ssh/config 2>/dev/null || true
+    chmod 644 ~/.ssh/*.pub 2>/dev/null || true
+    touch ~/.ssh/known_hosts
+    chmod 644 ~/.ssh/known_hosts
+    echo "SSH keys copied from host with correct permissions"
+else
+    mkdir -p ~/.ssh
+    chmod 700 ~/.ssh
+    touch ~/.ssh/known_hosts
+    echo "No SSH keys found at /tmp/ssh-host — skipping SSH setup"
+fi
+
+# Add github.com to known_hosts (prevents first-connect prompt)
+if ! grep -q "github.com" ~/.ssh/known_hosts 2>/dev/null; then
+    ssh-keyscan -t ed25519,rsa github.com >> ~/.ssh/known_hosts 2>/dev/null || true
+    echo "Added github.com to known_hosts"
+fi
+
+# ── Git identity ────────────────────────────────────────────────────────────
+GIT_USER_NAME="${GIT_USER_NAME:-}"
+GIT_USER_EMAIL="${GIT_USER_EMAIL:-}"
+
+if [ -n "${GIT_USER_NAME}" ]; then
+    git config --global user.name "${GIT_USER_NAME}"
+    echo "Set git user.name: ${GIT_USER_NAME}"
+fi
+if [ -n "${GIT_USER_EMAIL}" ]; then
+    git config --global user.email "${GIT_USER_EMAIL}"
+    echo "Set git user.email: ${GIT_USER_EMAIL}"
+fi
+
+# ── Workspace ───────────────────────────────────────────────────────────────
+mkdir -p /workspace
+mkdir -p /workspace-extra 2>/dev/null || true
+
 echo "Starting OpenCode server on ${HOST}:${PORT}..."
 exec opencode serve --port "${PORT}" --hostname "${HOST}"


### PR DESCRIPTION
## Summary

Enhances the Docker standalone mode with full code execution capabilities, persistent tool caches, host folder passthrough, and git/SSH support — enabling agents to run Python & TypeScript scripts, edit host files, and commit to GitHub directly from the container.

Closes #171

## Changes

### `docker-compose.yml`
- **Workspace bind mount**: `$WORKSPACE_DIR` → `/workspace` with commented examples for additional directories
- **SSH key passthrough**: `~/.ssh` → `/tmp/ssh-host:ro` (read-only staging; entrypoint copies with correct permissions)
- **Persistent named volumes**: `npm-cache` (`/home/opencode/.npm`) and `pip-cache` (`/home/opencode/.cache/pip`) — survive `docker compose down`

### `opencode_app/Dockerfile`
- Added `git` and `openssh-client` (for git operations and SSH-based git)
- Added `typescript` and `ts-node` (for running TypeScript scripts via `npx ts-node`)
- Added `requests`, `numpy`, `fastapi` Python packages

### `opencode_app/docker-entrypoint.sh`
- SSH key setup: copies from `/tmp/ssh-host` to `~/.ssh` with 600/700 permissions
- Auto-adds `github.com` to `known_hosts` via `ssh-keyscan` (prevents first-connect prompt)
- Configures `git user.name` / `git user.email` from `GIT_USER_NAME` / `GIT_USER_EMAIL` env vars
- Creates `/workspace` and `/workspace-extra` directories

### `.env.example`
- `WORKSPACE_DIR=~/VSCODE` — primary host directory mounted as `/workspace`
- `GIT_USER_NAME=` / `GIT_USER_EMAIL=` — git identity for commits inside container

## Capabilities Enabled

| Capability | How |
|---|---|
| Run Python scripts | `python3` + venv already in image; pip cache persists in named volume |
| Run TypeScript scripts | `npx ts-node file.ts` or `npx tsc` — added to image |
| Work on host files | `$WORKSPACE_DIR` bind-mounted to `/workspace` — agents read/write host files |
| GitHub SSH | Host `~/.ssh` → container `~/.ssh` (proper 600/700 perms) + `github.com` in known_hosts |
| Git commits | `GIT_USER_NAME` / `GIT_USER_EMAIL` set via `.env` → `git config` in entrypoint |
| Tool cache persistence | `npm-cache` and `pip-cache` named volumes survive `docker compose down` |

## Files Changed

4 files changed, 74 insertions(+), 2 deletions(-)