### PR TITLE
Integrate LEARNINGS-ASSESSMENT Phase 1 skill patterns

### DIFF
--- a/PLANS/PLAN-GIT-247.md
+++ b/PLANS/PLAN-GIT-247.md
@@ -1,0 +1,217 @@
+# PLAN-GIT-247: Integrate LEARNINGS-ASSESSMENT skill improvements
+
+**Issue:** [#247](https://github.com/darellchua2/opencode-config-template/issues/247)
+**Branch:** `issue-247`
+**Owner:** unassigned
+**Status:** Phase 1 complete (uncommitted); Phases 2–5 pending
+
+---
+
+## Dependency & Consumer Map
+
+### Skill → Agent dependencies
+
+| Skill | Consuming Agents | Notes |
+|-------|-----------------|-------|
+| `clean-code-skill` | `code-review-subagent` (anti-pattern scan L167), `python-reviewer-subagent` (Backend Patterns L93) | Error Handling section added in Phase 1 |
+| `security-audit-skill` | `code-review-subagent` (anti-pattern scan L168), `architecture-review-subagent` (Pattern Reference L92) | 3 new Learning sections in Phase 1 |
+| `python-backend-skill` | `python-reviewer-subagent` (Backend Patterns L93), `architecture-review-subagent` (Pattern Reference L92) | DI singleton section added in Phase 1 |
+| `design-patterns-skill` | `architecture-review-subagent` (Pattern Reference L92) | Concurrency Patterns section added in Phase 1 |
+| `api-design-skill` | `code-review-subagent`, `architecture-review-subagent` | Phase 2 target |
+| `docker-containerization-skill` | `code-review-subagent`, `architecture-review-subagent` | Phase 2 target |
+| `authentication-authorization-skill` | `code-review-subagent` | Phase 3 target |
+| `nextjs-devtools-mcp-skill` | — | Phase 3 target (no agent consumer currently) |
+| `code-smells-skill` | `code-review-subagent` | Phase 5 granularization target |
+
+### Phase-level dependencies
+
+- **Phases 1–3** are independent across skills (each skill file is standalone); no cross-skill hard dependencies.
+- **Phase 4** depends on a validation decision before work can begin.
+- **Phase 5** depends on structural changes to `code-smells-skill` and downstream domain skills, plus a mandatory run of `documentation-sync-workflow` (skill scope changes affect `setup.sh` counts).
+
+---
+
+## Phase 1 — COMPLETE (8 atomic steps, all `[x]`)
+
+- [x] **1.1** Add `### Learning: two-phase-dataclass-initialization` to `clean-code-skill/SKILL.md` (L398)
+  — **Why:** Two-phase init silently masks validation gaps; agents need to flag this anti-pattern.
+  — **Done when:** `rg "two-phase-dataclass-initialization" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan), `python-reviewer-subagent` (Backend Patterns).
+
+- [x] **1.2** Add `### Learning: broad-except-masks-bugs` to `clean-code-skill/SKILL.md` (L493, merged with silent-error-swallowing)
+  — **Why:** Bare `except:` clauses swallow errors silently; root-cause analysis becomes impossible.
+  — **Done when:** `rg "broad-except-masks-bugs" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan), `python-reviewer-subagent` (Backend Patterns).
+
+- [x] **1.3** Add `### Learning: silent-failure-sequential-async` to `clean-code-skill/SKILL.md` (L527) and new `## Error Handling` top-level section
+  — **Why:** Sequential `await` without error handling fails silently in async chains; grouped under a dedicated section for discoverability.
+  — **Done when:** `rg "silent-failure-sequential-async" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches AND `rg "## Error Handling" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan), `python-reviewer-subagent` (Backend Patterns).
+
+- [x] **1.4** Add `### Prefer DI Over Global Singletons` to `python-backend-skill/SKILL.md` (L214, under Step 2)
+  — **Why:** Global singletons create hidden coupling and prevent test isolation; DI is the preferred pattern for FastAPI projects.
+  — **Done when:** `rg "Prefer DI Over Global Singletons" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns L93), `architecture-review-subagent` (Pattern Reference L92).
+
+- [x] **1.5** Add 3 Learning sections to `security-audit-skill/SKILL.md`: `auth-early-return-null-account-id` (L152, A01), `claim-check-ephemeral-secret-cache` (L196, A02), `encryption-key-length-not-validated` (L247, A02)
+  — **Why:** These are real-world security gaps found in production code; the skill must teach agents to detect and flag them.
+  — **Done when:** `rg "auth-early-return-null-account-id|claim-check-ephemeral-secret-cache|encryption-key-length-not-validated" opencode_app/.opencode/skills/security-audit-skill/SKILL.md` returns 3 matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan L168), `architecture-review-subagent` (Pattern Reference L92–96).
+
+- [x] **1.6** Add `## Concurrency Patterns` with `### Learning: atomic-sql-update-race-free-transition` to `design-patterns-skill/SKILL.md` (L636)
+  — **Why:** Race conditions in state transitions are a recurring production issue; the atomic UPDATE pattern is the correct fix.
+  — **Done when:** `rg "atomic-sql-update-race-free-transition" opencode_app/.opencode/skills/design-patterns-skill/SKILL.md` matches.
+  — **Consumers affected:** `architecture-review-subagent` (Pattern Reference L92–96).
+
+- [x] **1.7** Update `code-review-subagent.md` anti-pattern scan list (L167–168) to reference new Phase 1 sections
+  — **Why:** The code-review agent must know about new anti-patterns to flag them during reviews.
+  — **Done when:** `rg "two-phase-dataclass|broad-except|claim-check|encryption-key-length|null-account-id" opencode_app/.opencode/agents/code-review-subagent.md` returns matches.
+  — **Consumers affected:** `code-review-subagent` (self-reference).
+
+- [x] **1.8** Update `python-reviewer-subagent.md` (L93) and `architecture-review-subagent.md` (L92–96) agent checklists to reference Phase 1 sections
+  — **Why:** Both agents need expanded pattern lists to surface new findings during Python and architecture reviews.
+  — **Done when:** `rg "two-phase-dataclass|global _service|broad-except" opencode_app/.opencode/agents/python-reviewer-subagent.md` matches AND `rg "singleton mutation|claim-check|Atomic conditional UPDATE" opencode_app/.opencode/agents/architecture-review-subagent.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (self-reference), `architecture-review-subagent` (self-reference).
+
+---
+
+## Phase 2 — Ready to draft (9 atomic steps, high confidence)
+
+- [ ] **2.1** Add `#### fail-closed-open-config-toggle` to `security-audit-skill/SKILL.md` (under A02 or new subsection)
+  — **Why:** Open-by-default security toggles create exploitable misconfiguration vectors; agents must detect and flag.
+  — **Done when:** `rg "fail-closed-open-config-toggle" opencode_app/.opencode/skills/security-audit-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+- [ ] **2.2** Add `#### missing-tenant-isolation-definitions` to `security-audit-skill/SKILL.md`
+  — **Why:** Multi-tenant systems without isolation boundaries leak data between tenants; a critical security pattern.
+  — **Done when:** `rg "missing-tenant-isolation" opencode_app/.opencode/skills/security-audit-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan), `architecture-review-subagent` (Pattern Reference).
+
+- [ ] **2.3** Add `#### local-terraform-state-production` to `security-audit-skill/SKILL.md`
+  — **Why:** Local state files in production contain sensitive outputs and lack audit trails; must flag as infra-security anti-pattern.
+  — **Done when:** `rg "local-terraform-state" opencode_app/.opencode/skills/security-audit-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan), `architecture-review-subagent` (Pattern Reference).
+
+- [ ] **2.4** Add `### Learning: json-default-str-numpy-masking` to `python-backend-skill/SKILL.md`
+  — **Why:** `json.dumps(default=str)` silently masks type errors when numpy arrays are passed; data corruption follows silently.
+  — **Done when:** `rg "json-default-str-numpy-masking" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns).
+
+- [ ] **2.5** Add `### Learning: centralized-single-source-config` to `python-backend-skill/SKILL.md`
+  — **Why:** Scattered config values across modules cause drift and make environment-specific overrides error-prone.
+  — **Done when:** `rg "centralized-single-source-config" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns), `architecture-review-subagent` (Pattern Reference).
+
+- [ ] **2.6** Add `### Learning: defensive-enum-mapping-from-db-strings` to `python-backend-skill/SKILL.md`
+  — **Why:** Unmapped DB strings crash enum construction; defensive mapping prevents production KeyError exceptions.
+  — **Done when:** `rg "defensive-enum-mapping" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns).
+
+- [ ] **2.7** Add `### Learning: schema-output-contract-gap` to `api-design-skill/SKILL.md`
+  — **Why:** API handlers that return ad-hoc dicts instead of schema-validated responses break consumer contracts silently.
+  — **Done when:** `rg "schema-output-contract-gap" opencode_app/.opencode/skills/api-design-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan), `architecture-review-subagent` (Pattern Reference).
+
+- [ ] **2.8** Add `### Learning: no-rollback-on-deploy` to `docker-containerization-skill/SKILL.md`
+  — **Why:** Deployments without rollback strategies leave production in a broken state when new images fail; a critical ops anti-pattern.
+  — **Done when:** `rg "no-rollback-on-deploy" opencode_app/.opencode/skills/docker-containerization-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan), `architecture-review-subagent` (Pattern Reference).
+
+- [ ] **2.9** Add `### Learning: double-checked-locking-async-refresh` to `design-patterns-skill/SKILL.md` (under Concurrency Patterns)
+  — **Why:** Double-checked locking in async contexts is a subtle correctness bug; the pattern section must warn against it.
+  — **Done when:** `rg "double-checked-locking-async-refresh" opencode_app/.opencode/skills/design-patterns-skill/SKILL.md` matches.
+  — **Consumers affected:** `architecture-review-subagent` (Pattern Reference).
+
+---
+
+## Phase 3 — Medium priority (14 atomic steps)
+
+- [ ] **3.1** Add `### Learning: inline-imports-in-functions` to `python-backend-skill/SKILL.md`
+  — **Why:** Lazy imports obscure module-level dependencies and break static analysis; flag as readability/maintainability issue.
+  — **Done when:** `rg "inline-imports-in-functions" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns).
+
+- [ ] **3.2** Add `### Learning: method-name-reuse-different-semantics` to `clean-code-skill/SKILL.md`
+  — **Why:** Reusing method names with different semantics across classes violates the principle of least surprise.
+  — **Done when:** `rg "method-name-reuse-different-semantics" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+- [ ] **3.3** Add `### Learning: hardcoded-sed-version-swap` to `docker-containerization-skill/SKILL.md`
+  — **Why:** Sed-based version substitution in Dockerfiles is brittle and non-portable; prefer ARG/buildkit.
+  — **Done when:** `rg "hardcoded-sed-version-swap" opencode_app/.opencode/skills/docker-containerization-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+- [ ] **3.4** Add `### Learning: self-documented-duplication` to `clean-code-skill/SKILL.md`
+  — **Why:** Code that is self-documented yet duplicated across modules indicates missing abstraction; DRY violation disguised as clarity.
+  — **Done when:** `rg "self-documented-duplication" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+- [ ] **3.5** Add `### Learning: mock-headers-magicmock-truthy` to `python-backend-skill/SKILL.md`
+  — **Why:** MagicMock returns truthy for any attribute access, masking header typos in tests; agents must flag as test anti-pattern.
+  — **Done when:** `rg "mock-headers-magicmock-truthy" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns).
+
+- [ ] **3.6** Add `### Learning: toast-promise-await-without-catch` to `clean-code-skill/SKILL.md`
+  — **Why:** Toast notifications wrapping Promises without catch handlers swallow errors silently from the user's perspective.
+  — **Done when:** `rg "toast-promise-await-without-catch" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+- [ ] **3.7** Add `### Learning: doc-claimed-purity-vs-reality` to `clean-code-skill/SKILL.md`
+  — **Why:** Functions documented as pure that perform I/O create false confidence and prevent correct refactoring.
+  — **Done when:** `rg "doc-claimed-purity-vs-reality" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+- [ ] **3.8** Add `### Learning: cross-container-hook-borrowing` to `design-patterns-skill/SKILL.md`
+  — **Why:** Borrowing hooks from one Docker container into another creates implicit coupling and brittle deployment dependencies.
+  — **Done when:** `rg "cross-container-hook-borrowing" opencode_app/.opencode/skills/design-patterns-skill/SKILL.md` matches.
+  — **Consumers affected:** `architecture-review-subagent` (Pattern Reference).
+
+- [ ] **3.9** Add `### Learning: placeholder-swap-validation` to `python-backend-skill/SKILL.md`
+  — **Why:** Template placeholder swaps without validation inject malformed content when keys are missing.
+  — **Done when:** `rg "placeholder-swap-validation" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns).
+
+- [ ] **3.10** Add `### Learning: hardcoded-magic-timeout-activities` to `python-backend-skill/SKILL.md`
+  — **Why:** Magic timeout values in activity/step functions create race conditions under load; must be configurable.
+  — **Done when:** `rg "hardcoded-magic-timeout" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns).
+
+- [ ] **3.11** Add `### Learning: cookie-only-proxy-with-server-rbac` to `authentication-authorization-skill/SKILL.md`
+  — **Why:** Cookie-only auth behind a proxy that also does RBAC creates a double-layer confusion; agents need to identify the correct enforcement boundary.
+  — **Done when:** `rg "cookie-only-proxy-with-server-rbac" opencode_app/.opencode/skills/authentication-authorization-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+- [ ] **3.12** Add `### Learning: zero-copy-buffer-to-uint8array` to `python-backend-skill/SKILL.md`
+  — **Why:** Converting buffers to Uint8Array without zero-copy creates unnecessary memory allocations in hot paths.
+  — **Done when:** `rg "zero-copy-buffer-to-uint8array" opencode_app/.opencode/skills/python-backend-skill/SKILL.md` matches.
+  — **Consumers affected:** `python-reviewer-subagent` (Backend Patterns).
+
+- [ ] **3.13** Add `### Learning: three-line-not-disposed-in-overlay-cleanup` to `nextjs-devtools-mcp-skill/SKILL.md`
+  — **Why:** Three.js objects not disposed during overlay cleanup cause GPU memory leaks in long-running sessions.
+  — **Done when:** `rg "three-line-not-disposed" opencode_app/.opencode/skills/nextjs-devtools-mcp-skill/SKILL.md` matches.
+  — **Consumers affected:** None — content addition only (no agent currently references this skill).
+
+- [ ] **3.14** Add `### Learning: feature-bounds-value-object` to `clean-code-skill/SKILL.md`
+  — **Why:** Feature flags gating business logic without value-object encapsulation create scattered conditionals; encapsulate in value objects.
+  — **Done when:** `rg "feature-bounds-value-object" opencode_app/.opencode/skills/clean-code-skill/SKILL.md` matches.
+  — **Consumers affected:** `code-review-subagent` (anti-pattern scan).
+
+---
+
+## Phase 4 — Validate first (1 atomic step)
+
+- [ ] **4.1** Add `### Learning: parallel-hierarchies-for-report-type-variants` to target skill (clean-code-skill OR clean-architecture-skill — validate first)
+  — **Why:** Parallel class hierarchies for report variants indicate missing abstraction; the correct skill home depends on whether the pattern is a code smell or an architecture concern.
+  — **Done when:** Validation decision recorded (which skill) AND `rg "parallel-hierarchies-for-report" <target-skill>/SKILL.md` matches.
+  — **Consumers affected:** Depends on target — `code-review-subagent` if clean-code; `architecture-review-subagent` if clean-architecture.
+  — **BLOCKED ON:** Validation of target skill (read both skill files and assessment context before deciding).
+
+---
+
+## Phase 5 — Optional (1 atomic step, BLOCKED ON USER CONFIRMATION)
+
+- [ ] **5.1** Granularize `code-smells-skill` items #8–11 — move project-specific smells into domain skills (inline-http-header-parsing → `python-backend-skill`, duplicated-response-parsing → `python-backend-skill`, duplicate-service-account-check → `python-backend-skill`, scattered-z-index-magic-numbers → `clean-code-skill` or frontend-design-skill)
+  — **Why:** Generic code-smell descriptions with project-specific examples reduce the skill's reusability; domain skills provide better context.
+  — **Done when:** Project-specific items removed from `code-smells-skill/SKILL.md` AND equivalent Learning sections added to target domain skills AND `documentation-sync-workflow` run to update `setup.sh` counts if skill file structure changed.
+  — **Consumers affected:** `code-review-subagent` (references both code-smells-skill and domain skills), all domain target skills.
+  — **BLOCKED ON USER CONFIRMATION:** This changes `code-smells-skill` scope and may require documentation-sync-workflow run.

