### PR TITLE
fix(setup): correct PowerShell agent layout check

### DIFF
--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -1358,7 +1358,7 @@ function Deploy-Agents {
         
         # Detect layout: flat files or subdirectories?
         $flatLayout = $true
-        if (Test-Path (Join-Path $AgentsSrcDir "primary")) -or (Test-Path (Join-Path $AgentsSrcDir "subagents"))) {
+        if ((Test-Path (Join-Path $AgentsSrcDir "primary")) -or (Test-Path (Join-Path $AgentsSrcDir "subagents"))) {
             $flatLayout = $false
         }
         


### PR DESCRIPTION
## Summary
- Fix PowerShell parser error in deploy/setup.ps1 agent layout detection
- Wrap the full Test-Path -or expression in parentheses so setup.ps1 can parse and run on Windows

## Verification
- powershell -NoProfile -ExecutionPolicy Bypass -File .\\deploy\\setup.ps1 -Help
- powershell -NoProfile -ExecutionPolicy Bypass -File .\\deploy\\setup.ps1 -SkillsOnly -DryRun -Yes