### PR TITLE
fix: deny read_mcp_resource + remove filesystem MCP server for #258

### DIFF
--- a/PLANS/PLAN-GIT-258.md
+++ b/PLANS/PLAN-GIT-258.md
@@ -1,0 +1,103 @@
+# Plan: Fix read_mcp_resource tool confusion + defend against OpenCode v1.18.4 GLM adapter regression
+
+## Ticket Reference
+- Platform: GitHub
+- ID: #258
+- URL: https://github.com/darellchua2/opencode-config-template/issues/258
+- Branch: GIT-258
+
+## Acceptance Criteria
+- [ ] Agent permission blocks in configurator repo deny `read_mcp_resource`, `list_mcp_resources`, `list_mcp_resource_templates` for file-focused agents
+- [ ] Global tool-selection rule added to `deploy/.AGENTS.md` (deployed to `~/.config/opencode/AGENTS.md`)
+- [ ] Skill instructions in `plan-execution-skill` disambiguated (replace "load" with explicit `Read` tool reference)
+- [ ] Documentation updated (README.md, setup scripts) with any new permission entries
+- [ ] OpenCode version pinned to v1.18.3 until upstream fix (separate action, documented in issue)
+- [ ] `filesystem` MCP server removed from canvastekk `opencode.json` (separate action, documented in issue)
+
+---
+
+## Dependency & Consumer Map
+
+| Node (file/module) | Depends on (must precede) | Consumers (who depends on this) | Change risk |
+|---------------------|---------------------------|---------------------------------|-------------|
+| `opencode_app/.opencode/agents/*.md` (permission blocks) | — | All subagents launched from configurator repo; deployed to `~/.config/opencode/agents/` | med — denies MCP resource tools globally for file-focused agents |
+| `deploy/.AGENTS.md` | — | All agents (global routing rules); deployed to `~/.config/opencode/AGENTS.md` | low — additive rule, no breaking change |
+| `opencode_app/.opencode/skills/plan-execution-skill/SKILL.md` | — | plan-execution-skill consumers (testing-subagent, tdd-subagent, any agent executing PLANs) | low — wording disambiguation only |
+| `README.md` | Agent changes complete | Documentation readers, deploy scripts | low — count/table sync only |
+
+## Implementation Phases
+
+### Phase 1: Add MCP Resource Tool Deny Rules to File-Focused Agents
+
+Add `read_mcp_resource: deny`, `list_mcp_resources: deny`, `list_mcp_resource_templates: deny` to the `permission` block of all file-focused agents that don't need MCP resource access.
+
+- [ ] **1.1** Add deny rules to `ticket-creation-subagent.md` permission block
+    — **Why:** Primary agent exhibiting the bug; creates and reads PLAN files locally
+    — **Done when:** Permission block contains all three deny entries and frontmatter parses correctly
+    — **Consumers affected:** ticket-creation-subagent (all projects)
+- [ ] **1.2** Add deny rules to `code-review-subagent.md` permission block
+    — **Why:** Reviews local source files; no need for MCP resource tools
+    — **Done when:** Permission block contains all three deny entries
+    — **Consumers affected:** code-review-subagent (all projects)
+- [ ] **1.3** Add deny rules to `architecture-review-subagent.md` permission block
+    — **Why:** Reviews local architecture files and PLAN files; no need for MCP resource tools
+    — **Done when:** Permission block contains all three deny entries
+    — **Consumers affected:** architecture-review-subagent (all projects)
+- [ ] **1.4** Add deny rules to `explorer-subagent.md` permission block
+    — **Why:** Explores local codebase; no need for MCP resource tools
+    — **Done when:** Permission block contains all three deny entries
+    — **Consumers affected:** explorer-subagent (all projects)
+- [ ] **1.5** Add deny rules to `testing-subagent.md` permission block
+    — **Why:** Reads/writes local test files; no need for MCP resource tools
+    — **Done when:** Permission block contains all three deny entries
+    — **Consumers affected:** testing-subagent (all projects)
+- [ ] **1.6** Add deny rules to `linting-subagent.md` permission block
+    — **Why:** Reads local source files for linting; no need for MCP resource tools
+    — **Done when:** Permission block contains all three deny entries
+    — **Consumers affected:** linting-subagent (all projects)
+- [ ] **1.7** Add deny rules to `documentation-subagent.md` permission block
+    — **Why:** Reads/writes local doc files; no need for MCP resource tools
+    — **Done when:** Permission block contains all three deny entries
+    — **Consumers affected:** documentation-subagent (all projects)
+- [ ] **1.8** Add deny rules to `pr-workflow-subagent.md` permission block
+    — **Why:** Reads local files for PR checks; no need for MCP resource tools
+    — **Done when:** Permission block contains all three deny entries
+    — **Consumers affected:** pr-workflow-subagent (all projects)
+- [ ] **1.9** Add deny rules to remaining file-focused agents (`coverage-subagent.md`, `tdd-subagent.md`, `error-resolver-subagent.md`, `technical-design-specialist-subagent.md`, `requirements-specialist-subagent.md`, `discovery-specialist-subagent.md`, `opencode-tooling-subagent.md`, `loop-operator-subagent.md`, `autoresearch-code-subagent.md`, `autoresearch-research-subagent.md`)
+    — **Why:** All work with local files and don't need MCP resource access; defense-in-depth across the full agent suite
+    — **Done when:** All listed agents have three deny entries in their permission blocks
+    — **Consumers affected:** all listed subagents (all projects)
+
+### Phase 2: Add Tool Selection Rules Guidance
+
+Add explicit tool-selection guidance to the most affected agent.
+
+- [ ] **2.1** Add "Tool Selection Rules" section to `ticket-creation-subagent.md` (after Prompt Defense Baseline, before CRITICAL section)
+    — **Why:** Even with permission denies, explicit guidance prevents confusion in edge cases where permissions are overridden or new MCP tools are added
+    — **Done when:** Section present with rule: "Always use built-in `Read` tool for local files; NEVER use `read_mcp_resource` etc."
+    — **Consumers affected:** ticket-creation-subagent
+
+### Phase 3: Add Global Tool-Selection Rule to deploy/.AGENTS.md
+
+- [ ] **3.1** Add "Local File Reading Rule" subsection under existing "## MCP Tool Routing" in `deploy/.AGENTS.md`
+    — **Why:** Global rule that benefits ALL agents across ALL projects, not just ticket-creation; prevents the error class from recurring with other agents or other MCP servers
+    — **Done when:** Subsection present with rule + comparison table (Read vs read_mcp_resource)
+    — **Consumers affected:** all agents (global, user-space)
+
+### Phase 4: Disambiguate plan-execution-skill Instructions
+
+- [ ] **4.1** Update `opencode_app/.opencode/skills/plan-execution-skill/SKILL.md` line 105: replace "load the PLAN's" with "Use the built-in `Read` tool to open the PLAN file and review its"
+    — **Why:** The word "load" is ambiguous and could trigger the model to use `read_mcp_resource` (loading MCP resources)
+    — **Done when:** Line 105 uses explicit `Read` tool reference instead of generic "load"
+    — **Consumers affected:** plan-execution-skill consumers (testing-subagent, tdd-subagent, any agent executing PLANs)
+- [ ] **4.2** Update `opencode_app/.opencode/skills/plan-execution-skill/SKILL.md` line 128: replace "read its" with "use the `Read` tool to review its"
+    — **Why:** Lowercase "read" is ambiguous; explicit tool name removes confusion
+    — **Done when:** Line 128 uses explicit `Read` tool reference
+    — **Consumers affected:** same as 4.1
+
+### Phase 5: Documentation Sync
+
+- [ ] **5.1** Run documentation-sync-workflow or manually verify README.md agent tables and setup script counts are consistent with permission block changes
+    — **Why:** Permission block changes are additive (deny rules) and don't change agent counts, but README permission documentation should reflect the new deny pattern if documented
+    — **Done when:** No count drift; README accurately reflects agent capabilities
+    — **Consumers affected:** documentation readers, deploy scripts

