### PR TITLE
feat(scripts): add git pull to pm2 restart script

### DIFF
--- a/restart-opencode-pm2.sh
+++ b/restart-opencode-pm2.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cd /home/silentx/VSCODE/opencode-config-template
+git checkout main
+git stash
+git pull
+git stash pop 2>/dev/null || true
+
 pm2 delete opencode 2>/dev/null || true
 pm2 start "opencode serve --hostname 0.0.0.0 --port 4096" --name opencode
 pm2 save


### PR DESCRIPTION
## Summary
- Adds `git checkout main`, `git stash`, `git pull`, and `git stash pop` steps to `restart-opencode-pm2.sh` before the pm2 restart
- Ensures the latest code is deployed on each scheduled restart (daily 3 AM via crontab)