--- a/opencode_app/.opencode/agents/architecture-review-subagent.md
+++ b/opencode_app/.opencode/agents/architecture-review-subagent.md
@@ -87,6 +87,14 @@ After completing the review, use the `continuous-learning` skill to persist find
 
 The continuous-learning skill auto-provisions `LEARNINGS/` if it doesn't exist in the project.
 
+## Pattern Reference (cross-skill)
+
+Actively scan for these architecture-relevant patterns during review:
+
+- **Global singleton mutation** — `global _service` pattern hides coupling, no lifecycle management; prefer FastAPI `Depends()` with `app.state` (see `python-backend-skill` → Prefer DI Over Global Singletons)
+- **Claim-check pattern for secrets** — in workflow orchestrators, plaintext credentials must never touch durable history; use opaque UUID claim IDs with TTL cache + single-read `pop()` (see `security-audit-skill` A02 → claim-check-ephemeral-secret-cache)
+- **Atomic conditional UPDATE** — race-free state transitions via `UPDATE ... WHERE expected_state RETURNING cols` as optimistic lock; avoids read-then-write TOCTOU races (see `design-patterns-skill` → Concurrency Patterns)
+
 ## Mandatory Consumer Traversal Gate
 
 **This is a blocking gate, not optional guidance.** Before sign-off, you MUST map every changed symbol's consumers. The review verdict is capped at `partial` if any changed symbol's consumers were not inspected.