--- a/PLANS/PLAN-GIT-258.md
+++ b/PLANS/PLAN-GIT-258.md
@@ -31,39 +31,39 @@
 
 Add `read_mcp_resource: deny`, `list_mcp_resources: deny`, `list_mcp_resource_templates: deny` to the `permission` block of all file-focused agents that don't need MCP resource access.
 
-- [ ] **1.1** Add deny rules to `ticket-creation-subagent.md` permission block
+- [x] **1.1** Add deny rules to `ticket-creation-subagent.md` permission block
     — **Why:** Primary agent exhibiting the bug; creates and reads PLAN files locally
     — **Done when:** Permission block contains all three deny entries and frontmatter parses correctly
     — **Consumers affected:** ticket-creation-subagent (all projects)
-- [ ] **1.2** Add deny rules to `code-review-subagent.md` permission block
+- [x] **1.2** Add deny rules to `code-review-subagent.md` permission block
     — **Why:** Reviews local source files; no need for MCP resource tools
     — **Done when:** Permission block contains all three deny entries
     — **Consumers affected:** code-review-subagent (all projects)
-- [ ] **1.3** Add deny rules to `architecture-review-subagent.md` permission block
+- [x] **1.3** Add deny rules to `architecture-review-subagent.md` permission block
     — **Why:** Reviews local architecture files and PLAN files; no need for MCP resource tools
     — **Done when:** Permission block contains all three deny entries
     — **Consumers affected:** architecture-review-subagent (all projects)
