### PR TITLE
docs(subagents): add CodeGraph integration instructions to subagent .md files

### DIFF
--- a/PLANS/PLAN-GIT-192.md
+++ b/PLANS/PLAN-GIT-192.md
@@ -42,45 +42,45 @@ If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
 ### 1.1 `explorer-subagent.md` — CodeGraph as primary exploration tool
 
-- [ ] Add `## CodeGraph Integration` section after existing tool guidance
-- [ ] `codegraph_explore` replaces multi-file grep/glob chains (primary tool for exploration)
-- [ ] `codegraph_context` replaces manual context building
-- [ ] `codegraph_search` replaces grep for symbol name lookups
-- [ ] `codegraph_files` replaces glob for file structure queries
-- [ ] `codegraph_node` replaces Read for single symbol details
-- [ ] Document fallback to grep/glob/read when `.codegraph/` doesn't exist
-- [ ] Exception: remote GitHub repos use `zai-zread` (CodeGraph is local-only)
+- [x] Add `## CodeGraph Integration` section after existing tool guidance
+- [x] `codegraph_explore` replaces multi-file grep/glob chains (primary tool for exploration)
+- [x] `codegraph_context` replaces manual context building
+- [x] `codegraph_search` replaces grep for symbol name lookups
+- [x] `codegraph_files` replaces glob for file structure queries
+- [x] `codegraph_node` replaces Read for single symbol details
+- [x] Document fallback to grep/glob/read when `.codegraph/` doesn't exist
+- [x] Exception: remote GitHub repos use `zai-zread` (CodeGraph is local-only)
 
 ### 1.2 `code-review-subagent.md` — CodeGraph for structural reviews
 
-- [ ] Add `## CodeGraph Integration` section after existing review methodology
-- [ ] `codegraph_impact` on changed files before starting review
-- [ ] `codegraph_callers`/`callees` to verify changed symbols don't break consumers
-- [ ] `codegraph_search` to find similar patterns across codebase
-- [ ] When delegating to `explore`: request "use codegraph_explore for structural analysis"
+- [x] Add `## CodeGraph Integration` section after existing review methodology
+- [x] `codegraph_impact` on changed files before starting review
+- [x] `codegraph_callers`/`callees` to verify changed symbols don't break consumers
+- [x] `codegraph_search` to find similar patterns across codebase
+- [x] When delegating to `explore`: request "use codegraph_explore for structural analysis"
 
 ### 1.3 `architecture-review-subagent.md` — CodeGraph for dependency analysis
 
-- [ ] Add `## CodeGraph Integration` section after existing analysis methodology
-- [ ] `codegraph_callers`/`callees` to map actual dependency graphs (not just imports)
-- [ ] `codegraph_explore` to verify dependency direction (domain -> infrastructure)
-- [ ] `codegraph_impact` with depth=3 to find high-coupling modules
-- [ ] When delegating to `explore`: request "use codegraph_explore for dependency analysis"
+- [x] Add `## CodeGraph Integration` section after existing analysis methodology
+- [x] `codegraph_callers`/`callees` to map actual dependency graphs (not just imports)
+- [x] `codegraph_explore` to verify dependency direction (domain -> infrastructure)
+- [x] `codegraph_impact` with depth=3 to find high-coupling modules
+- [x] When delegating to `explore`: request "use codegraph_explore for dependency analysis"
 
 ### 1.4 `refactoring-subagent.md` — CodeGraph for safe refactoring
 
-- [ ] Add `## CodeGraph Integration` section after existing refactoring methodology
-- [ ] `codegraph_callers` on symbols before changing — know ALL consumers first
-- [ ] `codegraph_impact` with depth=2 to assess change radius
-- [ ] `codegraph_search` + `codegraph_callees` to find symbols with identical call patterns
-- [ ] When delegating to `explore`: request "use codegraph_explore for pattern analysis"
+- [x] Add `## CodeGraph Integration` section after existing refactoring methodology
+- [x] `codegraph_callers` on symbols before changing — know ALL consumers first
+- [x] `codegraph_impact` with depth=2 to assess change radius
+- [x] `codegraph_search` + `codegraph_callees` to find symbols with identical call patterns
+- [x] When delegating to `explore`: request "use codegraph_explore for pattern analysis"
 
 ### 1.5 `testing-subagent.md` — CodeGraph for test discovery
 
