### PR TITLE
fix(ci): repoint release workflow lint at canonical opencode.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,9 @@ jobs:
 
       - name: Lint validation
         run: |
-          echo "Validating deploy/config.json..."
-          jq . deploy/config.json
-          echo "config.json is valid"
+          echo "Validating opencode_app/opencode.json..."
+          jq . opencode_app/opencode.json
+          echo "opencode.json is valid"
 
           echo "Validating deploy/setup.sh syntax..."
           bash -n deploy/setup.sh


### PR DESCRIPTION
## Summary

Fixes the post-merge CI failure that has been occurring on every merge to main since PR #231.

## Root cause

The 'Lint validation' step in `.github/workflows/release.yml` runs:
```bash
jq . deploy/config.json
```

But `deploy/config.json` was **deliberately deleted** in PR #231 (commit `981f317`) because it was a drifted duplicate of `opencode_app/opencode.json`. The duplicate was removed to eliminate the drift class entirely.

## Fix

Repoint the lint at `opencode_app/opencode.json` — the new single source of truth. Preserves the intent of the check (validate canonical config JSON syntax).

## Evidence of failure

Same error appeared on post-merge CI for PR #231, #248, and #249.

## Test plan

- [x] `jq . opencode_app/opencode.json` runs clean locally
- [ ] Post-merge CI on this PR should pass (verifies the fix)

## Risk

Very low. 3-line path change in a single workflow file. No behavior change.

## Related

- Root cause: commit `981f317` (PR #231)