-- [ ] **1.4** Add deny rules to `explorer-subagent.md` permission block
+- [x] **1.4** Add deny rules to `explorer-subagent.md` permission block
     — **Why:** Explores local codebase; no need for MCP resource tools
     — **Done when:** Permission block contains all three deny entries
     — **Consumers affected:** explorer-subagent (all projects)
-- [ ] **1.5** Add deny rules to `testing-subagent.md` permission block
+- [x] **1.5** Add deny rules to `testing-subagent.md` permission block
     — **Why:** Reads/writes local test files; no need for MCP resource tools
     — **Done when:** Permission block contains all three deny entries
     — **Consumers affected:** testing-subagent (all projects)
-- [ ] **1.6** Add deny rules to `linting-subagent.md` permission block
+- [x] **1.6** Add deny rules to `linting-subagent.md` permission block
     — **Why:** Reads local source files for linting; no need for MCP resource tools
     — **Done when:** Permission block contains all three deny entries
     — **Consumers affected:** linting-subagent (all projects)
-- [ ] **1.7** Add deny rules to `documentation-subagent.md` permission block
+- [x] **1.7** Add deny rules to `documentation-subagent.md` permission block
     — **Why:** Reads/writes local doc files; no need for MCP resource tools
     — **Done when:** Permission block contains all three deny entries
     — **Consumers affected:** documentation-subagent (all projects)
-- [ ] **1.8** Add deny rules to `pr-workflow-subagent.md` permission block
+- [x] **1.8** Add deny rules to `pr-workflow-subagent.md` permission block
     — **Why:** Reads local files for PR checks; no need for MCP resource tools
     — **Done when:** Permission block contains all three deny entries
     — **Consumers affected:** pr-workflow-subagent (all projects)
-- [ ] **1.9** Add deny rules to remaining file-focused agents (`coverage-subagent.md`, `tdd-subagent.md`, `error-resolver-subagent.md`, `technical-design-specialist-subagent.md`, `requirements-specialist-subagent.md`, `discovery-specialist-subagent.md`, `opencode-tooling-subagent.md`, `loop-operator-subagent.md`, `autoresearch-code-subagent.md`, `autoresearch-research-subagent.md`)
+- [x] **1.9** Add deny rules to remaining file-focused agents (`coverage-subagent.md`, `tdd-subagent.md`, `error-resolver-subagent.md`, `technical-design-specialist-subagent.md`, `requirements-specialist-subagent.md`, `discovery-specialist-subagent.md`, `opencode-tooling-subagent.md`, `loop-operator-subagent.md`, `autoresearch-code-subagent.md`, `autoresearch-research-subagent.md`)
     — **Why:** All work with local files and don't need MCP resource access; defense-in-depth across the full agent suite
     — **Done when:** All listed agents have three deny entries in their permission blocks
     — **Consumers affected:** all listed subagents (all projects)