-- [ ] Add `## CodeGraph Integration` section after existing test methodology
-- [ ] `codegraph_files` instead of glob chains for project layout
-- [ ] `codegraph_search` to find test-related symbols
-- [ ] When delegating to `explore`: request "use codegraph_files for structure and codegraph_search for test patterns"
+- [x] Add `## CodeGraph Integration` section after existing test methodology
+- [x] `codegraph_files` instead of glob chains for project layout
+- [x] `codegraph_search` to find test-related symbols
+- [x] When delegating to `explore`: request "use codegraph_files for structure and codegraph_search for test patterns"
 
 ---
 
@@ -88,9 +88,9 @@ If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
 ### 2.1 `opencode_app/AGENTS.md` — Add condensed CodeGraph section
 
-- [ ] Add CodeGraph tool priority table
-- [ ] Document per-project setup requirement (`codegraph init -i`)
-- [ ] Keep section concise (Docker AGENTS.md is a summary document)
+- [x] Add CodeGraph tool priority table
+- [x] Document per-project setup requirement (`codegraph init -i`)
+- [x] Keep section concise (Docker AGENTS.md is a summary document)
 
 ---
 
@@ -98,11 +98,11 @@ If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
 ### 3.1 `linting-subagent.md` — Brief CodeGraph mention
 
-- [ ] Add brief `codegraph_files` mention for project structure detection
+- [x] Add brief `codegraph_files` mention for project structure detection
 
 ### 3.2 `error-resolver-subagent.md` — Brief CodeGraph mention
 
-- [ ] Add brief `codegraph_node`/`codegraph_callers` mention for error tracing
+- [x] Add brief `codegraph_node`/`codegraph_callers` mention for error tracing
 
 ---
 
@@ -115,10 +115,10 @@ If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 ## Validation
 
 After all phases:
-- [ ] Grep `opencode_app/.opencode/agents/*.md` for "CodeGraph" — expect 7 files (5 critical + 2 optional)
-- [ ] Grep `opencode_app/AGENTS.md` for "CodeGraph" — expect at least 1 match
-- [ ] Verify each critical file has a tool priority table
-- [ ] Verify each critical file documents fallback behavior
+- [x] Grep `opencode_app/.opencode/agents/*.md` for "CodeGraph" — expect 7 files (5 critical + 2 optional)
+- [x] Grep `opencode_app/AGENTS.md` for "CodeGraph" — expect at least 1 match
+- [x] Verify each critical file has a tool priority table
+- [x] Verify each critical file documents fallback behavior
 
 ---
 

