### PR TITLE
feat(skills): add git-compact-commits-skill [BT-54]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ opencode-config-template/
 │   ├── .dockerignore    # Build exclusions
 │   └── .opencode/
 │       ├── agents/      # 29 subagent .md files (single source of truth)
-│       └── skills/      # 61 skill directories (single source of truth)
+│       └── skills/      # 62 skill directories (single source of truth)
 ├── PLANS/               # Execution plans (git-committed)
 ├── LEARNINGS/           # Knowledge persistence template (auto-provisioned in target projects)
 │   ├── _index.md        # Auto-generated index
@@ -65,7 +65,7 @@ opencode-config-template/
 
 Agents and skills have a **single source of truth** in `opencode_app/.opencode/`:
 - `opencode_app/.opencode/agents/` — All 29 subagent definitions
-- `opencode_app/.opencode/skills/` — All 61 skill directories
+- `opencode_app/.opencode/skills/` — All 62 skill directories
 
 For **user-space**: `deploy/setup.sh` and `deploy/setup.ps1` copy from `opencode_app/.opencode/` to `~/.config/opencode/`
 For **Docker**: The Dockerfile `COPY . /app/` includes `.opencode/` in the container

--- a/PLANS/PLAN-BT-54.md
+++ b/PLANS/PLAN-BT-54.md
@@ -1,0 +1,95 @@
+# PLAN-BT-54: Add git-compact-commits-skill
+
+**JIRA**: [BT-54](https://betekk.atlassian.net/browse/BT-54)
+**Branch**: `feature/git-compact-commits-skill`
+**Type**: Task — New Skill Creation
+**Priority**: Medium
+**Created**: 2026-05-24
+
+---
+
+## Overview
+
+Create a new skill `git-compact-commits-skill` that addresses gaps in existing commit-related skills:
+- No word count limits for commit bodies
+- No semantic grouping guidance
+- No compact authoring techniques
+- Basic CI enforcement only (commitlint defaults)
+
+The skill provides both CI enforcement (commitlint config + GitHub Actions) and authoring guidance (grouping strategy, length budgets, compact writing).
+
+## Acceptance Criteria
+
+- [ ] Skill file created at `opencode_app/.opencode/skills/git-compact-commits-skill/SKILL.md`
+- [ ] All 10 sections implemented with comprehensive content
+- [ ] Custom commitlint word-count plugin code included
+- [ ] commitlint.config.js with extended rules included
+- [ ] GitHub Actions workflow YAML included
+- [ ] `deploy/setup.sh` updated with new skill count and category listing
+- [ ] `deploy/setup.ps1` updated with new skill count and category listing
+- [ ] `README.md` updated with new skill in Skill Categories table
+- [ ] `semantic-release-convention-skill` section 6.1 updated with cross-reference
+
+## Scope
+
+| File | Action |
+|------|--------|
+| `opencode_app/.opencode/skills/git-compact-commits-skill/SKILL.md` | Create |
+| `deploy/setup.sh` | Update (skill count + listing) |
+| `deploy/setup.ps1` | Update (skill count + listing) |
+| `README.md` | Update (Skill Categories table) |
+| `opencode_app/.opencode/skills/semantic-release-convention-skill/SKILL.md` | Update (cross-reference in section 6.1) |
+
+---
+
+## Phase 1: Create Skill File
+
+- [ ] 1.1 Create directory `opencode_app/.opencode/skills/git-compact-commits-skill/`
+- [ ] 1.2 Write `SKILL.md` with all 10 sections:
+  - [ ] Section 1: What I Do (4 capabilities)
+  - [ ] Section 2: When to Use Me (trigger phrases)
+  - [ ] Section 3: Semantic Grouping Strategy (decision matrix, patterns, anti-patterns)
+  - [ ] Section 4: Length Budgets (subject 72/50, body 150 words, lines 100 chars)
+  - [ ] Section 5: Compact Writing Techniques (active voice, bullet points, scopes, omit "how")
+  - [ ] Section 6: Commit Templates (multi-file, multi-concern, phase-based)
+  - [ ] Section 7: GitHub Actions Enforcement (commitlint.config.js, word-count plugin, workflow YAML)
+  - [ ] Section 8: Local Git Hook (pre-commit alternative)
+  - [ ] Section 9: Integration (cross-refs to git-semantic-commits-skill and semantic-release-convention-skill)
+  - [ ] Section 10: Verification Commands
+
+## Phase 2: Sync Deployment Files
+
+- [ ] 2.1 Update `deploy/setup.sh` — increment total skill count, add `git-compact-commits-skill` to Git category listing
+- [ ] 2.2 Update `deploy/setup.ps1` — increment total skill count, add `git-compact-commits-skill` to Git category listing
+- [ ] 2.3 Update `README.md` — add row to Skill Categories table under Git category
+
+## Phase 3: Update Existing Skills
+
+- [ ] 3.1 Update `semantic-release-convention-skill/SKILL.md` section 6.1 — add note pointing to `git-compact-commits-skill` for extended length budgets and CI enforcement
+
+## Phase 4: Validation
+
+- [ ] 4.1 Verify skill file follows existing skill structure conventions
+- [ ] 4.2 Verify deploy scripts reference the skill correctly
+- [ ] 4.3 Verify README table includes the skill
+- [ ] 4.4 Run `deploy/setup.sh` dry-run validation (if applicable)
+
+---
+
+## Dependencies
+
+None — this is a standalone skill addition with sync updates to existing files.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Skill count mismatch across deploy scripts | Update both setup.sh and setup.ps1 in same commit |
+| README table formatting breaks | Follow existing markdown table format exactly |
+| semantic-release-convention-skill cross-reference placement unclear | Add as a note/blockquote in section 6.1, not a structural change |
+
+## Notes
+
+- Skill number will increment from current count (check deploy/setup.sh for current total)
+- Category: Git (alongside git-semantic-commits-skill, git-issue-labeler-skill, etc.)
+- The skill complements but does not replace `git-semantic-commits-skill` (which covers commit message types, scopes, breaking changes)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ opencode-config-template/
 │   ├── .dockerignore
 │   ├── .opencode/
 │   │       ├── agents/              # 31 subagent .md files
-│   │   └── skills/              # 61 skill directories
+│   │       └── skills/              # 62 skill directories
 │   └── README.md                # Docker usage guide
 ├── docker-compose.yml           # Docker Compose service definition
 ├── .env.example                 # Environment variable template
@@ -261,7 +261,7 @@ TypeScript, JavaScript, Python, Go, Rust, Java, C#, PHP, Ruby, C, C++, Swift, Ko
 
 ## Skill Modularization
 
-This repository implements **skill modularization** with 61 skills organized across 10 categories. Skills are designed with clear separation of concerns and explicit dependencies.
+This repository implements **skill modularization** with 62 skills organized across 10 categories. Skills are designed with clear separation of concerns and explicit dependencies.
 
 ### Skill Categories
 
@@ -272,7 +272,7 @@ This repository implements **skill modularization** with 61 skills organized acr
 | **Framework-Specific** (5) | nextjs-pr-workflow, nextjs-unit-test-creator, nextjs-standard-setup, nextjs-image-usage, typescript-dry-principle | Next.js 16 and TypeScript workflows |
 | **OpenCode Meta** (3) | opencode-agent-creation, opencode-skill-creation, opencode-skills-maintainer | Agent and skill creation/maintenance |
 | **OpenTofu** (7) | opentofu-aws-explorer, opentofu-keycloak-explorer, opentofu-kubernetes-explorer, opentofu-neon-explorer, opentofu-provider-setup, opentofu-provisioning-workflow, opentofu-ecr-provision | Infrastructure as Code |
-| **Git/Workflow** (9) | ascii-diagram-creator, mermaid-diagram-creator, ticket-plan-workflow-skill, plan-execution-skill, git-issue-labeler, git-issue-updater, git-semantic-commits, semantic-release-convention, plan-updater | Diagrams, git operations, release conventions, and workflows |
+| **Git/Workflow** (10) | ascii-diagram-creator, mermaid-diagram-creator, ticket-plan-workflow-skill, plan-execution-skill, git-issue-labeler, git-issue-updater, git-semantic-commits, semantic-release-convention, git-compact-commits, plan-updater | Diagrams, git operations, release conventions, compact commits, and workflows |
 | **Documentation** (3) | coverage-readme-workflow, docstring-generator, documentation-sync-workflow | Documentation generation |
 | **JIRA** (3) | jira-status-updater, jira-git-integration, jira-ticket-labeler | JIRA integration via MCP server |
 | **Code Quality** (7) | solid-principles, clean-code, clean-architecture, design-patterns, object-design, code-smells, complexity-management | Code quality analysis and patterns |

--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -373,12 +373,12 @@ USAGE:
     Usage: opencode --agent build 'implement auth feature'
             opencode --agent explore 'find all API routes'
  
-        SKILLS (61):
+        SKILLS (62):
              Framework (11):       test-generator-framework, linting-workflow,
-                                    pr-creation-workflow, pr-merge-workflow,
-                                    error-resolver-workflow, tdd-workflow,
-                                    docx-creation, pptx-specialist,
-                                    xlsx-specialist, pdf-specialist, frontend-design
+                                     pr-creation-workflow, pr-merge-workflow,
+                                     error-resolver-workflow, tdd-workflow,
+                                     docx-creation, pptx-specialist,
+                                     xlsx-specialist, pdf-specialist, frontend-design
 
            Language-Specific (4): python-pytest-creator, python-ruff-linter,
                                  javascript-eslint-linter, changelog-python-cliff
@@ -392,11 +392,11 @@ USAGE:
                                 opentofu-kubernetes-explorer, opentofu-neon-explorer,
                                 opentofu-provider-setup, opentofu-provisioning-workflow,
                                 opentofu-ecr-provision
-          Git/Workflow (9):     ascii-diagram-creator, mermaid-diagram-creator,
-                                ticket-plan-workflow-skill, plan-execution-skill,
-                                git-issue-labeler, git-issue-updater,
-                                git-semantic-commits, semantic-release-convention,
-                                plan-updater
+          Git/Workflow (10):    ascii-diagram-creator, mermaid-diagram-creator,
+                                 ticket-plan-workflow-skill, plan-execution-skill,
+                                 git-issue-labeler, git-issue-updater,
+                                 git-semantic-commits, semantic-release-convention,
+                                 git-compact-commits, plan-updater
          Documentation (3):    coverage-readme-workflow, docstring-generator,
                                 documentation-sync-workflow
 
@@ -1206,11 +1206,12 @@ function Deploy-Skills {
         Write-Host "Deployed $skillCount skills to $SkillsDir" -ForegroundColor Green
         Write-Host ""
         Write-Host "  Skill Categories:" -ForegroundColor Cyan
-         Write-Host "    Framework (10):"
-         Write-Host "      - test-generator-framework, linting-workflow"
-         Write-Host "      - pr-creation-workflow, error-resolver-workflow, tdd-workflow"
-         Write-Host "      - docx-creation, pptx-specialist, xlsx-specialist, pdf-specialist"
-         Write-Host "      - frontend-design"
+          Write-Host "    Framework (11):"
+          Write-Host "      - test-generator-framework, linting-workflow"
+          Write-Host "      - pr-creation-workflow, pr-merge-workflow"
+          Write-Host "      - error-resolver-workflow, tdd-workflow"
+          Write-Host "      - docx-creation, pptx-specialist, xlsx-specialist, pdf-specialist"
+          Write-Host "      - frontend-design"
         Write-Host "    Language-Specific (4):"
         Write-Host "      - python-pytest-creator, python-ruff-linter"
         Write-Host "      - javascript-eslint-linter, changelog-python-cliff"
@@ -1226,11 +1227,12 @@ function Deploy-Skills {
         Write-Host "      - opentofu-kubernetes-explorer, opentofu-neon-explorer"
         Write-Host "      - opentofu-provider-setup, opentofu-provisioning-workflow"
         Write-Host "      - opentofu-ecr-provision"
-        Write-Host "    Git/Workflow (9):"
+        Write-Host "    Git/Workflow (10):"
         Write-Host "      - ascii-diagram-creator, mermaid-diagram-creator"
         Write-Host "      - ticket-plan-workflow-skill, plan-execution-skill"
         Write-Host "      - git-issue-labeler, git-issue-updater"
         Write-Host "      - git-semantic-commits, semantic-release-convention"
+        Write-Host "      - git-compact-commits"
         Write-Host "      - plan-updater"
         Write-Host "    Documentation (3):"
         Write-Host "      - coverage-readme-workflow, docstring-generator"
@@ -1697,11 +1699,11 @@ function Show-NextSteps {
     Write-Host "         opencode `"prompt`" (uses build)"
      Write-Host ""
     Write-Host "=====================================================================" -ForegroundColor White
-     Write-Host "                     61 Skills Available" -ForegroundColor White
+     Write-Host "                     62 Skills Available" -ForegroundColor White
     Write-Host "=====================================================================" -ForegroundColor White
     Write-Host ""
-    Write-Host "  Framework (10) • Language-Specific (4) • Framework-Specific (5)"
-    Write-Host "  OpenCode Meta (3) • OpenTofu (7) • Git/Workflow (9)"
+    Write-Host "  Framework (11) • Language-Specific (4) • Framework-Specific (5)"
+    Write-Host "  OpenCode Meta (3) • OpenTofu (7) • Git/Workflow (10)"
     Write-Host "  Documentation (3) • JIRA (3) • Code Quality (7)"
     Write-Host "  Agent Optimization (4)"
     Write-Host ""

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -561,12 +561,12 @@ USAGE:
       microsoft-copilot  M365 Copilot conversations
       microsoft-dataverse Business data (Dynamics 365)
 
-   SKILLS (61):
+   SKILLS (62):
               Framework (11):       test-generator-framework, linting-workflow,
-                                    pr-creation-workflow, pr-merge-workflow,
-                                    error-resolver-workflow, tdd-workflow,
-                                    docx-creation, pptx-specialist,
-                                    xlsx-specialist, pdf-specialist, frontend-design
+                                     pr-creation-workflow, pr-merge-workflow,
+                                     error-resolver-workflow, tdd-workflow,
+                                     docx-creation, pptx-specialist,
+                                     xlsx-specialist, pdf-specialist, frontend-design
 
            Language-Specific (4): python-pytest-creator, python-ruff-linter,
                                  javascript-eslint-linter, changelog-python-cliff
@@ -583,11 +583,11 @@ USAGE:
                                 opentofu-provider-setup, opentofu-provisioning-workflow,
                                 opentofu-ecr-provision
 
-          Git/Workflow (9):     ascii-diagram-creator, mermaid-diagram-creator,
-                                 ticket-plan-workflow-skill, plan-execution-skill,
-                                 git-issue-labeler, git-issue-updater,
-                                 git-semantic-commits, semantic-release-convention,
-                                 plan-updater
+           Git/Workflow (10):    ascii-diagram-creator, mermaid-diagram-creator,
+                                  ticket-plan-workflow-skill, plan-execution-skill,
+                                  git-issue-labeler, git-issue-updater,
+                                  git-semantic-commits, semantic-release-convention,
+                                  git-compact-commits, plan-updater
 
          Documentation (3):    coverage-readme-workflow, docstring-generator,
                                 documentation-sync-workflow
@@ -2189,10 +2189,11 @@ print_summary() {
     if [ -d "$SKILLS_DIR" ] && [ "$(ls -A ${SKILLS_DIR} 2>/dev/null)" ]; then
         local skill_count=$(find ${SKILLS_DIR} -name "SKILL.md" 2>/dev/null | wc -l)
         echo "✓ skills: ${skill_count} skills deployed to ${SKILLS_DIR}/"
-        echo "    - Framework (10):"
+        echo "    - Framework (11):"
         echo "      - test-generator-framework"
         echo "      - linting-workflow"
         echo "      - pr-creation-workflow"
+        echo "      - pr-merge-workflow"
         echo "      - error-resolver-workflow"
         echo "      - tdd-workflow"
         echo "      - docx-creation"
@@ -2223,7 +2224,7 @@ print_summary() {
         echo "      - opentofu-provider-setup"
         echo "      - opentofu-provisioning-workflow"
         echo "      - opentofu-ecr-provision"
-        echo "    - Git/Workflow (9):"
+        echo "    - Git/Workflow (10):"
         echo "      - ascii-diagram-creator"
         echo "      - mermaid-diagram-creator"
         echo "      - ticket-plan-workflow-skill"
@@ -2232,6 +2233,7 @@ print_summary() {
         echo "      - git-issue-updater"
         echo "      - git-semantic-commits"
         echo "      - semantic-release-convention"
+        echo "      - git-compact-commits"
         echo "      - plan-updater"
         echo "    - Documentation (3):"
         echo "      - coverage-readme-workflow"
@@ -2313,11 +2315,11 @@ print_next_steps() {
     echo "         opencode \"prompt\" (uses build)"
      echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "                     📦 61 Skills Available"
+    echo "                     📦 62 Skills Available"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
-    echo "  Framework (10) • Language-Specific (4) • Framework-Specific (5)"
-    echo "  OpenCode Meta (3) • OpenTofu (7) • Git/Workflow (9)"
+    echo "  Framework (11) • Language-Specific (4) • Framework-Specific (5)"
+    echo "  OpenCode Meta (3) • OpenTofu (7) • Git/Workflow (10)"
     echo "  Documentation (3) • JIRA (3) • Code Quality (7)"
     echo "  Agent Optimization (4)"
     echo ""

--- a/opencode_app/.opencode/skills/git-compact-commits-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/git-compact-commits-skill/SKILL.md
@@ -1,0 +1,660 @@
+---
+name: git-compact-commits-skill
+description: Write compact commit messages within word/character budgets with semantic grouping of related changes, and enforce limits via commitlint GitHub Actions
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers, maintainers
+  workflow: commit-compact-authoring
+---
+
+## What I Do
+
+I provide compact commit message authoring and CI enforcement:
+
+1. **Semantic Grouping**: Combine related changes into single commits by phase, concern, or module
+2. **Compact Authoring**: Write commit messages within strict word/character budgets (150-word body, 72-char subject)
+3. **CI Enforcement**: Configure commitlint with custom word-count plugin and GitHub Actions workflow
+4. **Local Enforcement**: Pre-commit hook alternative for local validation
+
+This is a **guidance + enforcement skill** — I teach compact authoring AND provide the CI/CD config to enforce it.
+
+For commit type definitions and scope conventions, see `git-semantic-commits`.
+For the full release pipeline (PR titles, merge strategy, release tags), see `semantic-release-convention`.
+
+## When to Use Me
+
+Use this skill when:
+- Writing commit messages that need to stay within word/character limits
+- Grouping multiple related file changes into a single commit
+- Setting up commitlint with word-count enforcement in GitHub Actions
+- Creating a local pre-commit hook for message length validation
+- Preparing commits before a squash-merge PR workflow
+
+## Authority Boundaries
+
+| Concern | Authority Skill | Role |
+|---------|----------------|------|
+| Commit types, scopes, breaking changes | `git-semantic-commits` | Format definition |
+| Release pipeline, PR titles, merge strategy | `semantic-release-convention` | CI/CD workflow |
+| **Length budgets, grouping, compact writing** | **`git-compact-commits` (this skill)** | **Config details** |
+| commitlint config with extended rules | `git-compact-commits` (this skill) | Enforcement rules |
+
+## Scope: Two Use Cases
+
+This skill targets **both** commit scenarios in a squash-merge workflow:
+
+### 1. Branch Commits (Pre-Squash)
+
+Individual commits during development on a feature branch. These keep `git log` readable during code review and make `git rebase -i` easier.
+
+```
+feat(auth): add JWT token refresh and session store
+
+Implement automatic token refresh when access token expires.
+Add session storage for persisting auth state across reloads.
+
+Refs: BT-54
+```
+
+### 2. Squash-Merge Output
+
+The canonical commit produced by squash-merging a PR. This becomes the permanent record in the target branch.
+
+```
+feat(auth): add OAuth2 support with token refresh and session persistence
+
+Implement OAuth2 authentication flow with support for Google and GitHub
+providers. Add automatic token refresh when access token expires.
+Include session storage for persisting auth state across page reloads
+and browser restarts.
+
+BREAKING CHANGE: auth config schema has changed
+
+Closes BT-54
+```
+
+---
+
+## Section 1: Semantic Grouping Strategy
+
+### Decision Matrix
+
+```
+GROUP into 1 commit when:              SPLIT into N commits when:
+├─ Same concern (all auth changes)     ├─ Different concerns (auth + billing)
+├─ Same phase (all setup changes)      ├─ Different phases (setup + test)
+├─ Same module/directory               ├─ Different modules (api + ui)
+├─ Mutually dependent changes          ├─ Independent changes
+└─ Combined body ≤ 150 words          └─ Each deserves its own context
+```
+
+### Grouping Patterns
+
+#### By Phase
+
+Group changes that belong to the same development phase:
+
+```
+Phase: Setup
+  - Add config file
+  - Add environment variables
+  - Create database migration
+  → 1 commit: feat(db): add database schema and migration config
+
+Phase: Implementation
+  - Add model class
+  - Add repository layer
+  - Add service layer
+  → 1 commit: feat(api): implement user CRUD with repository pattern
+
+Phase: Testing
+  - Add unit tests
+  - Add integration test
+  - Update test fixtures
+  → 1 commit: test(api): add unit and integration tests for user CRUD
+```
+
+#### By Concern
+
+Group changes that address the same business concern:
+
+```
+Concern: Authentication
+  - Add login endpoint
+  - Add token middleware
+  - Add session handler
+  → 1 commit: feat(auth): add login flow with JWT and session handling
+
+Concern: Error Handling
+  - Add error boundary
+  - Add global error handler
+  - Add error logging
+  → 1 commit: feat(core): add error handling with boundary and logging
+```
+
+#### By Module
+
+Group changes in the same directory or module:
+
+```
+Module: src/components/Button/
+  - Button.tsx
+  - Button.test.tsx
+  - Button.styles.ts
+  → 1 commit: feat(ui): add Button component with tests and styles
+```
+
+### Anti-Patterns
+
+**Don't group unrelated changes:**
+```
+BAD: feat: add login endpoint, fix typo in readme, update deps
+GOOD: 3 separate commits for each concern
+```
+
+**Don't group if the body exceeds 150 words:**
+```
+BAD: A single commit covering 5 unrelated features
+GOOD: 5 focused commits, each under 150 words
+```
+
+**Don't group fixes with features:**
+```
+BAD: feat: add user registration and fix login timeout
+GOOD: feat(auth): add user registration + fix(auth): resolve login timeout
+```
+
+---
+
+## Section 2: Length Budgets
+
+### Character and Word Limits
+
+| Part | Ideal | Hard Limit | Rationale |
+|------|-------|-----------|-----------|
+| Subject line | 50 chars | 72 chars | GitHub truncates at 72 |
+| Body | ≤100 words | 150 words | Readability in git log |
+| Body line | 72 chars | 72 chars | Terminal width convention |
+| Footer line | 72 chars | 72 chars | Consistency with body |
+| Total message | ≤200 words | 250 words | Enforce brevity |
+
+### Length Calculation
+
+```bash
+count_subject_chars() {
+  echo "$1" | sed 's/^[^:]*: //' | wc -c
+}
+
+count_body_words() {
+  echo "$1" | sed '1,/^$/d' | wc -w
+}
+
+count_body_lines_over_72() {
+  echo "$1" | sed '1,/^$/d' | awk 'length > 72'
+}
+```
+
+---
+
+## Section 3: Compact Writing Techniques
+
+### 1. Use Active Voice, Imperative Mood
+
+```
+BAD:  Added authentication middleware that validates tokens
+GOOD: Add token validation middleware
+
+BAD:  Fixed the bug where users couldn't log in
+GOOD: Prevent login failure on expired tokens
+```
+
+### 2. Use Scopes to Absorb Context
+
+The scope replaces explanatory text:
+
+```
+BAD:  feat: add user registration endpoint to the API
+GOOD: feat(api): add user registration endpoint
+
+BAD:  fix: resolve CSS layout issue on the login page mobile view
+GOOD: fix(ui): resolve mobile layout on login page
+```
+
+### 3. Omit "How" — Focus on "What" and "Why"
+
+```
+BAD:  feat(auth): add JWT refresh by checking expiry and calling
+      the /token/refresh endpoint with the stored refresh token
+GOOD: feat(auth): add automatic token refresh on expiry
+
+The "how" belongs in the code, not the commit message.
+```
+
+### 4. Use Bullet Points, Not Paragraphs
+
+```
+BAD (paragraph):
+feat(auth): add OAuth2 support with Google and GitHub providers
+including token refresh mechanism, error handling for expired
+tokens, session persistence across page reloads, and automatic
+redirect to login when session expires
+
+GOOD (bullets):
+feat(auth): add OAuth2 support for third-party providers
+
+- Add Google and GitHub provider integration
+- Implement automatic token refresh on expiry
+- Persist auth state across page reloads
+- Redirect to login on session expiration
+```
+
+### 5. Consolidate Similar Items
+
+```
+BAD:
+feat(api): add user registration
+feat(api): add user login
+feat(api): add user logout
+
+GOOD:
+feat(api): add user registration, login, and logout endpoints
+```
+
+### 6. Use Abbreviations Strategically
+
+```
+BAD:  feat: add continuous integration and continuous deployment pipeline
+GOOD: feat: add CI/CD pipeline
+
+BAD:  fix: fix representational state transfer application programming interface
+GOOD: fix(api): resolve REST endpoint routing
+```
+
+---
+
+## Section 4: Commit Templates
+
+### Template: Multi-File Grouped Commit
+
+```
+<type>(<scope>): <concise subject>
+
+- Change 1 description
+- Change 2 description
+- Change 3 description
+
+[Optional: Why these changes are related]
+
+Refs: <ticket>
+```
+
+**Example:**
+```
+feat(auth): add OAuth2 login flow with session management
+
+- Add Google and GitHub OAuth2 provider configuration
+- Implement token exchange and refresh endpoints
+- Add session middleware for auth state persistence
+
+Refs: BT-54
+```
+
+### Template: Phase-Based Grouped Commit
+
+```
+<type>(<scope>): <phase> <concise subject>
+
+<phase-specific details>
+
+Refs: <ticket>
+```
+
+**Example (setup phase):**
+```
+chore(infra): set up database and migration tooling
+
+- Add PostgreSQL connection config and environment variables
+- Create initial schema migration for users table
+- Configure migration runner with seed data support
+
+Refs: BT-54
+```
+
+### Template: Multi-Concern (Squash-Merge Output)
+
+```
+<type>(<scope>): <primary feature summary>
+
+<primary feature details>
+
+- <secondary concern 1>
+- <secondary concern 2>
+
+[Optional footer]
+
+Closes: <ticket>
+```
+
+**Example:**
+```
+feat(api): add user authentication with OAuth2 and session management
+
+Implement OAuth2 authentication flow supporting Google and GitHub
+providers with automatic token refresh and error handling.
+
+- Add session middleware for auth state persistence
+- Add CSRF protection for OAuth2 callback
+- Update API docs with authentication endpoints
+
+BREAKING CHANGE: auth config schema has changed
+
+Closes BT-54
+```
+
+### Template: Compact Fix
+
+```
+fix(<scope>): <root cause> → <effect>
+
+<one-line explanation of the fix>
+
+Refs: <ticket>
+```
+
+**Example:**
+```
+fix(auth): handle expired refresh tokens gracefully
+
+Check token expiry before refresh attempt to prevent
+401 errors on stale sessions.
+
+Refs: BT-54
+```
+
+---
+
+## Section 5: GitHub Actions Enforcement
+
+### commitlint.config.js
+
+```js
+// commitlint.config.js
+// Authority: git-compact-commits-skill
+// This is the single source of truth for commitlint length rules.
+// The CI workflow in semantic-release-convention-skill section 6.1
+// references this config.
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  plugins: ['./commitlint-word-count.js'],
+  rules: {
+    'header-max-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 72],
+    'footer-max-line-length': [2, 'always', 72],
+    'body-word-count': [2, 'always', 150],
+  },
+}
+```
+
+### Custom Word Count Plugin
+
+```js
+// commitlint-word-count.js
+// Custom commitlint rule for body word count enforcement
+
+module.exports = {
+  rules: {
+    'body-word-count': (parsed, when, value) => {
+      const body = parsed.body || ''
+      const wordCount = body.trim().split(/\s+/).filter(Boolean).length
+
+      if (wordCount === 0) return [true, '']
+
+      const max = value || 150
+      const pass = when === 'always' ? wordCount <= max : wordCount > max
+
+      return [
+        pass,
+        pass
+          ? ''
+          : `Body has ${wordCount} words (${when === 'always' ? 'maximum' : 'minimum'} ${max}). Group related changes or use bullet points to stay within the limit.`,
+      ]
+    },
+  },
+}
+```
+
+### GitHub Actions Workflow
+
+```yaml
+# .github/workflows/commit-lint.yml
+name: Commit Lint
+on: [push, pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.js
+```
+
+### Package.json Dev Dependency
+
+```json
+{
+  "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0"
+  }
+}
+```
+
+---
+
+## Section 6: Local Git Hook
+
+### Pre-Commit Hook (commit-msg)
+
+```bash
+#!/bin/bash
+# .git/hooks/commit-msg
+# Validates commit message follows compact conventions
+
+COMMIT_MSG_FILE=$1
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# --- Subject length (72 chars hard limit) ---
+SUBJECT=$(echo "$COMMIT_MSG" | head -1)
+if [ ${#SUBJECT} -gt 72 ]; then
+  echo "ERROR: Subject line is ${#SUBJECT} chars (max 72)"
+  echo "Subject: $SUBJECT"
+  exit 1
+fi
+
+# --- Word count (150 words hard limit) ---
+BODY=$(echo "$COMMIT_MSG" | sed '1,/^$/d')
+if [ -n "$BODY" ]; then
+  WORD_COUNT=$(echo "$BODY" | wc -w)
+  if [ "$WORD_COUNT" -gt 150 ]; then
+    echo "ERROR: Body is ${WORD_COUNT} words (max 150)"
+    echo "Tip: Use bullet points or split into multiple commits"
+    exit 1
+  fi
+fi
+
+# --- Body line length (72 chars) ---
+if [ -n "$BODY" ]; then
+  LONG_LINES=$(echo "$BODY" | awk 'length > 72')
+  if [ -n "$LONG_LINES" ]; then
+    echo "WARNING: Some body lines exceed 72 characters:"
+    echo "$LONG_LINES" | while read -r line; do
+      echo "  (${#line} chars): $line"
+    done
+  fi
+fi
+
+echo "Commit message validated successfully"
+exit 0
+```
+
+### Installation
+
+```bash
+# Make hook executable
+chmod +x .git/hooks/commit-msg
+
+# Or use Husky for team sharing
+npm install --save-dev husky
+npx husky init
+echo 'npx --no -- commitlint --edit "\$1"' > .husky/commit-msg
+```
+
+---
+
+## Section 7: Integration with Existing Skills
+
+### Relationship Map
+
+```
+git-semantic-commits          (types, scopes, format)
+         │
+         ├── defines ──→ format structure
+         │
+         ▼
+git-compact-commits           (length, grouping, compact writing)
+         │
+         ├── extends ──→ length budgets + grouping strategy
+         ├── provides ──→ commitlint.config.js (authority for rules)
+         │
+         ▼
+semantic-release-convention   (CI/CD workflow, PR titles, release tags)
+         │
+         ├── consumes ──→ commitlint config from git-compact-commits
+         ├── governs ──→ PR title format, merge strategy, release pipeline
+         │
+         ▼
+     GitHub Actions           (enforcement)
+```
+
+### Data Flow
+
+1. `git-semantic-commits` defines WHAT a commit message looks like (type, scope, format)
+2. `git-compact-commits` defines HOW LONG it should be and HOW TO GROUP changes
+3. `semantic-release-convention` defines WHERE the commitlint config is used in CI
+
+### Cross-References
+
+- `git-semantic-commits` validation section → points here for extended length enforcement
+- `semantic-release-convention` section 6.1 → points here for commitlint config details
+
+---
+
+## Section 8: Verification Commands
+
+### Check Subject Length
+
+```bash
+# Check last commit's subject length
+git log -1 --pretty=%s | awk '{print length($0), $0}'
+
+# Check if subject exceeds 72 chars
+git log -1 --pretty=%s | awk '{if (length>72) print "FAIL:", length, "chars"; else print "OK:", length, "chars"}'
+```
+
+### Check Body Word Count
+
+```bash
+# Count words in last commit's body
+git log -1 --pretty=%b | wc -w
+
+# Check if body exceeds 150 words
+git log -1 --pretty=%b | awk '{words+=NF} END {if (words>150) print "FAIL:", words, "words"; else print "OK:", words, "words"}'
+```
+
+### Check Body Line Length
+
+```bash
+# Find lines exceeding 72 chars in body
+git log -1 --pretty=%b | awk 'length > 72 {print length, $0}'
+```
+
+### Validate Full Message
+
+```bash
+# Full validation of last commit
+echo "=== Commit Message Validation ==="
+SUBJECT=$(git log -1 --pretty=%s)
+BODY=$(git log -1 --pretty=%b)
+echo "Subject (${#SUBJECT} chars): $SUBJECT"
+[ ${#SUBJECT} -gt 72 ] && echo "  FAIL: exceeds 72 chars" || echo "  OK"
+echo "Body words: $(echo "$BODY" | wc -w)"
+echo "Body lines over 72 chars:"
+echo "$BODY" | awk 'length > 72 {print "  ", length, "chars:", $0}'
+```
+
+### Lint with commitlint
+
+```bash
+# Install commitlint
+npm install -g @commitlint/cli @commitlint/config-conventional
+
+# Lint last commit message
+echo "$(git log -1 --pretty=%B)" | commitlint
+
+# Lint specific message
+echo "feat(auth): add OAuth2 support" | commitlint
+```
+
+---
+
+## Section 9: Quick Reference Card
+
+### Length Budgets
+
+```
+Subject:  ≤ 72 chars  (50 ideal)
+Body:     ≤ 150 words (100 ideal)
+Lines:    ≤ 72 chars per line
+Total:    ≤ 250 words (200 ideal)
+```
+
+### Grouping Rules
+
+```
+GROUP when: same concern + same phase + same module + ≤ 150 words
+SPLIT when: different concern OR different phase OR > 150 words
+```
+
+### Compact Writing Checklist
+
+```
+☐ Subject under 72 chars?
+☐ Imperative mood? ("add" not "added")
+☐ Scope absorbs context? (feat(api): not "add api endpoint for")
+☐ Body uses bullets, not paragraphs?
+☐ "How" omitted (only "what" and "why")?
+☐ Similar items consolidated?
+☐ Body under 150 words?
+☐ Lines wrapped at 72 chars?
+```
+
+---
+
+## References
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Chris Beams - How to Write a Git Commit Message](https://cbea.ms/posts/git-commit/)
+- [Tim Pope - A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+- [commitlint Documentation](https://commitlint.js.org/)
+- [commitlint Rules Reference](https://commitlint.js.org/reference/rules)
+- [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action)

--- a/opencode_app/.opencode/skills/git-semantic-commits-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/git-semantic-commits-skill/SKILL.md
@@ -412,7 +412,10 @@ Update your API clients accordingly.
 3. **Subject Check**: Must be in imperative mood, no period at end
 4. **Subject Length**: Should be under 72 characters
 5. **Body Format**: Each line should be under 72 characters
-6. **Breaking Change**: Must be clearly indicated
+6. **Body Word Count**: Should be under 150 words
+7. **Breaking Change**: Must be clearly indicated
+
+> **Note**: For extended length enforcement (72-char subject hard limit, 150-word body limit, semantic grouping, commitlint config with custom word-count plugin, and GitHub Actions workflow), see `git-compact-commits-skill`. That skill is the authority for commitlint configuration and compact writing guidance.
 
 ### Validation Script
 

--- a/opencode_app/.opencode/skills/semantic-release-convention-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/semantic-release-convention-skill/SKILL.md
@@ -34,6 +34,7 @@ This is a **governance skill** - it defines conventions that other skills and ag
 | Skill | What It Consumes |
 |-------|-----------------|
 | `git-semantic-commits` | Commit type definitions and format rules |
+| `git-compact-commits` | Length budgets (72-char subject, 150-word body), semantic grouping strategy, commitlint config authority |
 | `pr-creation-workflow` | PR title format, label mapping, merge conventions, JIRA image handling |
 | `nextjs-pr-workflow` | Inherits via `pr-creation-workflow` |
 | `git-issue-labeler` | Semver label definitions and detection |
@@ -276,6 +277,8 @@ Four workflows enforce and automate these conventions:
 
 **Trigger**: Push to any branch
 
+> **Note**: The commitlint configuration with extended length rules (72-char subject, 150-word body, custom word-count plugin) is maintained in `git-compact-commits-skill`. That skill is the **authority** for `commitlint.config.js` and the word-count plugin. The workflow below uses that config.
+
 ```yaml
 name: Commit Lint
 on: [push]
@@ -287,6 +290,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.js
 ```
 
 ### 6.2. PR Title Validation

--- a/opencode_app/README.md
+++ b/opencode_app/README.md
@@ -23,7 +23,7 @@ opencode_app/
 ├── .dockerignore          # Excludes _archived, .env, node_modules
 └── .opencode/
     ├── agents/            # 31 agent .md files (single source of truth)
-    └── skills/            # 61 skill directories (single source of truth)
+    └── skills/            # 62 skill directories (single source of truth)
 ```
 
 ## How It Works


### PR DESCRIPTION
## Summary
- Add `git-compact-commits-skill` — a 10-section skill providing compact commit message authoring, semantic grouping strategy, and CI enforcement via commitlint
- Completes the 3-skill commit ecosystem alongside `git-semantic-commits` (format) and `semantic-release-convention` (CI/CD pipeline)
- Update deployment scripts and documentation with new skill count (61→62)

## JIRA Reference
- Ticket: BT-54
- Link: https://betekk.atlassian.net/browse/BT-54

## Changes
- **New**: `opencode_app/.opencode/skills/git-compact-commits-skill/SKILL.md` — 660-line skill covering semantic grouping, length budgets (72-char subject, 150-word body), compact writing techniques, commit templates, commitlint enforcement with custom word-count plugin, GitHub Actions workflow, local git hooks, and integration cross-references
- **Updated**: `semantic-release-convention-skill` — added to Governed Skills table, section 6.1 authority note
- **Updated**: `git-semantic-commits-skill` — added cross-reference in validation section
- **Updated**: `deploy/setup.sh` / `deploy/setup.ps1` — skill count 61→62, Git/Workflow 9→10, Framework 10→11
- **Updated**: `README.md`, `AGENTS.md`, `opencode_app/README.md` — skill counts

## Architecture Context
This skill completes a 3-skill commit ecosystem with clear authority boundaries:
| Skill | Authority |
|-------|-----------|
| `git-semantic-commits` | WHAT a commit looks like (types, scopes, format) |
| `git-compact-commits` (NEW) | HOW LONG it should be + HOW TO GROUP changes |
| `semantic-release-convention` | WHERE the config is used in CI/CD |

## Quality Checks
- Lint: Skipped (shell/markdown project, no framework linter)
- Build: Skipped (no build step)
- Test: Skipped (no test runner)
- Skill file convention: ✓ Proper frontmatter (name, description, license, compatibility)

## Files Modified
- `opencode_app/.opencode/skills/git-compact-commits-skill/SKILL.md` — New skill (660 lines)
- `opencode_app/.opencode/skills/git-semantic-commits-skill/SKILL.md` — Cross-reference
- `opencode_app/.opencode/skills/semantic-release-convention-skill/SKILL.md` — Governed Skills table
- `deploy/setup.sh` — Skill count updates
- `deploy/setup.ps1` — Skill count updates
- `README.md` — Skill count
- `AGENTS.md` — Skill count
- `opencode_app/README.md` — Skill count
- `PLANS/PLAN-BT-54.md` — Execution plan

## Code Review Results
Architecture review and code review both completed with all issues resolved:
- Body line length standardized to 72 chars across all 3 skills
- Squash-merge scope clarified (both branch commits and squash output)
- Cross-references added to all 3 skills
- commitlint word-count plugin fixed to respect `when` direction param
- Framework count corrected from 10 to 11 in deployment scripts

## Checklist
- [x] Code follows style guidelines
- [x] Skill file has proper frontmatter
- [x] Cross-references updated in sibling skills
- [x] Deploy scripts synchronized (setup.sh + setup.ps1)
- [x] Documentation counts updated
- [x] Self-reviewed