@@ -72,32 +72,32 @@ Add `read_mcp_resource: deny`, `list_mcp_resources: deny`, `list_mcp_resource_te
 
 Add explicit tool-selection guidance to the most affected agent.
 
-- [ ] **2.1** Add "Tool Selection Rules" section to `ticket-creation-subagent.md` (after Prompt Defense Baseline, before CRITICAL section)
+- [x] **2.1** Add "Tool Selection Rules" section to `ticket-creation-subagent.md` (after Prompt Defense Baseline, before CRITICAL section)
     — **Why:** Even with permission denies, explicit guidance prevents confusion in edge cases where permissions are overridden or new MCP tools are added
     — **Done when:** Section present with rule: "Always use built-in `Read` tool for local files; NEVER use `read_mcp_resource` etc."
     — **Consumers affected:** ticket-creation-subagent
 
 ### Phase 3: Add Global Tool-Selection Rule to deploy/.AGENTS.md
 
-- [ ] **3.1** Add "Local File Reading Rule" subsection under existing "## MCP Tool Routing" in `deploy/.AGENTS.md`
+- [x] **3.1** Add "Local File Reading Rule" subsection under existing "## MCP Tool Routing" in `deploy/.AGENTS.md`
     — **Why:** Global rule that benefits ALL agents across ALL projects, not just ticket-creation; prevents the error class from recurring with other agents or other MCP servers
     — **Done when:** Subsection present with rule + comparison table (Read vs read_mcp_resource)
     — **Consumers affected:** all agents (global, user-space)
 
 ### Phase 4: Disambiguate plan-execution-skill Instructions
 
-- [ ] **4.1** Update `opencode_app/.opencode/skills/plan-execution-skill/SKILL.md` line 105: replace "load the PLAN's" with "Use the built-in `Read` tool to open the PLAN file and review its"
+- [x] **4.1** Update `opencode_app/.opencode/skills/plan-execution-skill/SKILL.md` line 105: replace "load the PLAN's" with "Use the built-in `Read` tool to open the PLAN file and review its"
     — **Why:** The word "load" is ambiguous and could trigger the model to use `read_mcp_resource` (loading MCP resources)
     — **Done when:** Line 105 uses explicit `Read` tool reference instead of generic "load"
     — **Consumers affected:** plan-execution-skill consumers (testing-subagent, tdd-subagent, any agent executing PLANs)
-- [ ] **4.2** Update `opencode_app/.opencode/skills/plan-execution-skill/SKILL.md` line 128: replace "read its" with "use the `Read` tool to review its"
+- [x] **4.2** Update `opencode_app/.opencode/skills/plan-execution-skill/SKILL.md` line 128: replace "read its" with "use the `Read` tool to review its"
     — **Why:** Lowercase "read" is ambiguous; explicit tool name removes confusion
     — **Done when:** Line 128 uses explicit `Read` tool reference
     — **Consumers affected:** same as 4.1
 
 ### Phase 5: Documentation Sync
 
-- [ ] **5.1** Run documentation-sync-workflow or manually verify README.md agent tables and setup script counts are consistent with permission block changes
+- [x] **5.1** Run documentation-sync-workflow or manually verify README.md agent tables and setup script counts are consistent with permission block changes
     — **Why:** Permission block changes are additive (deny rules) and don't change agent counts, but README permission documentation should reflect the new deny pattern if documented
     — **Done when:** No count drift; README accurately reflects agent capabilities
     — **Consumers affected:** documentation readers, deploy scripts

--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ The configuration ships 26 MCP server entries. **6 are enabled by default:**
 | `zai-web-reader` | remote | Web page content extraction |
 | `zai-zread` | remote | GitHub repository search/reading |
 
-The remaining 20 (Microsoft 365, Autodesk, Google Cloud, `filesystem`, `next-devtools`, `web-search-prime`, etc.) are `enabled: false` and opt-in. To enable one, set `"enabled": true` (and grant its tools in the `tools` block) in `config.json`.
+The remaining 19 (Microsoft 365, Autodesk, Google Cloud, `next-devtools`, `web-search-prime`, etc.) are `enabled: false` and opt-in. To enable one, set `"enabled": true` (and grant its tools in the `tools` block) in `config.json`.
 
-> **Note — `filesystem` MCP is intentionally disabled.** OpenCode's built-in `read`/`write`/`edit`/`glob`/`grep`/`bash` tools already provide full file I/O, so `@modelcontextprotocol/server-filesystem` is redundant. Enable it per-project **only** if a specific tool requires MCP filesystem access — and note the server command requires allowed-directory path arguments (e.g. append your project root), so it would start broken without them.
+> **Note — `filesystem` MCP server has been permanently removed.** OpenCode's built-in `read`/`write`/`edit`/`glob`/`grep`/`bash` tools already provide full file I/O, so `@modelcontextprotocol/server-filesystem` was redundant and caused tool-selection ambiguity (the model would call `read_mcp_resource` instead of the built-in `Read` tool). Do not re-add it to project `opencode.json` files.
 
 ## Knowledge Persistence
 

--- a/deploy/.AGENTS.md
+++ b/deploy/.AGENTS.md
@@ -84,6 +84,18 @@ Always use built-in `webfetch` first. If it fails (e.g., response exceeds 5MB li
 | Remote GitHub repo exploration | `explorer-subagent` with `zai-zread` | — | Scoped to subagent, avoids context waste |
 | Error screenshot diagnosis | `error-resolver-subagent` | — | Scoped to subagent with `zai-vision-mcp-server` tools |
 
+### Local File Reading Rule
+
+**Always use the built-in `Read` tool for local files.** Never use MCP resource tools (`read_mcp_resource`, `list_mcp_resources`, `list_mcp_resource_templates`) for reading local files. MCP resource tools are for MCP server resources (database schemas, API resources) only — not for `file://` paths or local project files.
+
+| Task | Correct Tool | Wrong Tool |
+|------|-------------|------------|
+| Read a local `.md`/`.ts`/`.json` file | `Read` (filePath) | `read_mcp_resource` |
+| Read a PLAN file | `Read` (filePath) | `read_mcp_resource` |
+| Read MCP server resource | `read_mcp_resource` (server, uri) | `Read` |
+
+**Do not configure the `filesystem` MCP server** (`@modelcontextprotocol/server-filesystem`) in project `opencode.json` files — it is redundant with built-in `Read`/`glob`/`grep` and creates tool-selection ambiguity that causes the model to call `read_mcp_resource` with `server: "null"` instead of using `Read`.
+
 ## Subagent Chaining
 
 Subagents CAN spawn other subagents via the Task tool, controlled by `permission.task` in frontmatter. Hub-and-spoke (primary -> subagent) remains the recommended pattern for simplicity. See AGENTS.md for full details including permission syntax and current distribution.

