### PR TITLE
fix(config): set subagent_depth to 3 for autoresearch nested delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,18 @@ This repository implements **skill modularization** with 116 skills organized ac
 
 > **Built-in Delegation**: Subagents with `explore` can delegate codebase scanning to the built-in `explore` subagent. Subagents with `general` can delegate parallelizable multi-step work to the built-in `general` subagent. Access is controlled via `task` permissions in each agent's frontmatter (`"*": deny` by default, explicit allowlist).
 
+##### Subagent Nesting Depth
+
+`opencode_app/opencode.json` sets `subagent_depth: 3` (opencode's default is `1`). This is required for nested delegation chains used by the autoresearch subagents and other deep workflows:
+
+| Depth | Chain | Example |
+|-------|-------|---------|
+| `1` (opencode default) | primary → subagent | Blocks nesting entirely — autoresearch loops fail with "Subagent depth limit reached" |
+| `2` | primary → subagent → 1 nested | Minimum for autoresearch to delegate research/exploration |
+| `3` (set here) | primary → subagent → nested → one more | Comfortable headroom for autoresearch-code/ml/research loops |
+
+Each extra level multiplies token cost (every nested subagent runs its own full context). Lower it to `2` for tighter runs; raise it only if a deeper chain hits the wall again. See the [Subagent depth docs](https://opencode.ai/docs/config#subagent-depth).
+
 #### Trigger Phrases
 
 Some subagents recognize natural language triggers:

--- a/opencode_app/opencode.json
+++ b/opencode_app/opencode.json
@@ -2,6 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "model": "zai-coding-plan/glm-5.2",
   "default_agent": "build",
+  "subagent_depth": 3,
   "plugin": [
     "@franlol/opencode-md-table-formatter@latest",
     "opencode-dynamic-context-pruning",


### PR DESCRIPTION
## Summary

opencode's default `subagent_depth: 1` blocks autoresearch subagents from spawning their nested `explore`/`general` helpers, causing runs to fail with:

> Subagent depth limit reached (1). Increase "subagent_depth" to allow nested subagents.

This is hit frequently when using the `autoresearch-*` subagents, which delegate research/exploration to nested subagents.

## Changes

- **`opencode_app/opencode.json`** — add `subagent_depth: 3` (opencode default is `1`).
- **`README.md`** — new **Subagent Nesting Depth** subsection under Built-in Delegation, documenting the setting, the depth-vs-token-cost tradeoff, and the chain each depth supports.

| Depth | Chain | Effect |
|-------|-------|--------|
| `1` (opencode default) | primary → subagent | Blocks nesting — autoresearch loops fail |
| `2` | primary → subagent → 1 nested | Minimum to fix the autoresearch case |
| `3` (set here) | primary → subagent → nested → one more | Comfortable headroom for autoresearch-code/ml/research |

## Why 3 and not 2?

Depth `2` is the minimum to unblock autoresearch, but autoresearch loops are inherently deep iterative workflows that may chain another delegation. `3` provides headroom without excessive token cost. Each level multiplies context cost, so the README notes how to lower/raise it.

## Verification

- [x] `opencode.json` validated as well-formed JSON
- [x] No existing tests assert on this key (tests cover agent frontmatter / skill tiers only)

## Release

`fix(config)` → conventional commit → **patch** bump (label applied).

## After merge

Redeploy or copy the config to activate:
```
./deploy/setup.sh
# or
cp opencode_app/opencode.json ~/.config/opencode/config.json
```