--- a/opencode_app/.opencode/agents/code-review-subagent.md
+++ b/opencode_app/.opencode/agents/code-review-subagent.md
@@ -164,7 +164,8 @@ For each Critical / Major / Minor issue AND each Positive Observation, classify 
 **Anti-pattern detection is first-class.** Actively scan using:
 - `react-nextjs-antipatterns-skill` — React 19 / Next.js 16 runtime anti-patterns (hydration, RBAC, memory leaks)
 - `code-smells-skill` — long methods, large classes, feature envy, primitive obsession, duplication
-- `security-audit-skill` — OWASP issues, auth/validation flaws, secret exposure
+- `security-audit-skill` — OWASP issues, auth/validation flaws, secret exposure, claim-check pattern for secrets, encryption key length validation, null-account-id privilege escalation
+- `clean-code-skill` — broad `except Exception` masking bugs as outages, silent failure in sequential async (function catches own error), two-phase dataclass initialization (placeholder values requiring separate patch)
 
 ### Step 2 — Dedup check (before writing)
 

--- a/opencode_app/.opencode/agents/python-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/python-reviewer-subagent.md
@@ -90,7 +90,7 @@ You are a Python code review specialist. Perform thorough quality analysis with 
 | **Flask** | Blueprint organization, proper app factory, request context |
 | **SQLAlchemy** | Session management, relationship loading, migration compatibility |
 