--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -1722,7 +1722,7 @@ function Set-Configuration {
             Write-Host "Configured MCP servers:" -ForegroundColor Green
             Write-Host "    - Local (auto-start): atlassian, zai-vision-mcp-server, codegraph, mermaid"
             Write-Host "    - Remote (needs key): web-reader, zread"
-            Write-Host "    - Available but disabled (opt-in): web-search-prime, filesystem, next-devtools"
+            Write-Host "    - Available but disabled (opt-in): web-search-prime, next-devtools"
             Write-Host ""
         } else {
             Write-LogError "config.json source not found: $SourceConfig"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -632,7 +632,6 @@ USAGE:
       mermaid            Mermaid diagram rendering (SVG/PNG)
 
     Available but disabled (opt-in — set enabled: true in config.json):
-      filesystem         Local filesystem read/write (redundant with built-in file tools)
       next-devtools      Next.js DevTools integration
 
     Remote (requires ZAI_API_KEY):

--- a/opencode_app/.opencode/agents/architecture-review-subagent.md
+++ b/opencode_app/.opencode/agents/architecture-review-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/autoresearch-code-subagent.md
+++ b/opencode_app/.opencode/agents/autoresearch-code-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/autoresearch-research-subagent.md
+++ b/opencode_app/.opencode/agents/autoresearch-research-subagent.md
@@ -14,6 +14,9 @@ permission:
   bash: deny
   webfetch: allow
   websearch: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/code-review-subagent.md
+++ b/opencode_app/.opencode/agents/code-review-subagent.md
@@ -10,6 +10,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/coverage-subagent.md
+++ b/opencode_app/.opencode/agents/coverage-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   skill:
     coverage-readme-workflow-skill: allow
 ---

--- a/opencode_app/.opencode/agents/discovery-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/discovery-specialist-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     image-analyzer-subagent: allow

--- a/opencode_app/.opencode/agents/documentation-subagent.md
+++ b/opencode_app/.opencode/agents/documentation-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   skill:
     docstring-generator-skill: allow
     coverage-readme-workflow-skill: allow

--- a/opencode_app/.opencode/agents/error-resolver-subagent.md
+++ b/opencode_app/.opencode/agents/error-resolver-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   skill:
     error-resolver-workflow-skill: allow
     react-nextjs-antipatterns-skill: allow

--- a/opencode_app/.opencode/agents/explorer-subagent.md
+++ b/opencode_app/.opencode/agents/explorer-subagent.md
@@ -6,6 +6,9 @@ permission:
   read: allow
   edit: deny
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
 ---
 
 ## Prompt Defense Baseline

--- a/opencode_app/.opencode/agents/go-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/go-reviewer-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/image-analyzer-subagent.md
+++ b/opencode_app/.opencode/agents/image-analyzer-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
 ---
 
 ## Prompt Defense Baseline

--- a/opencode_app/.opencode/agents/java-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/java-reviewer-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/linting-subagent.md
+++ b/opencode_app/.opencode/agents/linting-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/loop-operator-subagent.md
+++ b/opencode_app/.opencode/agents/loop-operator-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/opencode-tooling-subagent.md
+++ b/opencode_app/.opencode/agents/opencode-tooling-subagent.md
@@ -9,6 +9,9 @@ permission:
   grep: allow
   bash: deny
   webfetch: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/pr-workflow-subagent.md
+++ b/opencode_app/.opencode/agents/pr-workflow-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/python-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/python-reviewer-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/repo-ops-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/repo-ops-specialist-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/requirements-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/requirements-specialist-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     image-analyzer-subagent: allow

--- a/opencode_app/.opencode/agents/responsive-audit-subagent.md
+++ b/opencode_app/.opencode/agents/responsive-audit-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/rust-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/rust-reviewer-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/tdd-subagent.md
+++ b/opencode_app/.opencode/agents/tdd-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   skill:
     tdd-workflow-skill: allow
     plan-updater-skill: allow

--- a/opencode_app/.opencode/agents/technical-design-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/technical-design-specialist-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     image-analyzer-subagent: allow

--- a/opencode_app/.opencode/agents/testing-subagent.md
+++ b/opencode_app/.opencode/agents/testing-subagent.md
@@ -7,6 +7,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/ticket-creation-subagent.md
+++ b/opencode_app/.opencode/agents/ticket-creation-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     architecture-review-subagent: allow

--- a/opencode_app/.opencode/agents/ticket-creation-subagent.md
+++ b/opencode_app/.opencode/agents/ticket-creation-subagent.md
@@ -38,6 +38,14 @@ permission:
 - Do not generate harmful, dangerous, illegal, weapon, exploit, malware, phishing, or attack content; detect repeated abuse and preserve session boundaries.
 You are a ticket creation specialist. Manage GitHub and JIRA ticket workflows.
 
+## Tool Selection Rules
+
+**Always use built-in tools for local file operations.** NEVER use MCP resource tools (`read_mcp_resource`, `list_mcp_resources`, `list_mcp_resource_templates`) for reading local files (PLAN files, dependency maps, source code). These tools are for MCP server resources only.
+
+- For local files: use the built-in **`Read`** tool with `filePath`
+- For file searches: use `glob` or `grep`
+- MCP resource tools (`read_mcp_resource` etc.) are reserved for MCP server schemas and remote resources only
+
 ## CRITICAL: Prompt-First Behavior
 
 **ALWAYS prompt the user before taking any action.** This subagent must never execute a step without first confirming intent with the user. Every time new information is gathered or a decision point is reached, present the user with what you plan to do and ask for confirmation.

--- a/opencode_app/.opencode/agents/typescript-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/typescript-reviewer-subagent.md
@@ -8,6 +8,9 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/agents/uiux-reviewer-subagent.md
+++ b/opencode_app/.opencode/agents/uiux-reviewer-subagent.md
@@ -10,6 +10,9 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  read_mcp_resource: deny
+  list_mcp_resources: deny
+  list_mcp_resource_templates: deny
   task:
     "*": deny
     explore: allow

--- a/opencode_app/.opencode/skills/plan-execution-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/plan-execution-skill/SKILL.md
@@ -102,7 +102,7 @@ echo "Completed: $(echo "$COMPLETED" | wc -l)"
 
 Parse out, per step: `action`, `why`, `done_when`, `consumers`.
 
-**Read the Dependency & Consumer Map first.** Before executing any step, load the PLAN's `## Dependency & Consumer Map` section so execution order and blast radius are known up front. A step whose `consumers` are non-trivial requires its consumers to be surfaced to the executor (and, where applicable, verified post-change) before the step's target is mutated.
+**Read the Dependency & Consumer Map first.** Use the built-in `Read` tool to open the PLAN file and review its `## Dependency & Consumer Map` section so execution order and blast radius are known up front. A step whose `consumers` are non-trivial requires its consumers to be surfaced to the executor (and, where applicable, verified post-change) before the step's target is mutated.
 
 ### Step 3: Analyze Current State
 
@@ -125,7 +125,7 @@ echo "Next step: $NEXT_STEP"
 Work through steps systematically:
 
 **Strategy**:
-1. **Surface consumers first** — before touching a step's target, read its `Consumers affected` line and the Dependency & Consumer Map. Do not mutate a target whose consumers have not been surfaced.
+1. **Surface consumers first** — before touching a step's target, use the `Read` tool to review its `Consumers affected` line and the Dependency & Consumer Map. Do not mutate a target whose consumers have not been surfaced.
 2. Group related steps (e.g., all tests together)
 3. Delegate to specialized subagents when appropriate:
    - Testing steps → `testing-subagent`

--- a/opencode_app/opencode.json
+++ b/opencode_app/opencode.json
@@ -181,11 +181,6 @@
       "command": ["npx", "-y", "next-devtools-mcp@latest"],
       "enabled": false
     },
