### PR TITLE
fix: code review fixes for #218 (step numbering, DRY detection, failure handling)

### DIFF
--- a/opencode_app/.opencode/agents/nextjs-setup-subagent.md
+++ b/opencode_app/.opencode/agents/nextjs-setup-subagent.md
@@ -8,6 +8,8 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  task:
+    "*": deny
   skill:
     nextjs-standard-setup-skill: allow
     docstring-generator-skill: allow
@@ -39,7 +41,7 @@ Workflow:
 5. Create Tekk-prefixed component architecture
 6. Configure proper imports and exports
 7. Add TSDoc documentation standards (via docstring-generator)
-8. Post-scaffold branch-workflow detection: use `glob`/`read` to check for existing release tooling (`.github/workflows/*release*`, `.releaserc*`, `release-please-config.json`, `.changeset/**`) and the skip marker (`.opencode/branch-workflow-skipped`). If ALL absent, include `NEEDS_GIT_BRANCH_SETUP: true` in the Return Contract so the primary agent can offer branch-workflow setup.
+8. Post-scaffold branch-workflow detection: check detection signals per `git-branch-workflow-setup-skill` §Detection Logic and the skip marker (`.opencode/branch-workflow-skipped`). If all signals absent, include `NEEDS_GIT_BRANCH_SETUP: true` in the Return Contract so the primary agent can offer branch-workflow setup.
 
 Always follow Next.js best practices:
 - Use next/image for all images

--- a/opencode_app/.opencode/agents/ticket-creation-subagent.md
+++ b/opencode_app/.opencode/agents/ticket-creation-subagent.md
@@ -215,11 +215,11 @@ After execution, this subagent provides:
 10. Commit PLAN file with semantic message: `docs(plan): add PLAN-{id}.md for {ticket-key}`
 11. Push branch to remote
 12. Post progress comment to ticket (GitHub: `gh issue comment`, JIRA: `atlassian_addCommentToJiraIssue`)
-13. **Optional branch-workflow signal:** After full-workflow branch creation, use `glob`/`read` to check for existing release tooling (`.github/workflows/*release*`, `.releaserc*`, `release-please-config.json`, `.changeset/**`) and the skip marker (`.opencode/branch-workflow-skipped`). If ALL absent, include `NEEDS_GIT_BRANCH_SETUP: true` in the Return Contract so the primary agent can offer branch-workflow setup. Do NOT invoke the skill or spawn `repo-ops-specialist` directly (permission denied).
+13. **Optional branch-workflow signal:** After full-workflow branch creation, check detection signals per `git-branch-workflow-setup-skill` §Detection Logic and the skip marker (`.opencode/branch-workflow-skipped`). If all signals absent, include `NEEDS_GIT_BRANCH_SETUP: true` in the Return Contract so the primary agent can offer branch-workflow setup. Do NOT invoke the skill or spawn `repo-ops-specialist` directly (permission denied).
 
 ### Step 4: Return Results
 
-13. Return ticket details to caller (see "What This Subagent Returns" section)
+14. Return ticket details to caller (see "What This Subagent Returns" section)
 
 ---
 

--- a/opencode_app/.opencode/skills/git-branch-workflow-setup-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/git-branch-workflow-setup-skill/SKILL.md
@@ -109,7 +109,7 @@ If the `question` tool is **unavailable, times out, or the context is non-intera
 
 ## Option Matrix
 
-When the user selects "Standard" or "Custom", the following parameters are configurable. **All defaults and valid values are cross-references** — this skill contains ZERO inline convention values:
+When the user selects "Standard" or "Custom", the following parameters are configurable. **Defaults and valid values are cross-referenced** to governance skills — this skill does not define new conventions:
 
 | Parameter | Default | Valid Values | Reference |
 |-----------|---------|--------------|-----------|
@@ -138,6 +138,14 @@ When the user accepts (options 1, 2, or 3), delegate execution to `repo-ops-spec
 | `checklist` | reference | Yes | Point to `version-bump-standard-skill` §Onboarding Checklist — do NOT copy steps |
 
 **Delegation instruction:** Pass the payload above to `repo-ops-specialist-subagent` via the Task tool. The executor loads `version-bump-standard-skill` (execution) and `semantic-release-convention-skill` (governance) itself — they are already in its `permission.skill` allowlist.
+
+### Failure Handling
+
+If `repo-ops-specialist-subagent` returns `Status: failed` or `Status: partial`:
+
+1. Do NOT write the skip marker (the user may want to retry)
+2. Surface the error to the user with the executor's **Issues** field
+3. Offer retry or skip — only write the skip marker if the user explicitly chooses skip
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

Hotfix for code review findings on PR #219 (issue #218). Fixes 2 Major and 2 Minor issues.

## Changes

| Issue | Severity | Fix |
|-------|----------|-----|
| Duplicate step 13 in ticket-creation-subagent | Major | Renumbered return step to 14 |
| Detection pattern mismatch (4 vs 6 signals) | Major | DRY fix: subagents reference skill §Detection Logic instead of listing patterns inline |
| No executor failure handling | Minor | Added failure handling subsection to delegation spec |
| nextjs-setup-subagent lacks task restriction | Minor | Added `task: { "*": deny }` to hard-block direct spawning |
| "ZERO inline" claim overstated | Nit | Softened to "cross-referenced, not defining new conventions" |

## Verification

- All counts remain correct (82 skills, Git/Workflow 12)
- Signal handler text consistent across all 3 AGENTS.md files