### PR TITLE
fix(config): add missing codegraph MCP server to root config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,6 +27,17 @@
     }
   },
   "mcp": {
+    "codegraph": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@colbymchenry/codegraph",
+        "serve",
+        "--mcp"
+      ],
+      "enabled": true
+    },
     "atlassian": {
       "type": "local",
       "command": [
@@ -214,6 +225,7 @@
     }
   },
   "tools": {
+    "codegraph*": true,
     "atlassian*": true,
     "zai-web-reader*": true,
     "zai-vision-mcp-server*": false,


### PR DESCRIPTION
## Summary

Adds the missing `codegraph` MCP server definition and `codegraph*` tool permission to the root `config.json`.

## Problem

The setup script copies `config.json` from the repo root to `~/.config/opencode/config.json`, but the codegraph entry only existed in `opencode_app/opencode.json` (Docker-only config). This meant codegraph was never available after running setup.

## Changes

- Added `codegraph` MCP server entry to `mcp` block (matching `opencode_app/opencode.json`)
- Added `"codegraph*": true` to `tools` block

## Test Plan

- [x] Diff matches `opencode_app/opencode.json` codegraph entry exactly
- [ ] Re-run `setup.sh --quick` and verify `~/.config/opencode/config.json` includes codegraph
- [ ] Restart opencode in a project with `.codegraph/` index and verify codegraph tools are available

Closes #190