-**Backend Patterns**: Use `python-backend` to check for SQLAlchemy detached-instance bugs, Pydantic-on-JSONB pitfalls, async SSE durability issues, and enum strategy resolution patterns.
+**Backend Patterns**: Use `python-backend` to check for SQLAlchemy detached-instance bugs, Pydantic-on-JSONB pitfalls, async SSE durability issues, enum strategy resolution patterns, two-phase dataclass initialization (placeholder values requiring separate patch), and `global _service` singletons (prefer FastAPI `Depends()` with `app.state` lifecycle). Also use `clean-code-skill` for broad `except Exception` masking bugs in auth/transport/processing paths.
 
 ## Severity Scoring
 

--- a/opencode_app/.opencode/skills/clean-code-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/clean-code-skill/SKILL.md
@@ -395,6 +395,32 @@ class Account {
 const result = account.withdraw(amount);
 ```
 
+### Learning: `two-phase-dataclass-initialization`
+
+A function returns an object with sentinel/placeholder values (`0.0`, `None`, `""`) that the caller must separately patch. If the second call is forgotten, the result is silently wrong — not an error, just incorrect data.
+
+**Rule:** Every function must return a **complete** object. If a field cannot be computed at construction time, make it `Optional[None]` so the type system surfaces the incompleteness.
+
+```python
+# BAD — caller must know to call compute_bounds() separately
+def create_template(name: str) -> Template:
+    return Template(name=name, mean=0.0, stddev=0.0, low=0.0, high=0.0)
+# ... later ...
+tpl = create_template("sensor")
+tpl.compute_bounds(data)  # FORGOTTEN → silent wrong results, 0.0 bounds
+
+# GOOD — split into separate complete-returning functions
+def create_empty_template(name: str) -> Template:
+    """Returns template with None bounds — caller MUST call populate()."""
+    return Template(name=name, mean=None, stddev=None, low=None, high=None)
+
+def populate_template(tpl: Template, data: list[float]) -> Template:
+    """Returns a NEW template with computed bounds."""
+    return Template(name=tpl.name, mean=mean(data), stddev=stdev(data), ...)
+```
+
+**Detection:** Look for functions returning objects with hardcoded `0.0`, `""`, `None`, `[]` defaults that have companion `compute_*` or `populate_*` methods.
+
 ---
 
 ## Comments
@@ -458,6 +484,90 @@ def extract_report_id(response: requests.Response) -> str:
         f"Could not extract report_id from response "
         f"(status={response.status_code}, body={response.text[:200]})"
     )
+```
+
+---
+
+## Error Handling
+
+### Learning: `broad-except-masks-bugs`
+
+**Suggestion #1 + #8 merged** — same root cause observed across 3 projects (Python async, Python DSP, TypeScript sequential async).
+
+Narrow catches handle expected transport errors; broad `except Exception` masks programming bugs as service outages. Expected errors (`ConnectError`, `TimeoutException`, `HTTPStatusError`) are caught and degraded. Unexpected errors (`AttributeError`, `KeyError`, `TypeError`) must propagate as 500s so monitoring surfaces them — they are never "service unreachable."
+
+```python
+# BAD — programming bugs (KeyError, AttributeError) are silently treated as "service down"
+try:
+    result = await client.call()
+except Exception:
+    logger.warning("Service unreachable, degrading...")
+    return fallback  # Bug is now invisible — circuit breaker trips on a typo
+
+# GOOD — narrow catch for expected transport errors; bugs propagate
+try:
+    result = await client.call()
+except (ConnectError, TimeoutException, HTTPStatusError):
+    logger.warning("Service unreachable, degrading...")
+    return fallback
+# AttributeError, KeyError, TypeError propagate as 500 → surfaces in monitoring
+```
+
+**Detection:**
+
+```bash
+# Find broad excepts in auth/transport/processing paths
+rg 'except Exception\b|except:' --type py -l
+# DSP/ML/processing modules are especially dangerous — wrong results with no error
+rg 'except Exception' --type py -g '*dsp*' -g '*audio*' -g '*process*'
+```
+
+**Rule:** Define a domain exception hierarchy for expected failures. Never catch `Exception` or bare `except:` in code paths that process external data — you will mask genuine bugs as degraded results.
+
+### Learning: `silent-failure-sequential-async`
+
+A critical async operation that catches its own failure and logs only `console.error` (or `logger.error`) prevents the caller from detecting the failure. The caller continues with stale or missing data, entering an inconsistent state with no feedback.
+
+**Rule:** Sequential async operations must either:
+1. **Throw on failure** — let the caller decide whether to degrade, or
+2. **Return a discriminated union** — `Result[T, E]` type so the caller explicitly handles both paths.
+
+```python
+# BAD — caller cannot detect failure; enters inconsistent state
+async def sync_engine_to_cds():
+    try:
+        data = await engine.get_data()
+        await cds.upload(data)
+    except Exception:
+        logger.error("Sync failed")  # Caller gets None, thinks everything is fine
+
+# GOOD — throws; caller catches explicitly
+async def sync_engine_to_cds() -> None:
+    data = await engine.get_data()
+    await cds.upload(data)  # Raises on failure — caller handles
+```
+
+```typescript
+// BAD — fire-and-forget with internal catch; caller has no signal
+toast.promise(apiCall(), {
+  error: "Failed",  // User sees toast, but caller's await never throws
+})
+await apiCall() // Unhandled rejection if no catch — see react-nextjs-antipatterns
+
+// GOOD — single consumer; error propagates
+try {
+  const result = await apiCall()
+  toast.success("Done")
+} catch (e) {
+  toast.error("Failed")
+}
+```
+
+**Detection:**
+
+```bash
+# Functions that catch their own errors and only log
+rg 'except.*:\s*\n\s*(logger|console)\.(error|warning)' --type py --type ts -U
 ```
 
 ---

--- a/opencode_app/.opencode/skills/design-patterns-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/design-patterns-skill/SKILL.md
@@ -633,6 +633,51 @@ history.undo();  // Removes item
 
 ---
 
+## Concurrency Patterns
+
+### Learning: `atomic-sql-update-race-free-transition`
+
+Use a single `UPDATE ... WHERE expected_state RETURNING cols` as an optimistic lock. The `WHERE` clause acts as the guard; `RETURNING` fetches needed columns in one round-trip. Losers re-read and reconcile idempotently.
+
+```python
+# WRONG — read-then-write race; two callers both transition state
+run = await db.get_run(run_id)
+if run.status == "pending":
+    run.status = "running"
+    await db.commit()  # RACE: another worker already committed "running"
+    await launch_side_effects(run)  # Duplicate side effects!
+
+# CORRECT — atomic conditional UPDATE
+from sqlalchemy import update
+
+result = await session.execute(
+    update(Run)
+    .where(Run.id == run_id, Run.status == "pending")  # Optimistic lock
+    .values(status="running", started_at=func.now())
+    .returning(Run)  # Fetch in same round-trip
+)
+row = result.fetchone()
+if row is None:
+    # Another worker already transitioned — reconcile idempotently
+    return await db.get_run(run_id)
+
+await launch_side_effects(row)  # Exactly ONE worker reaches here
+```
+
+**Key properties:**
+- **Race-free**: the database row-level lock ensures only one `UPDATE` matches
+- **One round-trip**: no separate SELECT + UPDATE
+- **Idempotent reconciliation**: losers simply re-read current state
+
+**Detection:**
+
+```bash
+# Find read-then-write patterns vulnerable to races
+rg 'get_.*\(\|fetch_.*\(' --type py -A 10 | rg 'status|state' | rg 'commit|save|update'
+```
+
+---
+
 ## Pattern Selection Guide
 
 | Problem | Pattern | Key Indicator |

--- a/opencode_app/.opencode/skills/python-backend-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/python-backend-skill/SKILL.md
@@ -211,6 +211,39 @@ async def get_user_service(repo: Annotated[UserRepository, Depends(get_user_repo
 UserServiceDep = Annotated[UserService, Depends(get_user_service)]
 ```
 
+### Prefer DI Over Global Singletons
+
+**Learning**: `module-singleton-global-mutation`
+
+Module-level singletons via `global _service` hide coupling, resist testing, and have no lifecycle management. The `httpx.AsyncClient` inside never gets closed, connections leak, and tests must null globals between runs.
+
+```python
+# WRONG — hidden coupling, no lifecycle, tests must mutate global state
+_service: Optional[MyService] = None
+
+def get_service() -> MyService:
+    global _service
+    if _service is None:
+        _service = MyService(client=httpx.AsyncClient())  # Never closed!
+    return _service
+
+# CORRECT — FastAPI Depends() with app.state lifecycle
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.client = httpx.AsyncClient()
+    yield
+    await app.state.client.aclose()  # Clean shutdown
+
+app = FastAPI(lifespan=lifespan)
+
+async def get_service(client: httpx.AsyncClient = Depends(lambda r: r.app.state.client)):
+    return MyService(client=client)
+```
+
+**Rule:** Use `FastAPI Depends()` with `app.state` for lifecycle-managed singletons. Never use `global _x` patterns — they hide dependencies from type checkers and prevent test overrides.
+
 ---
 
 ## Step 3: Django Project Structure

--- a/opencode_app/.opencode/skills/security-audit-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/security-audit-skill/SKILL.md
@@ -149,6 +149,42 @@ function requireAdmin(req, res, next) {
 }
 ```
 
+#### auth-early-return-null-account-id
+
+Skipping the ownership check when `account_id` is `None` (or missing from headers) allows any header-less user full access to resources. This is **horizontal privilege escalation** — one missing header bypasses all authorization.
+
+```bash
+# Detection: find auth checks that early-return on None/missing input
+rg 'account_id is None|account_id == None|if not account_id' --type py -A 3 | \
+  rg 'return (True|None|next|$)'
+```
+
+```python
+# VULNERABLE — None account_id skips ownership check entirely
+async def get_run(run_id: str, account_id: str | None):
+    run = await db.get_run(run_id)
+    if account_id is None:
+        return run  # ANY authenticated user gets ANY run
+    if run.account_id != account_id:
+        raise Forbidden()
+    return run
+
+# SECURE — separate legacy access from ownership verification
+async def get_run(run_id: str, account_id: str | None):
+    run = await db.get_run(run_id)
+
+    # Legacy: NULL-account runs are publicly readable (migration period only)
+    if run.account_id is None:
+        return run
+
+    # Non-NULL runs REQUIRE header match — no exception
+    if not account_id or run.account_id != account_id:
+        raise Forbidden("Ownership verification required")
+    return run
+```
+
+**Rule:** Never skip authorization on missing optional input. Separate "this resource is legacy/public" from "the caller didn't send a header" — they are different conditions with different security implications.
+
 ### A02: Cryptographic Failures
 
 - [ ] Verify TLS 1.2+ enforced everywhere
@@ -156,6 +192,96 @@ function requireAdmin(req, res, next) {
 - [ ] Confirm sensitive data encrypted at rest
 - [ ] Verify proper hashing algorithms (bcrypt, argon2 — not MD5/SHA1)
 - [ ] Check PII handling and data classification
+
+#### claim-check-ephemeral-secret-cache
+
+Store decrypted secrets in a short-lived in-memory TTL cache keyed by an opaque UUID. Pass only the **claim ID** through durable workflow history — never the plaintext credential.
+
+```bash
+# Detection: find plaintext secrets passed to workflow/activity arguments
+rg 'decrypt|get_secret|plaintext.*secret' --type py -A 5 | \
+  rg 'workflow\.(execute|start)|activity|yield|await.*\('
+```
+
+```python
+# VULNERABLE — plaintext secret persisted to orchestrator execution history
+@activity
+async def process_payment(run_id: str, api_key: str):  # api_key in durable history!
+    client = PaymentClient(api_key)
+
+# SECURE — claim-check pattern; only opaque UUID in history
+import asyncio, time, uuid
+from collections import OrderedDict
+
+class SecretCache:
+    def __init__(self, ttl: int = 300, max_size: int = 100):
+        self._cache: OrderedDict[str, tuple[str, float]] = OrderedDict()
+        self._ttl = ttl
+        self._max_size = max_size
+        self._lock = asyncio.Lock()
+
+    async def deposit(self, plaintext: str) -> str:
+        claim_id = str(uuid.uuid4())
+        async with self._lock:
+            self._cache[claim_id] = (plaintext, time.monotonic() + self._ttl)
+            if len(self._cache) > self._max_size:
+                self._cache.popitem(last=False)  # LRU eviction
+        return claim_id
+
+    async def redeem(self, claim_id: str) -> str | None:
+        async with self._lock:
+            entry = self._cache.pop(claim_id, None)  # Single-read (pop)
+            if entry and entry[1] > time.monotonic():
+                return entry[0]
+        return None  # Expired or already consumed
+
+@activity
+async def process_payment(run_id: str, claim_id: str):  # Only UUID in history
+    api_key = await secret_cache.redeem(claim_id)
+    if api_key is None:
+        raise ActivityError("Secret expired")
+```
+
+**Rule:** Plaintext credentials must never touch durable storage (workflow history, message queues, logs). Use opaque claim IDs as references; `pop()` (single-read) at execution time; TTL-based expiry.
+
+#### encryption-key-length-not-validated
+
+`base64-valid` does **not** mean crypto-valid. A key that decodes from base64 successfully may still be the wrong length for the cipher. Validate decoded byte length at **config-load time**, not at the first `encrypt()` call.
+
+```bash
+# Detection: find base64 decode without length validation
+rg 'b64decode|base64\.decode' --type py -B 2 -A 5 | grep -v 'len('
+```
+
+```python
+# VULNERABLE — broken config reaches production, fails at first customer-facing encrypt()
+import base64
+import os
+
+key_b64 = os.getenv("ENCRYPTION_KEY")  # "YWFhYQ==" decodes fine (4 bytes)
+key = base64.b64decode(key_b64)  # No error!
+# ... hours later, first customer request ...
+cipher = AESGCM(key)  # ValueError: "Invalid key length" — too late
+
+# SECURE — fail-fast at startup with clear error message
+import sys
+
+def validate_encryption_key(key_b64: str, expected_len: int = 32) -> bytes:
+    try:
+        key = base64.b64decode(key_b64)
+    except Exception as e:
+        sys.exit(f"FATAL: ENCRYPTION_KEY is not valid base64: {e}")
+    if len(key) != expected_len:
+        sys.exit(
+            f"FATAL: ENCRYPTION_KEY must be {expected_len} bytes "
+            f"for AES-256-GCM, got {len(key)}"
+        )
+    return key
+
+key = validate_encryption_key(os.getenv("ENCRYPTION_KEY"))  # Called at import time
+```
+
+**Rule:** Validate cryptographic key length, algorithm compatibility, and encoding at application startup. A clear error at boot is infinitely better than a cryptic `ValueError` on the first customer request.
 
 ### A03: Injection
 


### PR DESCRIPTION
## Summary

Phase 1 of the 5-phase LEARNINGS-ASSESSMENT integration. Adds 8 new skill sections across 4 skills and wires 3 review agents to the new patterns. Net additions only — no deletions, no API breaks, no sync-file impact.

Refs #247

## Changes

3 atomic commits, 7 modified files + 1 new PLAN file:

| Commit | Scope | Files | Lines |
|--------|-------|-------|-------|
| `feat(skills)` | 4 SKILL.md files | +314 | Pattern sections |
| `feat(agents)` | 3 agent .md files | +11/−2 | Checklist wiring |
| `docs(plan)` | PLAN-GIT-247.md | +217 | Tracking plan |

## Phase 1 scope (COMPLETE)

- **clean-code-skill:** +3 sections (Error Handling: broad-except, silent-failure-async; Object Calisthenics: two-phase dataclass)
- **python-backend-skill:** +1 section (Prefer DI Over Global Singletons)
- **security-audit-skill:** +3 sections (auth-early-return null-account-id, claim-check ephemeral-secret-cache, encryption-key-length-not-validated)
- **design-patterns-skill:** +1 section (Concurrency Patterns: atomic-sql-update)
- **code-review-subagent:** extended clean-code + security-audit bullets
- **python-reviewer-subagent:** extended Backend Patterns line
- **architecture-review-subagent:** new Pattern Reference (cross-skill) section

## Quality review

`opencode-tooling-subagent`: **0 Critical, 0 Major, 3 Minor** (pre-existing stylistic only)

## Sync-file impact

None — `setup.sh`/`setup.ps1`/READMEs enumerate skill **names**, not sections.

## Test plan

N/A — docs/config repo, no runtime code modified.

## Related

Refs #247, `PLANS/PLAN-GIT-247.md`