### PR TITLE
feat(release): align semantic-release config with canvastekk-frontend-nextjs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
             @semantic-release/changelog \
             @semantic-release/exec \
             @semantic-release/git \
-            @semantic-release/github
+            @semantic-release/github \
+            conventional-changelog-conventionalcommits
 
       - name: Create Release with CHANGELOG
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,12 +1,114 @@
 {
   "branches": [
-    "main"
+    "main",
+    {
+      "name": "dev",
+      "prerelease": "dev"
+    },
+    {
+      "name": "pre-dev",
+      "prerelease": "pre-dev"
+    },
+    {
+      "name": "uat",
+      "prerelease": "uat"
+    }
   ],
   "tagFormat": "v${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "docs",
+            "release": false
+          },
+          {
+            "type": "style",
+            "release": false
+          },
+          {
+            "type": "chore",
+            "release": false
+          },
+          {
+            "type": "test",
+            "release": false
+          },
+          {
+            "breaking": true,
+            "release": "major"
+          }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "feat",
+              "section": "Features"
+            },
+            {
+              "type": "fix",
+              "section": "Bug Fixes"
+            },
+            {
+              "type": "perf",
+              "section": "Performance Improvements"
+            },
+            {
+              "type": "refactor",
+              "section": "Code Refactoring"
+            },
+            {
+              "type": "docs",
+              "section": "Documentation"
+            },
+            {
+              "type": "chore",
+              "hidden": true
+            },
+            {
+              "type": "style",
+              "hidden": true
+            },
+            {
+              "type": "test",
+              "hidden": true
+            }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file."
+      }
+    ],
     [
       "@semantic-release/exec",
       {
@@ -17,22 +119,25 @@
       "@semantic-release/git",
       {
         "assets": [
-          "config.json",
-          "setup.sh",
+          "VERSION",
+          "CHANGELOG.md",
           "README.md",
           "AGENTS.md",
           "LICENSE",
-          "VERSION",
-          "CHANGELOG.md",
-          "skills/**/*"
+          "deploy/setup.sh",
+          "deploy/setup.ps1",
+          "opencode_app/opencode.json",
+          "opencode_app/.opencode/agents/**/*",
+          "opencode_app/.opencode/skills/**/*"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],
     [
       "@semantic-release/github",
       {
-        "assignees": []
+        "successComment": false,
+        "failComment": false
       }
     ]
   ]


### PR DESCRIPTION
## Summary

Aligns `.releaserc.json` with conventions from `canvastekk-frontend-nextjs` to standardize release behavior.

## Changes

| Aspect | Before | After |
|--------|--------|-------|
| Branches | `main` only | `main` + `dev`/`pre-dev`/`uat` prerelease |
| commit-analyzer preset | default (angular) | explicit `conventionalcommits` + releaseRules |
| `refactor:` → release | no | **patch** |
| Release notes sections | default | explicit (Features, Bug Fixes, Performance, Refactoring, Documentation) |
| Changelog title | default | custom |
| git commit body | with release notes | terse |
| GitHub comments | default (verbose) | silenced |
| git plugin assets | stale paths | refreshed |

## Intentional deviations (no package.json in this repo)

- KEEP `@semantic-release/exec` — writes `VERSION` file
- NO `@semantic-release/npm` — would fail
- KEEP `release.yml` — has automated CI (canvastekk runs manually)

## Workflow change

Added `conventional-changelog-conventionalcommits` to npm install (required by new preset).

## Test plan

- [x] `jq . .releaserc.json` valid
- [ ] Post-merge CI runs semantic-release with new preset

## Risk

Low. Config-only change. Worst case: revert if preset misbehaves.

## Related

Reference: canvastekk-frontend-nextjs/.releaserc.json