### PR TITLE
fix(deploy): correct unbalanced parens in setup.ps1 Deploy-Agents function

### DIFF
--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -1362,7 +1362,7 @@ function Deploy-Agents {
         
         # Detect layout: flat files or subdirectories?
         $flatLayout = $true
-        if (Test-Path (Join-Path $AgentsSrcDir "primary")) -or (Test-Path (Join-Path $AgentsSrcDir "subagents"))) {
+        if ((Test-Path (Join-Path $AgentsSrcDir "primary")) -or (Test-Path (Join-Path $AgentsSrcDir "subagents"))) {
             $flatLayout = $false
         }
         


### PR DESCRIPTION
## Summary

Fixes a pre-existing PowerShell parse error in `deploy/setup.ps1:1365` that caused the `Deploy-Agents` function to fail parsing on PowerShell 5.1+ / 7.x.

## Root Cause

Line 1365 had an unbalanced parenthesis expression:

```powershell
# Before (broken):
if (Test-Path (Join-Path $AgentsSrcDir "primary")) -or (Test-Path (Join-Path $AgentsSrcDir "subagents"))) {
                            ^                 ^^^
                       missing (            extra )
```

PowerShell parser reports 6 cascading syntax errors from this single root cause:
- Line 1327: Missing closing `}` in statement block (cascading — `function Deploy-Agents {` start)
- Line 1359: Missing closing `}` (cascading from `if (Test-Path $AgentsSrcDir) {`)
- Line 1365: The root cause — unbalanced parens in the `if` condition
- Line 1365: Unexpected token `)` in expression
- Line 1421: Unexpected token `}` (cascading)
- Line 1424: Unexpected token `}` (cascading)

## The Fix

```powershell
# After (fixed):
if ((Test-Path (Join-Path $AgentsSrcDir "primary")) -or (Test-Path (Join-Path $AgentsSrcDir "subagents"))) {
```

One character change: add `(` after `if ` to properly wrap the boolean expression. The extra `)` at the end remains as the closing paren for the new opening `(`.

## Impact

**Without fix:** Any user running `setup.ps1` on PowerShell 5.1+ or 7.x would hit a parse error when the script reaches the `Deploy-Agents` function (called from `Set-Configuration`, which is called in every setup mode including `-Quick`, `-SkillsOnly`, and interactive default). The script would terminate without deploying agents.

**With fix:** Parser validates cleanly. Function executes correctly.

## Verification

```bash
# PowerShell parser validation (using pwsh 7.4.7):
$tokens = $null; $errors = $null
[System.Management.Automation.Language.Parser]::ParseFile('deploy/setup.ps1', [ref]$tokens, [ref]$errors) | Out-Null
$errors.Count
# Before fix: 6
# After fix:  0  ✓
```

Also verified `setup.sh` is unaffected (it has no equivalent bug — bash parser passes).

## Provenance

- **Discovered during post-merge validation of #241** (Next.js subagent consolidation)
- **NOT caused by #241** — this bug was introduced in commit `0461f5d5` (2026-04-20), well before the consolidation work
- **git blame** confirms line 1365 was untouched since 2026-04-20
- Surfacing as an independent follow-up PR for clean audit trail

## Risk

**Very low.** Single-character fix. No behavioral change — the `if` expression evaluates identically (both forms check the same condition). The fix only changes how PowerShell parses the expression, not its semantics.

## Testing

- [x] PowerShell parser validates with zero errors (pwsh 7.4.7)
- [x] git diff is minimal (1 insertion, 1 deletion)
- [x] No behavioral change to condition evaluation
- [x] setup.sh unaffected

---

🤖 Generated with [OpenCode](https://opencode.ai)