--- a/PLANS/PLAN-GIT-192.md
+++ b/PLANS/PLAN-GIT-192.md
@@ -1,0 +1,130 @@
+# PLAN-GIT-192: Add CodeGraph priority instructions to subagent .md files
+
+**Issue**: [#192](https://github.com/darellchua2/opencode-config-template/issues/192)
+**Branch**: `issue-192-codegraph-subagent-awareness`
+**Status**: Ready to begin execution
+
+---
+
+## Problem
+
+Zero out of 31 custom subagent `.md` files in `opencode_app/.opencode/agents/` mention CodeGraph. Subagents run in isolated sessions and only see their own `.md` file, not the global `AGENTS.md`. Agents doing code exploration have no CodeGraph awareness despite it being configured and available.
+
+## Solution
+
+Add a `## CodeGraph Integration` section to 5 critical subagent `.md` files + fix the Docker `AGENTS.md` gap.
+
+## Reusable Template
+
+Each agent receives this base pattern, customized with role-specific guidance:
+
+```markdown
+## CodeGraph Integration
+
+When `.codegraph/` exists in the project, prioritize CodeGraph tools over grep/glob/read:
+
+| CodeGraph Tool | Replaces | Use For |
+|---|---|---|
+| `codegraph_search` | grep for symbols | Find symbols by name |
+| `codegraph_callers` / `callees` | Manual import tracking | Trace call flow in/out |
+| `codegraph_impact` | File-by-file search | Assess change radius |
+| `codegraph_files` | glob chains | Get indexed file structure |
+| `codegraph_node` | Read full file | Get one symbol's details |
+
+For deep exploration, delegate to `explore` with instructions to use `codegraph_explore` as the primary tool.
+
+If `.codegraph/` does not exist, fall back to grep/glob/read normally.
+```
+
+---
+
+## Phase 1: Critical Subagents
+
+### 1.1 `explorer-subagent.md` — CodeGraph as primary exploration tool
+
+- [ ] Add `## CodeGraph Integration` section after existing tool guidance
+- [ ] `codegraph_explore` replaces multi-file grep/glob chains (primary tool for exploration)
+- [ ] `codegraph_context` replaces manual context building
+- [ ] `codegraph_search` replaces grep for symbol name lookups
+- [ ] `codegraph_files` replaces glob for file structure queries
+- [ ] `codegraph_node` replaces Read for single symbol details
+- [ ] Document fallback to grep/glob/read when `.codegraph/` doesn't exist
+- [ ] Exception: remote GitHub repos use `zai-zread` (CodeGraph is local-only)
+
+### 1.2 `code-review-subagent.md` — CodeGraph for structural reviews
+
+- [ ] Add `## CodeGraph Integration` section after existing review methodology
+- [ ] `codegraph_impact` on changed files before starting review
+- [ ] `codegraph_callers`/`callees` to verify changed symbols don't break consumers
+- [ ] `codegraph_search` to find similar patterns across codebase
+- [ ] When delegating to `explore`: request "use codegraph_explore for structural analysis"
+
+### 1.3 `architecture-review-subagent.md` — CodeGraph for dependency analysis
+
+- [ ] Add `## CodeGraph Integration` section after existing analysis methodology
+- [ ] `codegraph_callers`/`callees` to map actual dependency graphs (not just imports)
+- [ ] `codegraph_explore` to verify dependency direction (domain -> infrastructure)
+- [ ] `codegraph_impact` with depth=3 to find high-coupling modules
+- [ ] When delegating to `explore`: request "use codegraph_explore for dependency analysis"
+
+### 1.4 `refactoring-subagent.md` — CodeGraph for safe refactoring
+
+- [ ] Add `## CodeGraph Integration` section after existing refactoring methodology
+- [ ] `codegraph_callers` on symbols before changing — know ALL consumers first
+- [ ] `codegraph_impact` with depth=2 to assess change radius
+- [ ] `codegraph_search` + `codegraph_callees` to find symbols with identical call patterns
+- [ ] When delegating to `explore`: request "use codegraph_explore for pattern analysis"
+
+### 1.5 `testing-subagent.md` — CodeGraph for test discovery
+
+- [ ] Add `## CodeGraph Integration` section after existing test methodology
+- [ ] `codegraph_files` instead of glob chains for project layout
+- [ ] `codegraph_search` to find test-related symbols
+- [ ] When delegating to `explore`: request "use codegraph_files for structure and codegraph_search for test patterns"
+
+---
+
+## Phase 2: Docker Mode Fix
+
+### 2.1 `opencode_app/AGENTS.md` — Add condensed CodeGraph section
+
+- [ ] Add CodeGraph tool priority table
+- [ ] Document per-project setup requirement (`codegraph init -i`)
+- [ ] Keep section concise (Docker AGENTS.md is a summary document)
+
+---
+
+## Phase 3: Optional Enhancements (Low Priority)
+
+### 3.1 `linting-subagent.md` — Brief CodeGraph mention
+
+- [ ] Add brief `codegraph_files` mention for project structure detection
+
+### 3.2 `error-resolver-subagent.md` — Brief CodeGraph mention
+
+- [ ] Add brief `codegraph_node`/`codegraph_callers` mention for error tracing
+
+---
+
+## Exclusions
+
+- **Built-in agents** (`explore`, `general`): No changes needed — they receive CodeGraph instructions via `AGENTS.md` injection
+- **No code changes**: This is purely documentation in `.md` files
+- **No setup.sh/setup.ps1 changes**: Agent file contents don't affect deploy scripts
+
+## Validation
+
+After all phases:
+- [ ] Grep `opencode_app/.opencode/agents/*.md` for "CodeGraph" — expect 7 files (5 critical + 2 optional)
+- [ ] Grep `opencode_app/AGENTS.md` for "CodeGraph" — expect at least 1 match
+- [ ] Verify each critical file has a tool priority table
+- [ ] Verify each critical file documents fallback behavior
+
+---
+
+## Commit Strategy
+
+One commit per phase using conventional commits:
+1. `docs(subagents): add CodeGraph integration to critical subagent .md files` (Phase 1)
+2. `docs(docker): add CodeGraph section to Docker AGENTS.md` (Phase 2)
+3. `docs(subagents): add CodeGraph hints to linting and error-resolver subagents` (Phase 3)

--- a/opencode_app/.opencode/agents/architecture-review-subagent.md
+++ b/opencode_app/.opencode/agents/architecture-review-subagent.md
@@ -73,6 +73,18 @@ After completing the review, use the `continuous-learning` skill to persist find
 
 The continuous-learning skill auto-provisions `LEARNINGS/` if it doesn't exist in the project.
 
+## CodeGraph Integration
+
+When `.codegraph/` exists in the project, use CodeGraph tools for architecture analysis:
+
+- **Dependency analysis**: Use `codegraph_callers`/`callees` to map actual dependency graphs (not just imports)
+- **Layer boundaries**: Use `codegraph_explore` to verify dependency direction (domain -> infrastructure)
+- **Complexity hotspots**: Use `codegraph_impact` with depth=3 to find high-coupling modules
+- **Symbol relationships**: Use `codegraph_search` to find interface implementations and cross-module references
+- **When delegating to `explore`**: Request "use codegraph_explore for dependency analysis" in the prompt
+
+If `.codegraph/` does not exist, proceed with import-based analysis.
+
 ## Built-in Subagent Delegation
 
 - Delegate to `explore` for initial codebase scanning:

--- a/opencode_app/.opencode/agents/architecture-review-subagent.md
+++ b/opencode_app/.opencode/agents/architecture-review-subagent.md
@@ -83,7 +83,7 @@ When `.codegraph/` exists in the project, use CodeGraph tools for architecture a
 - **Symbol relationships**: Use `codegraph_search` to find interface implementations and cross-module references
 - **When delegating to `explore`**: Request "use codegraph_explore for dependency analysis" in the prompt
 
-If `.codegraph/` does not exist, proceed with import-based analysis.
+If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
 ## Built-in Subagent Delegation
 

--- a/opencode_app/.opencode/agents/code-review-subagent.md
+++ b/opencode_app/.opencode/agents/code-review-subagent.md
@@ -148,7 +148,7 @@ When `.codegraph/` exists in the project, use CodeGraph tools to enhance structu
 - **Symbol analysis**: Use `codegraph_node` to inspect symbol signatures and dependencies without reading full files
 - **When delegating to `explore`**: Request "use codegraph_explore for structural analysis" in the prompt
 
-If `.codegraph/` does not exist, proceed with grep/glob-based exploration.
+If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
 ## Built-in Subagent Delegation
 

--- a/opencode_app/.opencode/agents/code-review-subagent.md
+++ b/opencode_app/.opencode/agents/code-review-subagent.md
@@ -138,6 +138,18 @@ After completing the review, use the `continuous-learning` skill to persist find
 
 The continuous-learning skill auto-provisions `LEARNINGS/` if it doesn't exist in the project.
 
+## CodeGraph Integration
+
+When `.codegraph/` exists in the project, use CodeGraph tools to enhance structural reviews:
+
+- **Before review**: Use `codegraph_impact` on changed files to understand change radius and affected consumers
+- **During review**: Use `codegraph_callers`/`callees` to verify changed symbols don't break downstream consumers
+- **Pattern detection**: Use `codegraph_search` to find similar patterns across the codebase (duplication, inconsistent implementations)
+- **Symbol analysis**: Use `codegraph_node` to inspect symbol signatures and dependencies without reading full files
+- **When delegating to `explore`**: Request "use codegraph_explore for structural analysis" in the prompt
+
+If `.codegraph/` does not exist, proceed with grep/glob-based exploration.
+
 ## Built-in Subagent Delegation
 
 - Delegate to `explore` for codebase scanning tasks:

--- a/opencode_app/.opencode/agents/error-resolver-subagent.md
+++ b/opencode_app/.opencode/agents/error-resolver-subagent.md
@@ -41,6 +41,15 @@ MCP Tools:
 - diagnose_error_screenshot: Analyze error screenshots
 - extract_text_from_screenshot: Extract error text from images
 
+## CodeGraph Integration
+
+When `.codegraph/` exists, use CodeGraph tools for error tracing:
+- `codegraph_node` to inspect error-related symbol details (signatures, return types)
+- `codegraph_callers` to trace how an error propagates through the call stack
+- `codegraph_search` to find similar error patterns across the codebase
+
+Fall back to grep/glob when `.codegraph/` is absent.
+
 Delegation:
 - Code changes: Delegate to parent agent (no write access)
 - System commands: Delegate to parent agent (no bash access)

--- a/opencode_app/.opencode/agents/error-resolver-subagent.md
+++ b/opencode_app/.opencode/agents/error-resolver-subagent.md
@@ -48,7 +48,7 @@ When `.codegraph/` exists, use CodeGraph tools for error tracing:
 - `codegraph_callers` to trace how an error propagates through the call stack
 - `codegraph_search` to find similar error patterns across the codebase
 
-Fall back to grep/glob when `.codegraph/` is absent.
+If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
 Delegation:
 - Code changes: Delegate to parent agent (no write access)

--- a/opencode_app/.opencode/agents/explorer-subagent.md
+++ b/opencode_app/.opencode/agents/explorer-subagent.md
@@ -11,6 +11,29 @@ permission:
 
 You are a codebase exploration agent optimized for coding tasks. Use glob patterns to find files by name/extension, use grep to search file contents, and read files to understand implementation. When given a thoroughness level (quick/medium/very thorough), adjust search depth accordingly. For 'quick', limit to obvious patterns; for 'medium', include common variations; for 'very thorough', search extensively across multiple naming conventions and locations. Always return specific file paths and line numbers for findings. Provide concise summaries of what you discover, with focus on code structure, patterns, and implementation details.
 
+## CodeGraph Integration
+
+When `.codegraph/` exists in the project, prioritize CodeGraph tools over grep/glob/read:
+
+| CodeGraph Tool | Replaces | Use For |
+|---|---|---|
+| `codegraph_explore` | Multi-file grep/glob chains | Deep multi-file exploration with source |
+| `codegraph_context` | Manual context building | Build relevant code context for a task |
+| `codegraph_search` | grep for symbol names | Find symbols by name (partial match) |
+| `codegraph_files` | glob for file structure | Get indexed file tree with metadata |
+| `codegraph_node` | Read full file for one symbol | Get symbol details (signature, docs, code) |
+| `codegraph_callers` / `callees` | Manual import tracking | Trace call flow in/out of a symbol |
+| `codegraph_impact` | File-by-file search | Assess change radius before edits |
+
+**Tool selection by thoroughness:**
+- `quick`: `codegraph_search` + `codegraph_files` only
+- `medium`: add `codegraph_node` for key symbols
+- `very thorough`: add `codegraph_explore` and `codegraph_callers`/`callees`
+
+If `.codegraph/` does not exist, fall back to grep/glob/read normally.
+
+For remote GitHub repo exploration, continue using `zai-zread` tools (CodeGraph is local-only).
+
 ## Remote Repo Exploration
 
 When exploring open source GitHub repositories (not the local codebase), use the `zai-zread` tools:

--- a/opencode_app/.opencode/agents/linting-subagent.md
+++ b/opencode_app/.opencode/agents/linting-subagent.md
@@ -27,9 +27,9 @@ You are a linting specialist. Analyze code quality and enforce best practices us
 
 ## CodeGraph Integration
 
-When `.codegraph/` exists, use `codegraph_files` for fast project structure detection instead of glob chains. Use `codegraph_search` to find linter-related symbols if needed. Fall back to glob/grep when `.codegraph/` is absent.
+When `.codegraph/` exists, use `codegraph_files` for fast project structure detection instead of glob chains. Use `codegraph_search` to find linter-related symbols if needed. If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
-Built-in Subagent Delegation:
+## Built-in Subagent Delegation
 - Delegate to `explore` for language and config detection:
   - Scanning for linter config files (.eslintrc*, pyproject.toml, ruff.toml, checkstyle.xml, .editorconfig)
   - Detecting project languages from file extensions and build files

--- a/opencode_app/.opencode/agents/linting-subagent.md
+++ b/opencode_app/.opencode/agents/linting-subagent.md
@@ -25,6 +25,10 @@ You are a linting specialist. Analyze code quality and enforce best practices us
 - C# .NET 10: Use `dotnet format`, StyleCop analyzers, Roslyn analyzers, and .NET code quality analyzers
 - Generic: Use linting-workflow for cross-language linting with auto-fix
 
+## CodeGraph Integration
+
+When `.codegraph/` exists, use `codegraph_files` for fast project structure detection instead of glob chains. Use `codegraph_search` to find linter-related symbols if needed. Fall back to glob/grep when `.codegraph/` is absent.
+
 Built-in Subagent Delegation:
 - Delegate to `explore` for language and config detection:
   - Scanning for linter config files (.eslintrc*, pyproject.toml, ruff.toml, checkstyle.xml, .editorconfig)

--- a/opencode_app/.opencode/agents/refactoring-subagent.md
+++ b/opencode_app/.opencode/agents/refactoring-subagent.md
@@ -62,6 +62,18 @@ Best Practices:
 - Extract early
 - Utility-first approach
 
+## CodeGraph Integration
+
+When `.codegraph/` exists in the project, use CodeGraph tools for safe refactoring:
+
+- **Before refactoring**: Use `codegraph_callers` on symbols you plan to change — know ALL consumers first
+- **Impact analysis**: Use `codegraph_impact` with depth=2 to assess change radius
+- **Finding duplicates**: Use `codegraph_search` and `codegraph_callees` to find symbols with identical call patterns
+- **Interface mapping**: Use `codegraph_callers`/`callees` to map interface implementations before restructuring
+- **When delegating to `explore`**: Request "use codegraph_explore for pattern analysis" in the prompt
+
+If `.codegraph/` does not exist, proceed with grep/glob-based analysis.
+
 Built-in Subagent Delegation:
 - Delegate to `explore` for codebase analysis:
   - Finding duplicate code patterns across files

--- a/opencode_app/.opencode/agents/refactoring-subagent.md
+++ b/opencode_app/.opencode/agents/refactoring-subagent.md
@@ -72,9 +72,9 @@ When `.codegraph/` exists in the project, use CodeGraph tools for safe refactori
 - **Interface mapping**: Use `codegraph_callers`/`callees` to map interface implementations before restructuring
 - **When delegating to `explore`**: Request "use codegraph_explore for pattern analysis" in the prompt
 
-If `.codegraph/` does not exist, proceed with grep/glob-based analysis.
+If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
-Built-in Subagent Delegation:
+## Built-in Subagent Delegation
 - Delegate to `explore` for codebase analysis:
   - Finding duplicate code patterns across files
   - Mapping class hierarchies and interface implementations

--- a/opencode_app/.opencode/agents/testing-subagent.md
+++ b/opencode_app/.opencode/agents/testing-subagent.md
@@ -35,9 +35,9 @@ When `.codegraph/` exists in the project, use CodeGraph tools for faster test di
 - **Coverage gaps**: Use `codegraph_callers` on untested functions to understand their consumers
 - **When delegating to `explore`**: Request "use codegraph_files for structure and codegraph_search for test patterns" in the prompt
 
-If `.codegraph/` does not exist, proceed with glob-based file discovery.
+If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
-Built-in Subagent Delegation:
+## Built-in Subagent Delegation
 - Delegate to `explore` for test discovery tasks:
   - Finding existing test files and test directories
   - Locating test framework configuration (conftest.py, jest.config, vitest.config, etc.)

--- a/opencode_app/.opencode/agents/testing-subagent.md
+++ b/opencode_app/.opencode/agents/testing-subagent.md
@@ -26,6 +26,17 @@ You are a testing specialist. Generate comprehensive tests following industry be
 - Next.js: Use nextjs-unit-test-creator for App Router, Server Components, API routes, and Server Actions
 - Generic: Use test-generator-framework for cross-language test generation
 
+## CodeGraph Integration
+
+When `.codegraph/` exists in the project, use CodeGraph tools for faster test discovery:
+
+- **File structure**: Use `codegraph_files` instead of glob chains for project layout and test directory detection
+- **Symbol search**: Use `codegraph_search` to find test-related symbols (describe, test, it, pytest, fixture)
+- **Coverage gaps**: Use `codegraph_callers` on untested functions to understand their consumers
+- **When delegating to `explore`**: Request "use codegraph_files for structure and codegraph_search for test patterns" in the prompt
+
+If `.codegraph/` does not exist, proceed with glob-based file discovery.
+
 Built-in Subagent Delegation:
 - Delegate to `explore` for test discovery tasks:
   - Finding existing test files and test directories

--- a/opencode_app/AGENTS.md
+++ b/opencode_app/AGENTS.md
@@ -31,3 +31,37 @@ Skills are loaded from `.opencode/skills/` — these are symlinked from the repo
 - Health check: `GET /global/health`
 - Auth keys: Injected from environment variables via entrypoint
 - Data persistence: `/home/opencode/.local/share/opencode` (named volume)
+
+## CodeGraph MCP Server
+
+[CodeGraph](https://github.com/colbymchenry/codegraph) is a pre-indexed code knowledge graph MCP server. It builds a local SQLite database of symbol relationships and call graphs for instant codebase queries.
+
+### Per-Project Setup
+
+```bash
+codegraph init -i
+```
+
+This creates a `.codegraph/` directory with an indexed database. Add `.codegraph/` to `.gitignore`.
+
+### MCP Tool Routing
+
+| Capability | Primary | Fallback | Reason |
+|---|---|---|---|
+| Codebase exploration | `codegraph_explore` / `codegraph_context` | grep/glob chains | Structured graph results, fewer tool calls |
+| Symbol lookup | `codegraph_search` / `codegraph_node` | grep | Instant name-based lookup |
+| Call tracing | `codegraph_callers` / `callees` | grep imports | Graph-based, transitive |
+| Impact analysis | `codegraph_impact` | Manual file search | Traces dependency chains |
+| File structure | `codegraph_files` | glob | Indexed, faster |
+
+### Subagent Integration
+
+The following subagents have CodeGraph instructions in their `.md` files and will use CodeGraph automatically when `.codegraph/` exists:
+
+| Subagent | Key CodeGraph Tools |
+|---|---|
+| `explorer-subagent` | `codegraph_explore`, `codegraph_context`, `codegraph_search`, `codegraph_files` |
+| `code-review-subagent` | `codegraph_impact`, `codegraph_callers`/`callees`, `codegraph_search` |
+| `architecture-review-subagent` | `codegraph_callers`/`callees`, `codegraph_explore`, `codegraph_impact` |
+| `refactoring-subagent` | `codegraph_callers`, `codegraph_impact`, `codegraph_search` |
+| `testing-subagent` | `codegraph_files`, `codegraph_search` |

--- a/opencode_app/AGENTS.md
+++ b/opencode_app/AGENTS.md
@@ -65,3 +65,5 @@ The following subagents have CodeGraph instructions in their `.md` files and wil
 | `architecture-review-subagent` | `codegraph_callers`/`callees`, `codegraph_explore`, `codegraph_impact` |
 | `refactoring-subagent` | `codegraph_callers`, `codegraph_impact`, `codegraph_search` |
 | `testing-subagent` | `codegraph_files`, `codegraph_search` |
+| `linting-subagent` | `codegraph_files`, `codegraph_search` |
+| `error-resolver-subagent` | `codegraph_node`, `codegraph_callers`, `codegraph_search` |


### PR DESCRIPTION
## Summary

Adds `## CodeGraph Integration` sections to 7 custom subagent `.md` files and the Docker `AGENTS.md`, so subagents are aware of and can use CodeGraph tools when `.codegraph/` exists in a project.

**Problem:** Zero out of 31 custom subagent `.md` files mentioned CodeGraph. Subagents run in isolated sessions and only see their own `.md` file — not the global `AGENTS.md` — so they had no CodeGraph awareness despite it being configured.

**Solution:** Added standardized CodeGraph integration sections documenting which tools to use, when to use them, and fallback behavior when `.codegraph/` is absent.

## Changes

### Phase 1 — Critical Subagents (5 files)
| File | CodeGraph Tools |
|---|---|
| `explorer-subagent.md` | Full tool priority table with thoroughness-based selection (quick/medium/very thorough) |
| `code-review-subagent.md` | `codegraph_impact` before review, `codegraph_callers`/`callees` during review |
| `architecture-review-subagent.md` | Dependency analysis, layer boundary verification, complexity hotspots |
| `refactoring-subagent.md` | Caller analysis before changes, impact assessment, duplicate detection |
| `testing-subagent.md` | Fast test discovery via `codegraph_files`, `codegraph_search` for test patterns |

### Phase 2 — Docker Mode (1 file)
| File | Details |
|---|---|
| `opencode_app/AGENTS.md` | Condensed CodeGraph section with MCP tool routing table + subagent integration table |

### Phase 3 — Optional Enhancements (2 files)
| File | CodeGraph Tools |
|---|---|
| `linting-subagent.md` | `codegraph_files` for project structure detection |
| `error-resolver-subagent.md` | `codegraph_node` for symbol details, `codegraph_callers` for error propagation tracing |

## Scope
- **9 files changed** (+252 lines, -3 lines)
- Purely documentation (`.md` files) — no code changes
- No lint/build/test applicable
- Semantic version: **patch** (non-breaking docs enhancement)

Closes #192