### PR TITLE
fix(ci): update release workflow paths for deploy/ restructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,13 @@ jobs:
 
       - name: Lint validation
         run: |
-          echo "🔍 Validating config.json..."
-          jq . config.json
-          echo "✅ config.json is valid"
+          echo "Validating deploy/config.json..."
+          jq . deploy/config.json
+          echo "config.json is valid"
 
-          echo "🔍 Validating setup.sh syntax..."
-          bash -n setup.sh
-          echo "✅ setup.sh syntax is valid"
+          echo "Validating deploy/setup.sh syntax..."
+          bash -n deploy/setup.sh
+          echo "setup.sh syntax is valid"
         continue-on-error: false
 
       - name: Setup Node.js


### PR DESCRIPTION
## Issue

CI  workflow failed after PR #195 merged because  and  moved to  but the lint validation step still referenced root-level paths.

**Failed run**: https://github.com/darellchua2/opencode-config-template/actions/runs/26277249041

## Fix

Update  lint step:
- `config.json` → `deploy/config.json`
- `setup.sh` → `deploy/setup.sh`

## Testing

- [x] Verified files exist at new paths locally
- [ ] CI will validate on merge

Related: #194