### PR TITLE
chore(agents): increase step limits for review subagents

### DIFF
--- a/opencode_app/.opencode/agents/architecture-review-subagent.md
+++ b/opencode_app/.opencode/agents/architecture-review-subagent.md
@@ -2,7 +2,7 @@
 description: Specialized subagent for architecture review using clean architecture principles, design patterns, and complexity management. Evaluates system design and suggests improvements.
 mode: subagent
 model: zai-coding-plan/glm-5.1
-steps: 20
+steps: 40
 permission:
   read: allow
   edit: deny

--- a/opencode_app/.opencode/agents/code-review-subagent.md
+++ b/opencode_app/.opencode/agents/code-review-subagent.md
@@ -2,7 +2,7 @@
 description: Comprehensive code review subagent combining SOLID principles, clean code, code smells, design patterns, and object design for thorough quality analysis. Ideal for pre-commit reviews and quality gates.
 mode: subagent
 model: zai-coding-plan/glm-5.1
-steps: 15
+steps: 30
 permission:
   read: allow
   edit:

--- a/opencode_app/.opencode/agents/go-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/go-reviewer-subagent.md
@@ -2,7 +2,7 @@
 description: Go code review subagent focusing on Go idioms, concurrency safety, error handling, and effective Go patterns for thorough Go quality analysis
 mode: subagent
 model: zai-coding-plan/glm-5.1
-steps: 15
+steps: 25
 permission:
   read: allow
   edit: deny

--- a/opencode_app/.opencode/agents/python-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/python-reviewer-subagent.md
@@ -2,7 +2,7 @@
 description: Python-specific code review subagent combining PEP 8, type hints, Pythonic patterns, security best practices, and async/concurrency review for thorough Python quality analysis
 mode: subagent
 model: zai-coding-plan/glm-5.1
-steps: 15
+steps: 25
 permission:
   read: allow
   edit: deny

--- a/opencode_app/.opencode/agents/rust-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/rust-reviewer-subagent.md
@@ -2,7 +2,7 @@
 description: Rust code review subagent focusing on ownership, borrow checker, unsafe safety, error handling with Result/Option, and idiomatic Rust patterns for thorough quality analysis
 mode: subagent
 model: zai-coding-plan/glm-5.1
-steps: 15
+steps: 25
 permission:
   read: allow
   edit: deny

--- a/opencode_app/.opencode/agents/typescript-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/typescript-reviewer-subagent.md
@@ -2,7 +2,7 @@
 description: TypeScript/JavaScript code review subagent focusing on type safety, modern ES patterns, React/Node best practices, and framework-specific quality analysis
 mode: subagent
 model: zai-coding-plan/glm-5.1
-steps: 15
+steps: 25
 permission:
   read: allow
   edit: deny


### PR DESCRIPTION
Review subagents were hitting step limits before completing thorough reviews.

## Changes

| Agent | Before | After | Reason |
|-------|--------|-------|--------|
| code-review-subagent | 15 | 30 | Needs diff read + test run + lint run + fix verification + report |
| architecture-review-subagent | 20 | 40 | Explores multiple files across repos, runs codegraph queries |
| python-reviewer-subagent | 15 | 25 | Focused review but still needs context reading |
| go-reviewer-subagent | 15 | 25 | Same |
| rust-reviewer-subagent | 15 | 25 | Same |
| typescript-reviewer-subagent | 15 | 25 | Same |

## Motivation

The code-review-subagent hit its 15-step limit twice during DA-1512 review, preventing it from running tests and lint checks before producing the final report.