### PR TITLE
feat(BT-70): import grill-with-docs skill suite (4 skills) + prd-specialist wiring

### DIFF
--- a/PLANS/PLAN-BT-70.md
+++ b/PLANS/PLAN-BT-70.md
@@ -1,0 +1,111 @@
+# PLAN: Import grill-with-docs skill suite from mattpocock/skills
+
+**Ticket**: [BT-70](https://betekk.atlassian.net/browse/BT-70)
+**Branch**: `feature/BT-70-grill-with-docs-skills`
+**Status**: In Progress
+**PRD**: None
+
+---
+
+## Summary
+
+Import the `grill-with-docs` skill and its two supporting engines (`grilling`, `domain-modeling`) from [mattpocock/skills](https://github.com/mattpocock/skills), adapted to this repo's skill conventions. mattpocock's `grill-with-docs` is a thin user-invoked orchestrator that composes two model-invoked engines: `grilling` (relentless one-question-at-a-time interview) and `domain-modeling` (captures `CONTEXT.md` glossary + ADRs inline).
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Number of skills | 3 | Faithful to mattpocock's engine/entry-point split; grill-with-docs is meaningless without its 2 engines |
+| Naming convention | `-skill` suffix | Matches repo convention (e.g. `continuous-learning-skill`) |
+| Skill format | Single self-contained `SKILL.md` | This repo uses single-file skills; CONTEXT-FORMAT + ADR-FORMAT inlined into domain-modeling-skill rather than separate files |
+| Trigger metadata | `grilling`/`domain-modeling` = `auto`; `grill-with-docs` = `explicit-only` | Mirrors mattpocock's `disable-model-invocation` split |
+| New category | "Planning & Alignment" (3 skills) | Grilling/domain-modeling don't fit existing categories cleanly |
+| Skill count | 82 → 85 | +3 skills |
+
+### Architecture
+
+```
+User: "grill with docs"
+  → Primary agent loads grill-with-docs-skill (explicit-only)
+  → Orchestrates two model-invoked engines:
+      grilling-skill (auto)        — interview loop, one question at a time
+      domain-modeling-skill (auto) — CONTEXT.md + ADR capture inline
+  → Result: alignment + durable artifacts (glossary + ADRs)
+```
+
+---
+
+## Pre-existing Count Verification (2026-06-21)
+
+- Declared skill count in setup.sh/setup.ps1: **82**
+- Actual skill dirs (excl `_archived`/`scripts`) BEFORE this work: **82** (in sync)
+- After adding 3 skills: actual = **85**
+- Implementation rule: use verification command, sync declared → 85
+
+---
+
+## Implementation Phases
+
+### Phase 1: Skill Creation (DONE)
+
+- [x] **1.1** Created `grilling-skill/SKILL.md` — model-invoked interview engine
+- [x] **1.2** Created `domain-modeling-skill/SKILL.md` — model-invoked doc-capture engine (CONTEXT-FORMAT + ADR-FORMAT inlined)
+- [x] **1.3** Created `grill-with-docs-skill/SKILL.md` — user-invoked orchestrator
+
+### Phase 2: OpenCode Compliance Review
+
+- [ ] **2.1** Review all 3 skills with `opencode-tooling-subagent` for:
+    - Frontmatter correctness (name, license, compatibility, metadata, version)
+    - Trigger/invocation model (auto vs explicit-only)
+    - Repo conventions alignment
+    - Cross-skill references resolve
+    - No `glm-5.2` leakage (skills are not subagents, but check model-tiering awareness)
+- [ ] **2.2** Apply any fixes the subagent identifies
+
+### Phase 3: Subagent Wiring
+
+- [ ] **3.1** Determine which subagent(s) should use these skills:
+    - Candidates: `prd-specialist-subagent` (discovery interview overlaps), `ticket-creation-subagent` (pre-ticket alignment), `code-review-subagent`/`architecture-review-subagent` (domain-model capture post-review)
+    - Most natural fit: `prd-specialist-subagent` — grilling is the same relentless-interview pattern
+- [ ] **3.2** Apply wiring (add skill reference to chosen subagent's `.md`)
+
+### Phase 4: Deploy Script Updates
+
+- [ ] **4.1** Update `deploy/setup.sh`:
+    - Skill count: `SKILLS (82)` → `SKILLS (85)`
+    - Add new category "Planning & Alignment (3)" to the skills listing
+- [ ] **4.2** Update `deploy/setup.ps1` (parity):
+    - Skill count: `SKILLS (82)` → `SKILLS (85)`
+    - Add same category listing
+
+### Phase 5: README Sync
+
+- [ ] **5.1** Update `README.md` Skill Categories table (+ Planning & Alignment row)
+- [ ] **5.2** Update `opencode_app/README.md` if it has a skills listing
+
+### Phase 6: Code Review
+
+- [ ] **6.1** Final code review (use `code-review-subagent`) to catch any remaining issues:
+    - Frontmatter consistency across the 3 files
+    - Count synchronization (setup.sh, setup.ps1, README.md)
+    - No orphaned cross-references
+    - Category placement correctness
+
+---
+
+## Acceptance Criteria
+
+- [ ] 3 skills follow repo frontmatter conventions
+- [ ] opencode-tooling-subagent confirms compliance
+- [ ] Suitable subagent identified and wired
+- [ ] setup.sh + setup.ps1 counts synchronized at 85
+- [ ] README.md updated with new category
+- [ ] Code review passes with no blocking issues
+- [ ] Branch pushed with PLAN committed
+
+---
+
+## Notes
+
+- mattpocock's `grill-me` (grilling without docs) was intentionally NOT imported — `grill-with-docs-skill` references it as a fallback but it doesn't exist yet. If the user wants parity, a future ticket can add `grill-me-skill`.
+- The three skills reference each other in their "Integration with Other Skills" tables; all cross-references resolve within this set.

--- a/PLANS/PLAN-BT-70.md
+++ b/PLANS/PLAN-BT-70.md
@@ -15,12 +15,13 @@ Import the `grill-with-docs` skill and its two supporting engines (`grilling`, `
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Number of skills | 3 | Faithful to mattpocock's engine/entry-point split; grill-with-docs is meaningless without its 2 engines |
+| Number of skills | 4 (3 planned + grill-me-skill added per review) | Faithful to mattpocock's engine/entry-point split; grill-with-docs is meaningless without its 2 engines; grill-me added to resolve dangling cross-references flagged by opencode-tooling-subagent |
 | Naming convention | `-skill` suffix | Matches repo convention (e.g. `continuous-learning-skill`) |
 | Skill format | Single self-contained `SKILL.md` | This repo uses single-file skills; CONTEXT-FORMAT + ADR-FORMAT inlined into domain-modeling-skill rather than separate files |
-| Trigger metadata | `grilling`/`domain-modeling` = `auto`; `grill-with-docs` = `explicit-only` | Mirrors mattpocock's `disable-model-invocation` split |
-| New category | "Planning & Alignment" (3 skills) | Grilling/domain-modeling don't fit existing categories cleanly |
-| Skill count | 82 → 85 | +3 skills |
+| Trigger metadata | `grilling`/`domain-modeling` = `auto`; `grill-with-docs`/`grill-me` = `explicit-only` | Mirrors mattpocock's `disable-model-invocation` split |
+| New category | "Planning & Alignment" (4 skills) | Grilling/domain-modeling don't fit existing categories cleanly |
+| Skill count | 82 → 86 | +4 skills |
+| Subagent wiring | `prd-specialist-subagent` granted `grilling-skill` + `domain-modeling-skill` | Discovery interview = grilling pattern; domain term capture = domain-modeling |
 
 ### Architecture
 
@@ -51,45 +52,30 @@ User: "grill with docs"
 - [x] **1.1** Created `grilling-skill/SKILL.md` — model-invoked interview engine
 - [x] **1.2** Created `domain-modeling-skill/SKILL.md` — model-invoked doc-capture engine (CONTEXT-FORMAT + ADR-FORMAT inlined)
 - [x] **1.3** Created `grill-with-docs-skill/SKILL.md` — user-invoked orchestrator
+- [x] **1.4** Created `grill-me-skill/SKILL.md` — user-invoked orchestrator (added during Phase 2 review to resolve dangling refs)
 
-### Phase 2: OpenCode Compliance Review
+### Phase 2: OpenCode Compliance Review (DONE)
 
-- [ ] **2.1** Review all 3 skills with `opencode-tooling-subagent` for:
-    - Frontmatter correctness (name, license, compatibility, metadata, version)
-    - Trigger/invocation model (auto vs explicit-only)
-    - Repo conventions alignment
-    - Cross-skill references resolve
-    - No `glm-5.2` leakage (skills are not subagents, but check model-tiering awareness)
-- [ ] **2.2** Apply any fixes the subagent identifies
+- [x] **2.1** Reviewed all skills with `opencode-tooling-subagent` — verdict PASS-WITH-FIXES
+- [x] **2.2** Applied fixes: created `grill-me-skill` (resolves 4 dangling refs); removed `" grill with docs"` trigger phrase from grilling-skill (prevents auto-engine hijacking the orchestrator's trigger)
 
-### Phase 3: Subagent Wiring
+### Phase 3: Subagent Wiring (DONE)
 
-- [ ] **3.1** Determine which subagent(s) should use these skills:
-    - Candidates: `prd-specialist-subagent` (discovery interview overlaps), `ticket-creation-subagent` (pre-ticket alignment), `code-review-subagent`/`architecture-review-subagent` (domain-model capture post-review)
-    - Most natural fit: `prd-specialist-subagent` — grilling is the same relentless-interview pattern
-- [ ] **3.2** Apply wiring (add skill reference to chosen subagent's `.md`)
+- [x] **3.1** Identified `prd-specialist-subagent` as the best fit (discovery interview = grilling; domain term capture = domain-modeling)
+- [x] **3.2** Granted `grilling-skill: allow` + `domain-modeling-skill: allow` in prd-specialist-subagent permission.skill; added "Interview Enhancement Skills" guidance section
 
-### Phase 4: Deploy Script Updates
+### Phase 4: Deploy Script Updates (DONE)
 
-- [ ] **4.1** Update `deploy/setup.sh`:
-    - Skill count: `SKILLS (82)` → `SKILLS (85)`
-    - Add new category "Planning & Alignment (3)" to the skills listing
-- [ ] **4.2** Update `deploy/setup.ps1` (parity):
-    - Skill count: `SKILLS (82)` → `SKILLS (85)`
-    - Add same category listing
+- [x] **4.1** Updated `deploy/setup.sh`: count 82→86, added "Planning & Alignment (4)" to help + Deploy-Skills summary + banner
+- [x] **4.2** Updated `deploy/setup.ps1`: count 82→86, same category additions (parity)
 
-### Phase 5: README Sync
+### Phase 5: README Sync (DONE)
 
-- [ ] **5.1** Update `README.md` Skill Categories table (+ Planning & Alignment row)
-- [ ] **5.2** Update `opencode_app/README.md` if it has a skills listing
+- [x] **5.1** Updated `README.md`: 82 skills/14 categories → 86 skills/15 categories; added Planning & Alignment row to Skill Categories table
 
 ### Phase 6: Code Review
 
-- [ ] **6.1** Final code review (use `code-review-subagent`) to catch any remaining issues:
-    - Frontmatter consistency across the 3 files
-    - Count synchronization (setup.sh, setup.ps1, README.md)
-    - No orphaned cross-references
-    - Category placement correctness
+- [ ] **6.1** Final code review to catch any remaining issues
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ TypeScript, JavaScript, Python, Go, Rust, Java, C#, PHP, Ruby, C, C++, Swift, Ko
 
 ## Skill Modularization
 
-This repository implements **skill modularization** with 82 skills organized across 14 categories. Skills are designed with clear separation of concerns and explicit dependencies.
+This repository implements **skill modularization** with 86 skills organized across 15 categories. Skills are designed with clear separation of concerns and explicit dependencies.
 
 ### Skill Categories
 
@@ -297,6 +297,7 @@ This repository implements **skill modularization** with 82 skills organized acr
 | **Configuration** (2) | microsoft-m365-config-skill, codegraph-setup-skill | Microsoft 365 MCP and CodeGraph setup |
 | **Security** (2) | security-audit-skill, authentication-authorization-skill | Security auditing, vulnerability scanning, and auth implementation |
 | **DevOps** (4) | docker-containerization-skill, monorepo-management-skill, database-migration-skill, logging-observability-skill | Containerization, monorepos, database migrations, and observability |
+| **Planning & Alignment** (4) | grilling-skill, domain-modeling-skill, grill-with-docs-skill, grill-me-skill | Relentless interview/grilling sessions and domain model (CONTEXT.md glossary + ADR) capture |
 
 > **Note**: 6 redundant skills archived to `skills/_archived/`: `nextjs-complete-setup`, `python-docstring-generator`, `nextjs-tsdoc-documentor`, `git-pr-creator`, `git-issue-plan-workflow`, `jira-ticket-plan-workflow`. Use `docstring-generator` for all language docstrings (Python PEP 257, TypeScript TSDoc, Java Javadoc, C# XML docs). Use `ticket-plan-workflow-skill` for unified GitHub/JIRA ticket planning. 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ opencode-config-template/
 │   ├── .dockerignore
 │   ├── .opencode/
 │   │       ├── agents/              # 35 subagent .md files
-│   │       └── skills/              # 82 skill directories
+│   │       └── skills/              # 86 skill directories
 │   └── README.md                # Docker usage guide
 ├── docker-compose.yml           # Docker Compose service definition
 ├── .env.example                 # Environment variable template

--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -380,7 +380,7 @@ USAGE:
     Usage: opencode --agent build 'implement auth feature'
             opencode --agent explore 'find all API routes'
  
-          SKILLS (82):
+          SKILLS (86):
               Framework (15):       test-generator-framework, linting-workflow,
                                       pr-creation-workflow, pr-merge-workflow,
                                       error-resolver-workflow, tdd-workflow,
@@ -432,6 +432,9 @@ USAGE:
 
                  DevOps (4):     docker-containerization-skill, monorepo-management-skill,
                                  database-migration-skill, logging-observability-skill
+
+      Planning & Alignment (4): grilling-skill, domain-modeling-skill,
+                                grill-with-docs-skill, grill-me-skill
 
     Run 'opencode --list-skills' for detailed descriptions
     Run 'opencode --skill <name> \"prompt\"' to invoke a skill
@@ -1283,6 +1286,9 @@ function Deploy-Skills {
         Write-Host "      - construction-bd-skill"
         Write-Host "    Configuration (2):"
         Write-Host "      - microsoft-m365-config-skill, codegraph-setup-skill"
+        Write-Host "    Planning & Alignment (4):"
+        Write-Host "      - grilling-skill, domain-modeling-skill"
+        Write-Host "      - grill-with-docs-skill, grill-me-skill"
         Write-Host ""
         Write-Host "  Run 'opencode --list-skills' for detailed descriptions"
         Write-Host ""
@@ -1732,7 +1738,7 @@ function Show-NextSteps {
     Write-Host "         opencode `"prompt`" (uses build)"
      Write-Host ""
     Write-Host "=====================================================================" -ForegroundColor White
-     Write-Host "                     82 Skills Available" -ForegroundColor White
+     Write-Host "                     86 Skills Available" -ForegroundColor White
     Write-Host "=====================================================================" -ForegroundColor White
     Write-Host ""
     Write-Host "  Framework (15) • Language-Specific (6) • Framework-Specific (7)"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -584,7 +584,7 @@ USAGE:
       google-gce         Google Compute Engine management
       google-gke         Google Kubernetes Engine management
 
-   SKILLS (82):
+   SKILLS (86):
                Framework (15):       test-generator-framework, linting-workflow,
                                       pr-creation-workflow, pr-merge-workflow,
                                       error-resolver-workflow, tdd-workflow,
@@ -641,6 +641,9 @@ USAGE:
 
                  DevOps (4):     docker-containerization-skill, monorepo-management-skill,
                                  database-migration-skill, logging-observability-skill
+
+      Planning & Alignment (4): grilling-skill, domain-modeling-skill,
+                                grill-with-docs-skill, grill-me-skill
 
     Run 'opencode --list-skills' for detailed descriptions
     Run 'opencode --skill <name> "prompt"' to invoke a skill
@@ -2299,6 +2302,11 @@ print_summary() {
         echo "      - object-design"
         echo "      - code-smells"
         echo "      - complexity-management"
+        echo "    - Planning & Alignment (4):"
+        echo "      - grilling-skill"
+        echo "      - domain-modeling-skill"
+        echo "      - grill-with-docs-skill"
+        echo "      - grill-me-skill"
 
     else
         echo "✗ skills: Not deployed"
@@ -2364,7 +2372,7 @@ print_next_steps() {
     echo "         opencode \"prompt\" (uses build)"
      echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "                     📦 82 Skills Available"
+    echo "                     📦 86 Skills Available"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
     echo "  Framework (15) • Language-Specific (6) • Framework-Specific (7)"

--- a/opencode_app/.opencode/agents/prd-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/prd-specialist-subagent.md
@@ -15,6 +15,8 @@ permission:
   skill:
     prd-creation-skill: allow
     search-first-skill: allow
+    grilling-skill: allow
+    domain-modeling-skill: allow
 ---
 
 ## Prompt Defense Baseline
@@ -54,6 +56,13 @@ Invoke this subagent when the user uses phrases like:
 3. **At every optional section**: Present the section and ask "Adding this section?"
 4. **After all sections**: Show the full PRD summary and confirm before writing the file
 5. **Never assume** — always confirm. If the user provides incomplete information, ask for clarification rather than guessing.
+
+### Interview Enhancement Skills
+
+The discovery interview benefits from two model-invoked skills (already permitted above):
+
+- **`grilling-skill`** — Use its relentless one-question-at-a-time-with-recommendation methodology during Step 2 (core sections). When a section has unresolved branches, apply grilling: ask one question, give your recommended answer, wait for feedback before proceeding.
+- **`domain-modeling-skill`** — When the user introduces domain-specific terminology during discovery, use domain-modeling to sharpen it (propose precise canonical terms, list alternatives under `_Avoid_`). Capture resolved terms inline in `CONTEXT.md` if one exists, or note them for the PRD's glossary section. Only offer an ADR when a decision is hard-to-reverse + surprising + a real trade-off.
 
 ## Delegation Instructions
 

--- a/opencode_app/.opencode/skills/domain-modeling-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/domain-modeling-skill/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: domain-modeling-skill
+description: Actively build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain CONTEXT.md and ADRs inline. Changes the model — not merely reads it.
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers, agents
+  workflow: documentation, domain-design
+  trigger: auto
+version: 1
+---
+
+## What I do
+
+I actively build and sharpen the project's domain model as you design. This is the **active** discipline — challenging terms, inventing edge-case scenarios, and writing the glossary and decisions down the moment they crystallise.
+
+Merely *reading* `CONTEXT.md` for vocabulary is NOT this skill — that's a one-line habit any skill can do. I am for when you're **changing** the model, not just consuming it.
+
+1. **Challenge terms** against the existing glossary and surface contradictions immediately
+2. **Sharpen fuzzy language** by proposing precise canonical terms
+3. **Stress-test with scenarios** that probe edge cases and force precision about concept boundaries
+4. **Cross-reference with code** — when the user states how something works, verify the code agrees
+5. **Update CONTEXT.md inline** — capture resolved terms immediately, never batch them
+6. **Offer ADRs sparingly** — only when a decision is hard-to-reverse, surprising, and a real trade-off
+
+I am the **docs engine** (model-invoked). `grill-with-docs-skill` pairs me with `grilling-skill` so docs are captured during the interview.
+
+## When to use me
+
+Use this skill when:
+- The user introduces or disputes domain terminology
+- A ubiquitous language needs to be established or sharpened
+- An architectural decision has just been made and may warrant an ADR
+- Another skill (e.g. `grill-with-docs-skill`) delegates doc maintenance during a session
+- Code contradicts the user's stated understanding of how the system works
+
+**Trigger phrases**:
+- "let's define our terms"
+- "that should be an ADR"
+- "update CONTEXT.md"
+- "is that the right word for"
+- "capture this decision"
+- "ubiquitous language"
+
+## File Structure
+
+### Single-context repos (most repos)
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+### Multi-context repos
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          # system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 # context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+### Create files lazily
+
+Only create files when you have something to write:
+- No `CONTEXT.md` → create one when the first term is resolved
+- No `docs/adr/` → create it when the first ADR is needed
+
+**Inference rules:**
+- If `CONTEXT-MAP.md` exists → read it to find contexts
+- If only a root `CONTEXT.md` exists → single context
+- If neither exists → create a root `CONTEXT.md` lazily when the first term resolves
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.
+
+## Core Workflow
+
+### Step 1: Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately:
+
+> "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Step 2: Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term:
+
+> "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Step 3: Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Step 4: Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it:
+
+> "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Step 5: Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Do not batch these up — capture them as they happen. Use the **CONTEXT.md Format** below.
+
+`CONTEXT.md` must be **totally devoid of implementation details**. Do not treat it as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Step 6: Offer ADRs sparingly
+
+Only offer to create an ADR when **all three** are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, **skip the ADR**. Use the **ADR Format** below.
+
+## CONTEXT.md Format
+
+### Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+### Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include project-specific terms.** General programming concepts (timeouts, error types, utility patterns) don't belong. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+### Multi-context map
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+
+## Relationships
+
+- **Ordering → Billing**: Ordering emits `OrderPlaced` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+## ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc. Create the directory lazily.
+
+### Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+### Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them:
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+### Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+### What qualifies for an ADR
+
+All three of these must be true (hard to reverse + surprising + real trade-off). If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record.
+
+| Qualifies | Example |
+|-----------|---------|
+| **Architectural shape** | "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres." |
+| **Integration patterns between contexts** | "Ordering and Billing communicate via domain events, not synchronous HTTP." |
+| **Technology choices that carry lock-in** | Database, message bus, auth provider, deployment target — not every library, just ones that would take a quarter to swap out |
+| **Boundary and scope decisions** | "Customer data is owned by the Customer context; others reference it by ID only." The explicit no-s are as valuable as the yes-s. |
+| **Deliberate deviations from the obvious path** | "We're using manual SQL instead of an ORM because X." Stops the next engineer from "fixing" something that was deliberate. |
+| **Constraints not visible in code** | "We can't use AWS because of compliance." "Response times must be under 200ms because of the partner API contract." |
+| **Rejected alternatives when non-obvious** | If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months. |
+
+## Rules
+
+- **Never put implementation details in CONTEXT.md.** It is a glossary, not a spec.
+- **Capture inline, not in batches.** Resolved terms and decisions are written the moment they crystallise.
+- **Be opinionated about language.** Pick the best word; list the others under `_Avoid_`.
+- **Don't create ADRs reflexively.** The three-criteria gate exists to keep signal high.
+- **Verify claims against code.** The user's mental model and the code can drift; your job is to catch it.
+
+## Integration with Other Skills
+
+| Skill | Integration |
+|-------|-------------|
+| `grill-with-docs-skill` | Orchestrates `grilling-skill` + me to capture docs during an interview |
+| `grilling-skill` | The interview engine whose resolved terms I write down |
+| `continuous-learning-skill` | ADRs and glossary entries feed into long-term learning storage |
+| `architecture-review-subagent` | Review findings may surface decisions worth recording as ADRs |
+
+## Example Usage
+
+### During a grilling session
+
+```
+User: "When an order is cancelled, we refund the original payment method."
+Agent: "Quick glossary check — your CONTEXT.md defines 'cancellation' as voiding before fulfillment.
+        You just described refunding a *delivered* order, which sounds different. Is that
+        'return'? I'll add both terms if they're distinct."
+```
+
+The skill will:
+1. Cross-reference the claim against the existing `CONTEXT.md`
+2. Surface the contradiction
+3. Propose precise terms (`cancellation` vs `return`)
+4. Update `CONTEXT.md` inline once resolved
+
+### Offer an ADR
+
+```
+Agent: "We've decided ordering and billing communicate via domain events rather than
+        synchronous HTTP. That's hard to reverse, surprising (most teams default to HTTP),
+        and a real trade-off (eventual consistency). Want me to record it as ADR-0003?"
+```
+
+## References
+
+- `grill-with-docs-skill` - User-facing command that pairs `grilling-skill` with me
+- `grilling-skill` - The interview engine I capture docs from
+- `continuous-learning-skill` - Long-term storage for decisions

--- a/opencode_app/.opencode/skills/grill-me-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/grill-me-skill/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: grill-me-skill
+description: A relentless interview to sharpen a plan or design. User-invoked orchestrator that runs grilling-skill WITHOUT doc capture. Use when you want a grilling session but don't need CONTEXT.md or ADR artifacts.
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: planning, alignment
+  trigger: explicit-only
+version: 1
+---
+
+## What I do
+
+I orchestrate a plain grilling session — a relentless interview that sharpens a plan or design, with no doc artifacts produced. I delegate entirely to `grilling-skill` (the model-invoked interview engine).
+
+Use `grill-with-docs-skill` instead if you also want the session to capture `CONTEXT.md` (glossary) and ADRs inline.
+
+## When to use me
+
+Use this skill when:
+- You want to stress-test a plan or design via interview, but don't need durable doc artifacts
+- A quick alignment check before building is enough
+
+**Trigger phrases**:
+- "grill me"
+- "interview me about this plan"
+- "stress-test this idea"
+
+## Core Workflow
+
+### Step 1: Load the engine
+
+Delegate all behavior to `grilling-skill`. Do not reimplement the interview loop.
+
+### Step 2: Run the grilling session
+
+Apply `grilling-skill`'s rules:
+- One question at a time, each with a recommended answer
+- Explore the codebase instead of asking when possible
+- Walk the decision tree branch-by-branch until resolved or the user wants to build
+
+### Step 3: Conclude
+
+Summarise the resolved decisions and any open questions. No files are written.
+
+## Rules
+
+- **Do not reimplement the engine.** Delegate to `grilling-skill`.
+- **No doc capture.** If the user wants CONTEXT.md/ADR capture, redirect to `grill-with-docs-skill`.
+
+## Integration with Other Skills
+
+| Skill | Integration |
+|-------|-------------|
+| `grilling-skill` | The interview engine I orchestrate |
+| `grill-with-docs-skill` | The variant that ALSO captures CONTEXT.md + ADRs |
+| `domain-modeling-skill` | Not used by me (that's grill-with-docs-skill's job) |
+
+## Example Usage
+
+```
+"Grill me about how we should structure the notifications module"
+```
+
+The skill will delegate to `grilling-skill`, which interviews one question at a time with recommendations until the decision tree is resolved. No docs are written.
+
+## References
+
+- `grilling-skill` - Interview engine
+- `grill-with-docs-skill` - Variant with doc capture

--- a/opencode_app/.opencode/skills/grill-with-docs-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/grill-with-docs-skill/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: grill-with-docs-skill
+description: A relentless interview to sharpen a plan or design, which also creates docs (CONTEXT.md glossary and ADRs) as we go. User-invoked orchestrator that pairs grilling-skill with domain-modeling-skill.
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: planning, alignment, documentation
+  trigger: explicit-only
+version: 1
+---
+
+## What I do
+
+I orchestrate a focused session that combines two engines:
+
+1. **`grilling-skill`** — relentlessly interviews the user about the plan, one question at a time with a recommended answer, until the decision tree is resolved
+2. **`domain-modeling-skill`** — captures the crystallised terminology into `CONTEXT.md` and records hard-to-reverse decisions as ADRs, inline as they emerge
+
+The result is alignment AND a durable artifact: the next session (or the next agent) inherits a sharpened glossary and recorded decisions, so the work doesn't have to be re-litigated.
+
+## When to use me
+
+Use this skill when:
+- You want to stress-test a plan or design before building
+- You want the alignment session to ALSO produce domain docs (glossary + ADRs)
+- You're starting a non-trivial feature and want to lock down terminology first
+
+**Trigger phrases**:
+- "grill with docs"
+- "grill me and write it up"
+- "stress-test this plan and capture it"
+- "interview me and document"
+
+If you want the interview WITHOUT doc capture, use `grill-me-skill` instead.
+
+## Core Workflow
+
+### Step 1: Load both engines
+
+This skill delegates all behavior to two model-invoked engines. Do not reimplement them:
+
+- `grilling-skill` — owns the interview loop
+- `domain-modeling-skill` — owns doc capture
+
+### Step 2: Run the grilling session
+
+Invoke `grilling-skill` to conduct the interview. Apply its rules throughout:
+- One question at a time, each with a recommended answer
+- Explore the codebase instead of asking when possible
+- Walk the decision tree branch-by-branch
+
+### Step 3: Capture docs inline during the session
+
+As `grilling-skill` resolves each branch, hand off to `domain-modeling-skill` to:
+- **Challenge and sharpen terminology** against the existing `CONTEXT.md`
+- **Update `CONTEXT.md` inline** the moment a term is resolved
+- **Offer an ADR** only when a decision is hard-to-reverse + surprising + a real trade-off
+
+The two engines run interleaved, not sequentially. Doc capture happens *during* the interview, not after.
+
+### Step 4: Conclude
+
+When `grilling-skill` signals convergence (every branch resolved, or the user wants to build), summarise:
+- Terms added/changed in `CONTEXT.md`
+- ADRs created (if any)
+- Remaining open questions (if any)
+
+## Why This Combination Matters
+
+> With a ubiquitous language, conversations among developers and expressions of the code are all derived from the same domain model.
+> — Eric Evans, *Domain-Driven Design*
+
+Agents dropped into a project usually decode jargon as they go, using 20 words where 1 will do. A shared `CONTEXT.md` fixes this concisely:
+
+- **Before**: "There's a problem when a lesson inside a section of a course is made 'real' (i.e. given a spot in the file system)"
+- **After**: "There's a problem with the materialization cascade"
+
+This concision pays off session after session: variables/functions/files are named consistently, the codebase is easier to navigate, and the agent spends fewer tokens on thinking because it has a more concise language.
+
+## Rules
+
+- **Do not reimplement the engines.** Delegate to `grilling-skill` and `domain-modeling-skill`. This skill is an orchestrator, nothing more.
+- **Capture inline, not in a batch.** Docs are written as terms/decisions crystallise, not collected and dumped at the end.
+- **Respect the user's appetite.** If they want a shorter session, stop grilling earlier. Don't grill past their signal.
+- **Don't force ADRs.** The three-criteria gate (hard-to-reverse + surprising + real trade-off) is enforced by `domain-modeling-skill`. Most sessions create zero ADRs, and that's correct.
+
+## Integration with Other Skills
+
+| Skill | Integration |
+|-------|-------------|
+| `grilling-skill` | The interview engine I orchestrate |
+| `domain-modeling-skill` | The doc-capture engine I orchestrate |
+| `ticket-plan-workflow-skill` | A grilled, documented plan feeds cleanly into ticket/branch/PLAN creation |
+| `plan-execution-skill` | The resolved plan + glossary give execution a precise vocabulary |
+| `continuous-learning-skill` | ADRs and glossary entries become durable learnings |
+
+## Example Usage
+
+```
+"Grill with docs — we're adding a notifications module"
+```
+
+The skill will:
+1. Load `grilling-skill` and `domain-modeling-skill`.
+2. Begin the interview: "First — push, pull, or hybrid notifications? I recommend hybrid. Agree?"
+3. As terms resolve (e.g. "notification" vs "alert" vs "digest"), update `CONTEXT.md` inline.
+4. If a hard-to-reverse decision emerges (e.g. "we'll use a message bus, not polling"), offer an ADR.
+5. Conclude with a summary of docs written and any open questions.
+
+## References
+
+- `grilling-skill` - Interview engine
+- `domain-modeling-skill` - Doc-capture engine

--- a/opencode_app/.opencode/skills/grilling-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/grilling-skill/SKILL.md
@@ -36,7 +36,6 @@ Use this skill when:
 - "stress-test this plan"
 - "walk through the decision tree"
 - "what haven't we covered"
-- " grill with docs"
 
 ## Core Workflow
 

--- a/opencode_app/.opencode/skills/grilling-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/grilling-skill/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: grilling-skill
+description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building it, resolve a design decision tree, or uses any 'grill' trigger phrases. Asks one question at a time with a recommended answer.
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: developers, agents
+  workflow: planning, alignment
+  trigger: auto
+version: 1
+---
+
+## What I do
+
+I am the reusable interview engine behind `grill-me-skill` and `grill-with-docs-skill`. I relentlessly interview the user about a plan or design until we reach a shared understanding:
+
+1. **Decision-tree walk**: Walk down each branch of the design tree, resolving dependencies between decisions one-by-one
+2. **One question at a time**: Never ask multiple questions at once — that is bewildering
+3. **Recommended answer**: For each question, provide my recommended answer so the user can accept or correct
+4. **Codebase-first**: If a question can be answered by exploring the codebase, explore it instead of asking
+5. **Shared understanding**: Continue until every branch of the decision tree is resolved
+
+I am the **engine** (model-invoked). User-facing skills (`grill-me-skill`, `grill-with-docs-skill`) orchestrate me; they do not duplicate my behavior.
+
+## When to use me
+
+Use this skill when:
+- A plan, spec, or design needs stress-testing before implementation begins
+- The user uses any "grill" trigger phrase
+- Another skill (e.g. `grill-with-docs-skill`) delegates an interview session
+- Ambiguity in requirements is causing misalignment between user and agent
+
+**Trigger phrases**:
+- "grill me"
+- "interview me about"
+- "stress-test this plan"
+- "walk through the decision tree"
+- "what haven't we covered"
+- " grill with docs"
+
+## Core Workflow
+
+### Step 1: Frame the session
+
+State what we're grilling about in one sentence, then begin immediately. Do not ask the user "what do you want to be grilled on?" if it's already clear from context.
+
+### Step 2: Walk the decision tree
+
+For each unresolved branch of the design:
+
+1. **Identify the next dependency** — the decision that unblocks the most other decisions. Start with the highest-leverage unknowns.
+2. **Formulate a single question** — one question, phrased so a concrete answer resolves the branch.
+3. **Provide your recommended answer** — give your best recommendation with one-line rationale, so the user can say "yes" or correct you.
+4. **Wait for feedback** — do NOT proceed until the user answers. Asking multiple questions at once is the primary failure mode of this skill.
+
+### Step 3: Resolve via codebase, not questioning
+
+Before asking any question, check: **can I answer this myself by reading the code or project docs?**
+
+| Situation | Action |
+|-----------|--------|
+| Code clearly answers it | Read it and state the answer, don't ask |
+| Code contradicts the user's claim | Surface the contradiction: "Your code does X, but you said Y — which is right?" |
+| Genuinely a user-only decision | Ask the question |
+| Documented in `CONTEXT.md`, README, or ADRs | Read it, don't ask |
+
+### Step 4: Continue until convergence
+
+Keep walking the tree until either:
+- Every branch is resolved (success)
+- The user signals they want to start building (respect this — don't grill past their appetite)
+- Remaining unknowns are genuinely unresolvable until implementation begins (note them explicitly and move on)
+
+## Rules
+
+- **One question at a time.** This is the non-negotiable rule. A wall of questions overwhelms the user and breaks the feedback loop.
+- **Always recommend.** A bare question forces the user to do all the thinking. Lead with your recommendation.
+- **Never invent answers for user-only decisions.** If it's a product, scope, or preference call, ask — don't assume.
+- **Respect the stop signal.** When the user says "that's enough" or "let's build," stop grilling immediately.
+- **Don't repeat resolved questions.** Track what's been answered; re-asking signals you weren't listening.
+
+## Integration with Other Skills
+
+| Skill | Integration |
+|-------|-------------|
+| `grill-with-docs-skill` | Orchestrates me AND `domain-modeling-skill` to capture docs during the interview |
+| `grill-me-skill` | Orchestrates me alone (no docs capture) |
+| `domain-modeling-skill` | Paired with me by `grill-with-docs-skill` to write CONTEXT.md + ADRs inline |
+| `ticket-plan-workflow-skill` | Feeds a grilled, resolved plan into ticket/branch creation |
+
+## Example Usage
+
+### Plain grilling session
+
+```
+"Grill me about how we should structure the notifications module"
+```
+
+The skill will:
+1. Frame the session: "We're designing the notifications module structure."
+2. Ask one question with a recommendation: "First — should notifications be push, pull, or hybrid? I recommend hybrid (push for real-time, a polling fallback for missed events) — agree?"
+3. Wait for the answer, then proceed to the next branch.
+4. Continue until the decision tree is resolved.
+
+## References
+
+- `grill-with-docs-skill` - User-facing command that pairs me with doc capture
+- `domain-modeling-skill` - Doc capture engine used alongside me
+- `strategic-compact-skill` - A resolved grilling session can be compacted into a decision summary


### PR DESCRIPTION
## Summary

Imports the **grill-with-docs** skill suite (adapted from [mattpocock/skills](https://github.com/mattpocock/skills)) — a user-invoked orchestrator that composes two model-invoked engines for relentless interview + domain doc capture.

**Refs: BT-70**

---

## What was added

### 4 new skills in `opencode_app/.opencode/skills/`

| Skill | Trigger | Role |
|-------|---------|------|
| `grilling-skill` | auto (model-invoked) | Interview engine — one question at a time with recommended answer |
| `domain-modeling-skill` | auto (model-invoked) | Doc-capture engine — CONTEXT.md glossary + ADRs inline |
| `grill-with-docs-skill` | explicit-only (user-invoked) | Orchestrator — pairs grilling + domain-modeling |
| `grill-me-skill` | explicit-only (user-invoked) | Bare grilling without doc capture |

### Architecture

```
User: "grill with docs"
  → grill-with-docs-skill (explicit-only orchestrator)
  → grilling-skill (auto)          — interview loop
  → domain-modeling-skill (auto)   — CONTEXT.md + ADR capture inline
  → Result: alignment + durable artifacts
```

### Subagent wiring

`prd-specialist-subagent` now has `grilling-skill: allow` + `domain-modeling-skill: allow` in `permission.skill`, with an "Interview Enhancement Skills" guidance section mapping discovery interviews to grilling and domain term capture to domain-modeling.

### Documentation sync

| File | Change |
|------|--------|
| `deploy/setup.sh` | Count 82→86; added "Planning & Alignment (4)" category |
| `deploy/setup.ps1` | Count 82→86; same category (Windows parity) |
| `README.md` | 82 skills/14 categories → 86 skills/15 categories; added Planning & Alignment row; fixed stale count in Docker file tree |

### PLAN tracking

`PLANS/PLAN-BT-70.md` — all 5 implementation phases complete.

---

## Review history

| Reviewer | Verdict | Notes |
|----------|---------|-------|
| `opencode-tooling-subagent` | PASS-WITH-FIXES | Created `grill-me-skill` (4 dangling refs); removed trigger-phrase overlap from `grilling-skill` |
| `code-review-subagent` | PASS | Count sync verified, category math verified, no stale counts, frontmatter/YAML valid |

---

## Verification

```bash
# Skill count
ls -d opencode_app/.opencode/skills/*/ | grep -vE "_archived|scripts" | wc -l  # 86

# No stale counts
grep -rn '82\|85' deploy/setup.sh deploy/setup.ps1 README.md | grep -v '86'  # (empty)

# All frontmatter valid (name, description, license, compatibility, metadata.trigger)
head -12 opencode_app/.opencode/skills/{grilling,domain-modeling,grill-with-docs,grill-me}-skill/SKILL.md
```

---

## Semantic versioning

**minor** — additive, non-breaking: new skills, new category, subagent wiring, doc sync.