-    "filesystem": {
-      "type": "local",
-      "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem@latest"],
-      "enabled": false
-    },
     "microsoft-teams": {
       "type": "local",
       "command": ["npx", "-y", "mcp-remote", "https://mcp.cloud.microsoft/teams/v1/sse"],
@@ -259,7 +254,6 @@
     "autodesk-fusion*": false,
     "autodesk-help*": false,
     "next-devtools*": false,
-    "filesystem*": false,
     "microsoft-teams*": false,
     "microsoft-mail*": false,
     "microsoft-calendar*": false,


### PR DESCRIPTION
## Summary

Fixes the recurring `read_mcp_resource` tool-call error caused by two root causes:

1. **Tool confusion** — the `filesystem` MCP server exposed local files as MCP resources, causing the model to call `read_mcp_resource` instead of the built-in `Read` tool
2. **Missing defense-in-depth** — agent permission blocks didn't deny MCP resource tools

Closes #258

## Changes by Category

### Agent Permission Hardening (27 agents)
Added explicit deny rules for MCP resource tools to all file-focused agents:
```
permission.tool.deny: ["read_mcp_resource", "list_mcp_resources", "list_mcp_resource_templates"]
```
This ensures agents always prefer built-in `Read`/`Grep`/`Glob` tools over MCP equivalents.

### Tool-Selection Guidance
- **ticket-creation-subagent.md**: Added "Tool Selection Rules" section clarifying built-in tool priority
- **deploy/.AGENTS.md**: Added global "Local File Reading Rule" under MCP Tool Routing
- **plan-execution-skill/SKILL.md**: Disambiguated lines 105 + 128 — replaced ambiguous "load"/"read" with explicit `Read` tool references

### MCP Server Removal (permanent)
- **opencode_app/opencode.json**: Removed `filesystem` MCP server entry + tools block
- **README.md**: Updated disabled MCP server count 20→19, replaced note with permanent removal warning
- **deploy/setup.sh**: Removed filesystem from help listings
- **deploy/setup.ps1**: Removed filesystem from help listings

### Planning
- **PLANS/PLAN-GIT-258.md**: Created and completed all phases

## Test Plan
- [x] Validated `opencode_app/opencode.json` parses as valid JSON
- [x] Verified all 27 agent files have consistent deny rules
- [x] Confirmed filesystem MCP server fully removed from all configs and docs

## Risk Assessment
**Low risk** — this change is purely defensive:
- Adding deny rules doesn't break any existing functionality (agents already use built-in tools)
- Removing the filesystem MCP server eliminates a source of tool confusion
- No runtime code changes; only configuration and documentation