### PR TITLE
feat(pptx): slide_type decoupling - layout_name first-class (GIT-93)

### DIFF
--- a/opencode_app/.opencode/skills/_common/scripts/layout_contract.py
+++ b/opencode_app/.opencode/skills/_common/scripts/layout_contract.py
@@ -5,7 +5,7 @@ template (embedded-schema-first, sidecar fallback) and matches a slide_type to
 the best layout by placeholder-composition fingerprint. Physically lives in the
 shared ``_common/scripts`` package so all three skills (generate-slide,
 generate-template, template-modifier) import it from one place instead of
-parasitically reaching into ``pptx-generate-slide-skill/scripts/ppt_builder.py``.
+parasitically reaching into ``generate-slide-skill/scripts/ppt_builder.py``.
 
 Extracted from ``ppt_builder.py`` (PLAN-GIT-72 Phase 2 / architecture-review C1
 closure). The 13 symbols here are pure — they operate on the contract dict /
@@ -211,6 +211,52 @@ def servable_slide_types(contract: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     return report
 
 
+def available_layouts(contract: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Report ALL layouts a template's contract exposes (GIT-93 Phase 1).
+
+    Unlike :func:`servable_slide_types` (which reports only the 8 standard
+    engine slide_types and whether the contract can serve each), this returns
+    **every** layout in the contract so the agent can target any of them via a
+    ``layout_name`` field — including layouts whose placeholder composition
+    does not fingerprint-match any of the 8 standard types (e.g. Agenda,
+    Timeline, Team, Quote layouts in a designer deck).
+
+    Each entry: ``{"name", "index", "fingerprint", "content_area_in2"}``.
+    """
+    layouts = (contract or {}).get("layouts", [])
+    return [
+        {
+            "name": L.get("name", ""),
+            "index": L.get("index"),
+            "fingerprint": list(L.get("fingerprint", [])),
+            "content_area_in2": L.get("content_area_in2", 0),
+        }
+        for L in layouts
+    ]
+
+
+def classify_layout_fingerprint(fp: List[str]) -> Optional[str]:
+    """Map an arbitrary placeholder-composition fingerprint to the nearest
+    standard engine slide_type (GIT-93 Phase 1).
+
+    Reuses :func:`_composition_diff` against the 8 ideal fingerprints and
+    returns the slide_type with the fewest missing placeholders (ties broken
+    by fewest extras, then dict order). Returns ``None`` when ``fp`` is empty.
+    Useful as a semantic hint for non-standard layouts so the agent can pick a
+    sensible field set (e.g. a ``[TITLE, OBJECT]`` Agenda layout →
+    ``"content_slide"`` → use ``body``).
+    """
+    if not fp:
+        return None
+    best: Optional[Tuple[int, int, str]] = None  # (missing, extra, slide_type)
+    for slide_type, ideal in _SLIDE_TYPE_FINGERPRINT.items():
+        missing, extra = _composition_diff(ideal, fp)
+        candidate = (missing, extra, slide_type)
+        if best is None or candidate[:2] < best[:2]:
+            best = candidate
+    return best[2] if best else None
+
+
 # ---------------------------------------------------------------------------
 # Embedded-schema probe helpers + render-contract entrypoint (US-4.1)
 # ---------------------------------------------------------------------------
@@ -237,7 +283,7 @@ def _warn_if_embedded_stale(template_path: str, contract: Dict[str, Any]) -> Non
     if live is not None and live != n_embedded:
         logger.warning(
             "Stale embedded schema in %s: describes %d layouts, live template has %d "
-            "(template may have been edited after embed); re-run pptx-generate-template-skill",
+            "(template may have been edited after embed); re-run generate-template-skill",
             template_path, n_embedded, live,
         )
 

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/multipass_render.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/multipass_render.py
@@ -1,74 +1,29 @@
-"""BT-142 Phase 3.5a — Multi-pass render + merge (engine hard limit L1).
+"""GIT-93 Phase 5 — single-pass render + deck merge.
 
-The chenyu engine's ``slide_type`` enum has exactly 8 values
-(``title_slide``, ``content_slide``, ``section_header_slide``,
-``two_content_slide``, ``comparison_slide``, ``content_image_slide``,
-``chart_slide``, ``closing_slide``). Each ``slide_type`` resolves to ONE
-layout via fingerprint/name match. Designer decks routinely need >8
-distinct layouts (BETEKK V9.1.1 needs 10: Cover, Story, Problem Impact,
-Problem, Solution/Brand, Solution/Demo, Market Validation, Business Model,
-Team, Ask/Closing).
+Originally (BT-142 Phase 3.5a) this module worked around the engine's 8-type
+``slide_type`` ceiling by partitioning slides into ≤8-layout batches,
+pseudo-typing each batch (``_custom_N``), and merging. GIT-93 made
+``layout_name`` a first-class field (Phase 2), so a single
+``generate_ppt_from_data`` pass renders N distinct layouts — the batching /
+pseudo-typing machinery is obsolete and was deleted.
 
-This module solves L1 in three steps:
-
-  1. **Partition** ``slide_data_list`` into batches of ≤8 distinct target
-     layouts. Each slide may carry an extended field ``layout_name`` that
-     names the target layout explicitly (falls back to ``slide_type`` when
-     absent). The orchestrator assigns pseudo-types ``_custom_1`` ...
-     ``_custom_8`` so each batch fits the engine's enum cap.
-  2. **Render** each batch via ``ppt_builder.generate_ppt_from_data`` to a
-     separate ``batch_N.pptx``. The engine treats pseudo-types as
-     ``content_slide`` and we pin the layout via ``config_overrides``.
-  3. **Merge** the per-batch decks into a single output PPTX, deep-copying
-     each slide + its rels + media parts.
-
-The merge primitive (``merge_decks``) is also independently useful: any
-caller that already has multiple rendered decks can stitch them.
-
-Public API:
+This module now exposes:
   - ``merge_decks(primary_path, other_paths, output_path)`` → str (output path)
-  - ``partition_slides(slide_data_list, max_layouts=8)`` → List[List[dict]]
-  - ``multipass_render(slide_data_list, template_path, output_path, **kw)`` → str
-"""
+    — independently useful for stitching pre-rendered decks.
+  - ``multipass_render(slide_data_list, template_path, output_path, render_fn=None)``
+    → str — retained as a thin single-pass wrapper for callers that used the
+    old API; delegates directly to ``generate_ppt_from_data``.
 
+The merge primitives (``_copy_slide`` / ``_relink_image_rels``) are unchanged.
+"""
 from __future__ import annotations
 
 import logging
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_MAX_LAYOUTS_PER_BATCH = 8
-
-
-def partition_slides(
-    slide_data_list: List[dict],
-    max_layouts: int = DEFAULT_MAX_LAYOUTS_PER_BATCH,
-) -> List[List[dict]]:
-    """Group ``slide_data_list`` into batches of ≤ ``max_layouts`` distinct layouts.
-
-    Each slide's layout is determined by its ``layout_name`` field if present,
-    else its ``slide_type``. Slides sharing a layout stay in the same batch
-    (so a batch never wastes a layout slot on a duplicate).
-    """
-    if max_layouts < 1:
-        raise ValueError("max_layouts must be ≥ 1")
-    batches: List[List[dict]] = []
-    current: List[dict] = []
-    current_layouts: set = set()
-    for slide in slide_data_list:
-        layout = slide.get("layout_name") or slide.get("slide_type", "content_slide")
-        if layout not in current_layouts and len(current_layouts) >= max_layouts:
-            batches.append(current)
-            current = []
-            current_layouts = set()
-        current.append(slide)
-        current_layouts.add(layout)
-    if current:
-        batches.append(current)
-    return batches
 
 
 def _copy_slide(src_slide, dst_prs) -> None:
@@ -217,79 +172,32 @@ def merge_decks(
     return str(Path(output_path).resolve())
 
 
-def _batch_to_engine_slides(
-    batch: List[dict],
-) -> Tuple[List[dict], Dict[str, str]]:
-    """Convert a batch (with extended ``layout_name``) to engine-compatible slides.
-
-    Returns ``(engine_slides, config_overrides)`` where ``config_overrides``
-    maps pseudo-types to layout names (the engine pins via
-    ``<slide_type>_layout`` keys).
-
-    Slides WITHOUT ``layout_name`` pass through unchanged (their original
-    ``slide_type`` is preserved — pseudo-typing only kicks in when the caller
-    explicitly targets a layout by name, which is the >8-layout case).
-    """
-    config_overrides: Dict[str, str] = {}
-    layout_to_pseudo: Dict[str, str] = {}
-    engine_slides: List[dict] = []
-    next_idx = 1
-    for slide in batch:
-        # Only pseudo-type when layout_name is explicitly set; otherwise pass
-        # the original slide_type through unchanged (the engine handles it).
-        layout_name = slide.get("layout_name")
-        if not layout_name:
-            engine_slides.append(slide)
-            continue
-        if layout_name not in layout_to_pseudo:
-            pseudo = f"_custom_{next_idx}"
-            next_idx += 1
-            layout_to_pseudo[layout_name] = pseudo
-            config_overrides[f"{pseudo}_layout"] = layout_name
-        pseudo = layout_to_pseudo[layout_name]
-        # Copy and remap slide_type to the pseudo-type. The engine treats
-        # unknown types as ``content_slide`` (per ppt_builder error handling),
-        # and the config pin routes to the correct layout.
-        new_slide = dict(slide)
-        new_slide["slide_type"] = pseudo
-        # Preserve original slide_type in notes so the engine can still
-        # classify subtitle/body behaviour. ppt_builder keys behaviour off
-        # _LAYOUTS_WITH_BODY / _LAYOUTS_WITH_SUBTITLE sets — pseudo-types
-        # won't be in either, so we mark them as content-like via the body
-        # field presence.
-        if "body" not in new_slide and "body_left" not in new_slide:
-            new_slide.setdefault("body", "")
-        engine_slides.append(new_slide)
-    return engine_slides, config_overrides
-
-
 def multipass_render(
     slide_data_list: List[dict],
     template_path: str,
     output_path: str,
-    max_layouts: int = DEFAULT_MAX_LAYOUTS_PER_BATCH,
-    render_fn=None,
+    render_fn: Optional[Any] = None,
 ) -> str:
-    """Render ``slide_data_list`` to ``output_path``, using multi-pass if >8 layouts.
+    """Render ``slide_data_list`` to ``output_path`` in a single pass.
 
-    When the distinct layout count ≤ ``max_layouts``, calls ``render_fn``
-    once directly (no merge overhead). When > ``max_layouts``, partitions
-    into batches, renders each, and merges.
+    GIT-93 Phase 5: ``layout_name`` is now native (Phase 2), so a single
+    ``generate_ppt_from_data`` pass renders N distinct layouts — no batching
+    or pseudo-typing is needed. This wrapper is retained for callers that
+    used the old >8-layout multipass API; it delegates directly.
 
     Args:
-        slide_data_list: list of slide dicts (extended with optional ``layout_name``)
-        template_path: source template
-        output_path: final PPTX path
-        max_layouts: per-batch cap (default 8)
+        slide_data_list: list of slide dicts (may carry ``layout_name``).
+        template_path: source template.
+        output_path: final PPTX path.
         render_fn: callable ``(slides, template_path, output_path,
             config_overrides) -> str`` — defaults to a thin wrapper over
-            ``ppt_builder.generate_ppt_from_data``
+            ``ppt_builder.generate_ppt_from_data``.
 
     Returns:
-        absolute path to ``output_path``
+        absolute path to ``output_path``.
     """
     if render_fn is None:
-        from ppt_builder import generate_ppt_from_data, DEFAULT_OUTPUT_DIR
+        from ppt_builder import generate_ppt_from_data
 
         def render_fn(slides, tpl, out, overrides):
             return generate_ppt_from_data(
@@ -299,39 +207,12 @@ def multipass_render(
                 config_overrides=overrides,
             )
 
-    batches = partition_slides(slide_data_list, max_layouts=max_layouts)
-    if len(batches) == 1:
-        engine_slides, overrides = _batch_to_engine_slides(batches[0])
-        return render_fn(engine_slides, template_path, output_path, overrides)
-
-    # Multi-pass: render each batch to a temp file, then merge.
-    out_dir = Path(output_path).parent
-    out_dir.mkdir(parents=True, exist_ok=True)
-    stem = Path(output_path).stem
-    batch_paths: List[str] = []
-    for i, batch in enumerate(batches):
-        engine_slides, overrides = _batch_to_engine_slides(batch)
-        batch_path = str(out_dir / f"{stem}.__batch{i}.pptx")
-        logger.info("multipass_render: batch %d (%d slides, %d layouts)",
-                    i, len(engine_slides), len(overrides))
-        render_fn(engine_slides, template_path, batch_path, overrides)
-        batch_paths.append(batch_path)
-
-    primary = batch_paths[0]
-    rest = batch_paths[1:]
-    result = merge_decks(primary, rest, output_path)
-    # Clean up batch files
-    for p in batch_paths:
-        try:
-            Path(p).unlink()
-        except OSError:
-            pass
-    return result
+    # Single pass — no batching. config_overrides is empty: layout_name is
+    # resolved natively by _select_layout, and pseudo-typing is obsolete.
+    return render_fn(slide_data_list, template_path, output_path, {})
 
 
 __all__ = [
-    "DEFAULT_MAX_LAYOUTS_PER_BATCH",
-    "partition_slides",
     "merge_decks",
     "multipass_render",
 ]

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/overflow_check.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/overflow_check.py
@@ -75,48 +75,93 @@ class OverflowFinding:
         }
 
 
+def _resolve_layout_contract(
+    slide_data: Dict[str, Any],
+    contract: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """GIT-93 Phase 6 — resolve the contract layout dict for a slide.
+
+    Precedence: ``layout_name`` → exact name match in ``contract["layouts"]``;
+    else ``slide_type`` → fingerprint match via ``layout_contract``. Returns
+    the layout dict or ``None``.
+    """
+    if contract is None or not isinstance(contract, dict):
+        return None
+    layouts = contract.get("layouts")
+    if not isinstance(layouts, list) or not layouts:
+        return None
+    # 1. layout_name (GIT-93): explicit per-slide targeting. Match the SAME
+    # way the render path does (_resolve_layout: case-insensitive exact, then
+    # normalized stripping ``^\d+_``) so a slide that renders also gets overflow
+    # geometry — previously this used bare ``==`` and silently deferred
+    # case/prefix-divergent names (code-review MINOR-2).
+    layout_name = slide_data.get("layout_name")
+    if layout_name:
+        from layout_contract import _normalize_layout_name
+        target_lower = layout_name.lower()
+        target_norm = _normalize_layout_name(layout_name)
+        for L in layouts:
+            if not isinstance(L, dict):
+                continue
+            lname = L.get("name", "")
+            if lname.lower() == target_lower:
+                return L
+        for L in layouts:
+            if not isinstance(L, dict):
+                continue
+            if _normalize_layout_name(L.get("name", "")) == target_norm:
+                return L
+        return None  # name given but not found → no silent fallback (explicit)
+    # 2. slide_type: fingerprint match (pure, operates on the contract dict).
+    slide_type = slide_data.get("slide_type")
+    if slide_type:
+        try:
+            from layout_contract import _resolve_layout_by_fingerprint
+            idx, _ = _resolve_layout_by_fingerprint(slide_type, contract)
+            if idx is not None and 0 <= idx < len(layouts):
+                return layouts[idx]
+        except Exception:
+            pass
+    return None
+
+
 def _available_height_for_field(
     field_name: str,
-    slide_type: str,
+    slide_data: Dict[str, Any],
     contract: Optional[Dict[str, Any]],
 ) -> Optional[float]:
     """Look up the available content height (in inches) for a body field.
 
-    Returns ``None`` when the contract is missing or the field is unknown —
-    in that case the caller treats overflow detection as best-effort (a missing
-    ceiling means we cannot confidently say OVERFLOW, so default to FIT and
-    let the post-render image verification (Phase 2.4b) catch real overflow).
+    GIT-93 Phase 6 (NF-1/NF-2): resolves geometry by ``layout_name`` →
+    ``contract["layouts"][i]`` → ``placeholders`` (falling back to slide_type
+    fingerprint). Reads ``ph.get("type")`` (the contract emits ``"type"`` —
+    e.g. ``"OBJECT"``/``"body"``), NOT the dead ``"role"`` key. Retires the
+    ``layouts_by_slide_type`` dead key (NF-2 bug-fix). Returns ``None`` when
+    geometry is unavailable (defer to image oracle).
     """
-    if contract is None:
-        return None
-    # The contract exposes per-layout placeholder geometry. Look up by slide_type.
-    layouts_by_type = contract.get("layouts_by_slide_type") if isinstance(contract, dict) else None
-    if not isinstance(layouts_by_type, dict):
-        return None
-    layout = layouts_by_type.get(slide_type)
-    if not isinstance(layout, dict):
+    layout = _resolve_layout_contract(slide_data, contract)
+    if not layout:
         return None
     placeholders = layout.get("placeholders") if isinstance(layout.get("placeholders"), list) else []
-    # Match by role: 'body' → 'body'; 'body_left'/'body_right' → look for left/right
     for ph in placeholders:
         if not isinstance(ph, dict):
             continue
-        ph_role = ph.get("role", "")
+        ph_type = ph.get("type", "")  # NF-1: contract emits "type", not "role"
         ph_height = ph.get("height_in")
         if ph_height is None:
             continue
-        if field_name == "body" and ph_role in ("body", "OBJECT", "object"):
+        if field_name == "body" and ph_type in ("body", "OBJECT", "object"):
             try:
                 return float(ph_height)
             except (TypeError, ValueError):
                 continue
-        if field_name in ("body_left", "body_right") and ph_role in ("body", "OBJECT", "object"):
+        if field_name in ("body_left", "body_right") and ph_type in ("body", "OBJECT", "object"):
             # Two-body layouts report a single body height per column; use as estimate.
             try:
                 return float(ph_height)
             except (TypeError, ValueError):
                 continue
-        if field_name == "subtitle" and ph_role in ("subtitle", "SUBTITLE"):
+        if field_name == "subtitle" and ph_type in ("subtitle", "SUBTITLE"):
             try:
                 return float(ph_height)
             except (TypeError, ValueError):
@@ -210,7 +255,7 @@ def overflow_check(
             text = _text_for_field(slide, field_name)
             if not text:
                 continue
-            avail = _available_height_for_field(field_name, slide_type, template_contract)
+            avail = _available_height_for_field(field_name, slide, template_contract)
             if avail is None:
                 deferred = True
                 continue

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/ppt_builder.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/ppt_builder.py
@@ -94,7 +94,7 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 # BT-142 Phase 2.3: the bundled default template is REMOVED. Callers MUST
 # supply a user template path — there is no fallback. This enforces the user's
 # "no bundled default.pptx" invariant (Goal #1 of PLAN-BT-142).
-# scripts → pptx-generate-slide-skill → skills → .opencode → repo root
+# scripts → generate-slide-skill → skills → .opencode → repo root
 _REPO_ROOT = _SCRIPT_DIR.parents[3]
 DEFAULT_OUTPUT_DIR = Path.cwd() / "output"
 
@@ -125,23 +125,11 @@ _PT_TO_ROLE = {"title": "title", "subtitle": "subtitle", "body": "body"}
 # historical 12/14 visual hierarchy (0.857) now that sizes are template-derived.
 _BODY_DESC_RATIO = 0.85
 
-_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-
 # PLAN-GIT-72: _LAYOUT_NAME_MAP / _SLIDE_TYPE_FINGERPRINT / _SERVES_LAYOUT moved
-# to layout_contract (shared). _LAYOUTS_WITH_* below are fill-specific (stay).
+# to layout_contract (shared). GIT-93 Phase 3 retired the _LAYOUTS_WITH_*
+# fill-gate sets — fill dispatch is now field-presence + placeholder-driven.
 
-_LAYOUTS_WITH_SUBTITLE = {
-    "title_slide", "closing_slide",
-}
-_LAYOUTS_WITH_BODY = {
-    "content_slide", "content_image_slide",
-}
-_LAYOUTS_WITH_TWO_BODIES = {
-    "two_content_slide", "comparison_slide",
-}
-_LAYOUTS_WITH_CHART = {
-    "chart_slide",
-}
+_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 
 # Slide types whose body/content area is the primary selection concern
 # (used for the content_area_in2 tie-break).
@@ -315,19 +303,43 @@ def _select_layout(
     exact_idx: Dict[str, Any],
     norm_idx: Dict[str, Any],
     page_num: int,
+    layout_name: Optional[str] = None,
 ) -> Optional[Any]:
-    """Resolve a slide_type to a concrete ``SlideLayout`` (issue #44).
+    """Resolve a slide_type to a concrete ``SlideLayout`` (issue #44 + GIT-93).
 
-    Precedence: config pin (``<slide_type>_layout``) → fingerprint match →
-    name-based fallback → degradation (skip + warn). Without a contract the path
-    is the original name-based matching, so behaviour is backward compatible.
+    Precedence (GIT-93 Phase 2): **layout_name** (highest) → config pin →
+    fingerprint match → name-based fallback → degradation (skip + warn).
+
+    ``layout_name`` is the first-class mechanism that makes ANY template layout
+    targetable — including layouts outside the 8 standard types. The config pin
+    branch now also rescues pseudo-types (``_custom_N``) because the gate no
+    longer rejects unknown types when a rescue path exists (T2.3/T2.4 bug fix).
     """
-    if slide_type not in _SLIDE_TYPE_FINGERPRINT and slide_type not in _LAYOUT_NAME_MAP:
+    # 0. layout_name — explicit per-slide layout targeting (GIT-93 Phase 2).
+    #    Highest precedence: per-slide authoring wins over deck-wide operator
+    #    config (NIT-1 policy). Resolves by name against the live template.
+    if layout_name:
+        layout = _resolve_layout([layout_name], exact_idx, norm_idx)
+        if layout is not None:
+            return layout
+        logger.warning(
+            "Page %d: layout_name '%s' not found on template; falling back",
+            page_num, layout_name,
+        )
+
+    pinned = config.get(f"{slide_type}_layout")
+    is_known = (slide_type in _SLIDE_TYPE_FINGERPRINT
+                or slide_type in _LAYOUT_NAME_MAP)
+
+    # Gate (GIT-93 T2.3): an unknown slide_type with NO layout_name and NO
+    # config pin cannot be resolved — skip it. Previously this rejected unknown
+    # types unconditionally BEFORE the config-pin branch, which silently broke
+    # the pseudo-type escape hatch (T2.4 bug fix).
+    if not is_known and not layout_name and not pinned:
         logger.warning("Page %d: unknown slide_type '%s', skipped", page_num, slide_type)
         return None
 
-    # 1. Config pin — explicit layout name (highest precedence; all 8 types).
-    pinned = config.get(f"{slide_type}_layout")
+    # 1. Config pin — explicit layout name (all types incl. pseudo-types).
     if pinned:
         layout = _resolve_layout([pinned], exact_idx, norm_idx)
         if layout is not None:
@@ -336,7 +348,7 @@ def _select_layout(
             "Page %d: config pin '%s' not found; falling back", page_num, pinned)
 
     # 2. Fingerprint match (contract-aware; names are a tie-breaker).
-    if contract:
+    if contract and slide_type in _SLIDE_TYPE_FINGERPRINT:
         idx, reason = _resolve_layout_by_fingerprint(slide_type, contract)
         if idx is not None:
             return prs.slide_layouts[idx]
@@ -389,6 +401,7 @@ def _validate_template(
     prs: Presentation,
     template_path: str,
     contract: Optional[Dict[str, Any]] = None,
+    slide_data_list: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
     """US-4.7 pre-flight: abort with :class:`TemplateError` on severe problems.
 
@@ -396,6 +409,11 @@ def _validate_template(
     types. Openability is checked by the caller (``Presentation(...)`` is wrapped).
     Minor issues (missing fonts, no header/footer, small content area, no embedded
     schema) are NOT checked here — they stay non-fatal warnings elsewhere.
+
+    GIT-93 T2.5: "serves none of the 8 types" is downgraded from fatal to warning
+    when at least one slide carries an explicit ``layout_name`` (it targets a
+    layout directly, bypassing the 8-type fingerprint servability check). Stays
+    fatal when no slide carries ``layout_name`` (preserves the original guard).
     """
     try:
         masters = list(prs.slide_masters)
@@ -424,10 +442,23 @@ def _validate_template(
             served = {}
         available = [t for t, info in served.items() if info and info.get("available")]
         if not available:
-            raise TemplateError(
-                f"Template serves none of the 8 slide types — cannot generate "
-                f"any slide: {template_path}"
+            # GIT-93 T2.5: relax if >=1 slide carries an explicit layout_name.
+            has_layout_name = bool(slide_data_list) and any(
+                isinstance(s, dict) and s.get("layout_name")
+                for s in slide_data_list
             )
+            if has_layout_name:
+                logger.warning(
+                    "Template serves none of the 8 standard slide types, but >=1 "
+                    "slide carries an explicit layout_name — proceeding (layouts "
+                    "targeted directly, bypassing fingerprint servability): %s",
+                    template_path,
+                )
+            else:
+                raise TemplateError(
+                    f"Template serves none of the 8 slide types — cannot generate "
+                    f"any slide (and no slide carries a layout_name): {template_path}"
+                )
 
 
 def _remove_all_slides(prs: Presentation) -> int:
@@ -1333,7 +1364,7 @@ def generate_ppt_from_data(
     # #46 (P3): state machine ① — discard any derived template_new.pptx left
     # from a prior run so the base template.pptx is re-evaluated fresh each
     # request. Inline (no cross-skill import); the full lifecycle lives in the
-    # pptx-template-modifier-skill and is wired by P4 when cloning is implemented.
+    # template-modifier-skill and is wired by P4 when cloning is implemented.
     _derived = template.with_name(template.stem + "_new" + template.suffix)
     if _derived.exists():
         try:
@@ -1348,7 +1379,7 @@ def generate_ppt_from_data(
 
     config = _load_config(str(template))
     # #47 (P4): merge caller-supplied layout overrides (e.g. cloned-layout pins
-    # from pptx-template-modifier-skill's resolve_and_clone). Caller overrides win.
+    # from template-modifier-skill's resolve_and_clone). Caller overrides win.
     if config_overrides:
         config = {**config, **config_overrides}
 
@@ -1412,7 +1443,7 @@ def generate_ppt_from_data(
     # US-4.7 (AC4/AC5/AC6): severe template problems abort before the render loop.
     # Structural checks (no master / zero layouts) always run; servability (AC6)
     # runs only when the contract is available. See ``_validate_template``.
-    _validate_template(prs, str(template), contract)
+    _validate_template(prs, str(template), contract, slide_data_list)
 
     # US-4.2: build a {layout_name: {role: size_pt}} map from the embedded
     # schema (best-effort) for the M1 base-size resolution chain. Absent/corrupt
@@ -1450,9 +1481,11 @@ def generate_ppt_from_data(
     for page_num, slide_data in enumerate(slide_data_list, start=1):
         slide_type = slide_data.get("slide_type", "")
 
-        # Resolve layout: config pin → fingerprint match → name fallback (#44).
+        # Resolve layout: layout_name (GIT-93) → config pin → fingerprint match
+        # → name fallback (#44).
         layout = _select_layout(
-            slide_type, contract, config, prs, exact_idx, norm_idx, page_num
+            slide_type, contract, config, prs, exact_idx, norm_idx, page_num,
+            layout_name=slide_data.get("layout_name"),
         )
         if layout is None:
             continue  # degradation warning already logged
@@ -1482,69 +1515,73 @@ def generate_ppt_from_data(
                         slide_report.append(entry)
                     logger.info("  Title: \"%s\"", title_text)
 
-            # Fill subtitle (for title, agenda, closing, section-header-sub).
+            # Fill/clear subtitle (GIT-93 Phase 3: field-driven + sweep).
             # With content -> fill (overrides inheritance). Without content ->
             # REMOVE the placeholder so the layout's inherited sample text (e.g.
             # closing's "Prepared by: Lecturer Name", title's "Click to edit
             # Master subtitle style") cannot bleed in (an empty <a:p/> still
-            # inherits — verified empirically).
-            if slide_type in _LAYOUTS_WITH_SUBTITLE:
-                sub_ph = _find_placeholder(slide, _SUBTITLE_TYPE)
-                if sub_ph:
-                    if slide_type == "closing_slide":
-                        # closing sign-off from presenter fields; fall back to an
-                        # explicit subtitle; both empty -> removed below.
-                        subtitle_text = _compose_signoff(slide_data) or slide_data.get("subtitle", "")
-                    else:
-                        subtitle_text = slide_data.get("subtitle", "")
-                    if subtitle_text:
-                        fit = _set_text(
-                            sub_ph, subtitle_text,
-                            role="subtitle", schema_font_map=schema_font_map, layout=layout,
+            # inherits — verified empirically). MAJOR-1: the sweep MUST survive
+            # the field-driven refactor for the standard title/closing types.
+            sub_ph = _find_placeholder(slide, _SUBTITLE_TYPE)
+            if sub_ph:
+                if slide_type == "closing_slide":
+                    # closing sign-off from presenter fields; fall back to an
+                    # explicit subtitle; both empty -> removed below.
+                    # (NF-3: preserve _compose_signoff.)
+                    subtitle_text = _compose_signoff(slide_data) or slide_data.get("subtitle", "")
+                else:
+                    subtitle_text = slide_data.get("subtitle", "")
+                if subtitle_text:
+                    fit = _set_text(
+                        sub_ph, subtitle_text,
+                        role="subtitle", schema_font_map=schema_font_map, layout=layout,
+                    )
+                    if fit and fit.adjusted:
+                        logger.info(
+                            "  Subtitle auto-shrunk %g→%gpt",
+                            fit.base_size_pt, fit.applied_size_pt,
                         )
-                        if fit and fit.adjusted:
-                            logger.info(
-                                "  Subtitle auto-shrunk %g→%gpt",
-                                fit.base_size_pt, fit.applied_size_pt,
-                            )
-                        entry = _font_fit_report_entry("subtitle", "subtitle", fit)
+                    entry = _font_fit_report_entry("subtitle", "subtitle", fit)
+                    if entry:
+                        slide_report.append(entry)
+                    logger.info("  Subtitle: \"%s\"", subtitle_text[:50])
+                else:
+                    _remove_placeholder(sub_ph)
+                    logger.info("  Subtitle: removed (no content; no inherited-sample bleed)")
+
+            # Fill body text (GIT-93 Phase 3: field-driven — any slide with a
+            # body field whose layout has a BODY/OBJECT placeholder). Guard
+            # against body_left/body_right so a slide carrying BOTH does not
+            # double-fill/overwrite (the two fields were mutually exclusive
+            # under the old type-membership gates).
+            body_text = slide_data.get("body", "")
+            if body_text and not (slide_data.get("body_left") or slide_data.get("body_right")):
+                body_ph = _find_body_placeholder(slide)
+                if body_ph:
+                    fit = _set_body_text(
+                        body_ph, body_text,
+                        role="body", schema_font_map=schema_font_map, layout=layout,
+                    )
+                    if fit:
+                        entry = _font_fit_report_entry("body", "body", fit)
                         if entry:
                             slide_report.append(entry)
-                        logger.info("  Subtitle: \"%s\"", subtitle_text[:50])
-                    else:
-                        _remove_placeholder(sub_ph)
-                        logger.info("  Subtitle: removed (no content; no inherited-sample bleed)")
+                        if fit.adjusted:
+                            logger.info(
+                                "  Body auto-shrunk %g→%gpt",
+                                fit.base_size_pt, fit.applied_size_pt,
+                            )
+                        if not fit.fits:
+                            logger.warning(
+                                "  Body still overflows at %gpt floor (AC1 best-effort)",
+                                fit.applied_size_pt,
+                            )
+                    logger.info("  Body: %d lines", len([l for l in body_text.split("\n") if l.strip()]))
 
-            # Fill body text (for content slides)
-            if slide_type in _LAYOUTS_WITH_BODY:
-                body_text = slide_data.get("body", "")
-                if body_text:
-                    body_ph = _find_body_placeholder(slide)
-                    if body_ph:
-                        fit = _set_body_text(
-                            body_ph, body_text,
-                            role="body", schema_font_map=schema_font_map, layout=layout,
-                        )
-                        if fit:
-                            entry = _font_fit_report_entry("body", "body", fit)
-                            if entry:
-                                slide_report.append(entry)
-                            if fit.adjusted:
-                                logger.info(
-                                    "  Body auto-shrunk %g→%gpt",
-                                    fit.base_size_pt, fit.applied_size_pt,
-                                )
-                            if not fit.fits:
-                                logger.warning(
-                                    "  Body still overflows at %gpt floor (AC1 best-effort)",
-                                    fit.applied_size_pt,
-                                )
-                        logger.info("  Body: %d lines", len([l for l in body_text.split("\n") if l.strip()]))
-
-            # Fill two body areas (for two-content slides)
-            if slide_type in _LAYOUTS_WITH_TWO_BODIES:
-                body_left = slide_data.get("body_left", "")
-                body_right = slide_data.get("body_right", "")
+            # Fill two body areas (GIT-93 Phase 3: field-driven).
+            body_left = slide_data.get("body_left", "")
+            body_right = slide_data.get("body_right", "")
+            if body_left or body_right:
                 objects = _find_placeholders(slide, _OBJECT_TYPE)
                 # BODY placeholders serve the same role as OBJECT (the
                 # introspector normalizes BODY→OBJECT in the contract, but
@@ -1589,8 +1626,11 @@ def generate_ppt_from_data(
                         "  Two-content slide has no content placeholders; "
                         "body_left/body_right dropped")
 
-            # Add chart (for chart slides)
-            if slide_type in _LAYOUTS_WITH_CHART:
+            # Add chart (GIT-93 Phase 3: field-driven — any slide carrying
+            # chart_type; PLUS a known chart_slide whose chart_type is absent
+            # so _add_chart_to_slide still applies its bar default, preserving
+            # backward compat).
+            if slide_type == "chart_slide" or slide_data.get("chart_type"):
                 _add_chart_to_slide(slide, slide_data)
 
             # Embed image (any slide carrying image_path) — #18

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/schema_validator.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/schema_validator.py
@@ -36,7 +36,7 @@ import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from density_mode import DEFAULT_DENSITY_MODE, validate_density
-from schemas import SLIDE_SCHEMAS, VALID_SLIDE_TYPES
+from schemas import ALL_FIELD_SPECS, SLIDE_SCHEMAS, VALID_SLIDE_TYPES
 
 # Allowed scalar python types for each declared field ``type`` string.
 _TYPE_CHECKERS = {
@@ -206,6 +206,54 @@ def _validate_field(
                 )
 
 
+def _validate_generic_fields(
+    slide_data: Dict[str, Any],
+    slide_index: int,
+    result: "ValidationResult",
+) -> None:
+    """GIT-93 Phase 4 — validate a ``layout_name``-targeted slide generically.
+
+    Used when ``slide_type`` is unknown but ``layout_name`` is present. Instead
+    of the per-type schema (which doesn't exist for the unknown type), this
+    validates each PRESENT field against the union catalog ``ALL_FIELD_SPECS``
+    and enforces a minimal cross-field invariant set.
+
+    Invariant downshift (documented): unknown-type slides lose the per-type
+    REQUIRED guarantee in favor of recommended-warnings. ``title`` and
+    ``notes`` are warned-if-absent (non-fatal). The chart pair
+    (``chart_type`` → ``categories``+``series``) stays hard-error.
+    """
+    # Per-field validation against the union catalog.
+    for field, value in slide_data.items():
+        if field in ("slide_type", "layout_name"):
+            continue
+        spec = ALL_FIELD_SPECS.get(field)
+        if spec:
+            _validate_field(value, spec, slide_index, field, result)
+        else:
+            result.add(ValidationIssue(
+                f"unknown field '{field}' for layout_name-targeted slide",
+                slide_index=slide_index, field_path=field, severity="warning",
+            ))
+    # T4.2b: title / notes recommended (warn-if-absent) — restores parity with
+    # the per-type schemas' required-field intent, kept non-fatal.
+    for req_field in ("title", "notes"):
+        if req_field not in slide_data or slide_data[req_field] in (None, ""):
+            result.add(ValidationIssue(
+                f"missing recommended field '{req_field}' for "
+                f"layout_name-targeted slide",
+                slide_index=slide_index, field_path=req_field, severity="warning",
+            ))
+    # T4.3: chart pair enforcement — hard error (a chart without data is broken).
+    if slide_data.get("chart_type"):
+        for req in ("categories", "series"):
+            if not slide_data.get(req):
+                result.add(ValidationIssue(
+                    f"chart slide missing required field '{req}'",
+                    slide_index=slide_index, field_path=req, severity="error",
+                ))
+
+
 def validate_slide(slide_data: Any, slide_index: int) -> ValidationResult:
     """Validate a single slide object against its ``slide_type`` schema."""
     result = ValidationResult()
@@ -234,15 +282,20 @@ def validate_slide(slide_data: Any, slide_index: int) -> ValidationResult:
         return result
 
     if slide_type not in SLIDE_SCHEMAS:
-        # Unknown slide_type: the engine skips these gracefully, so this is a
-        # warning, not a fatal error (keeps backward compatibility).
-        result.add(ValidationIssue(
-            f"unknown slide_type '{slide_type}' — will be skipped "
-            f"(valid types: {list(VALID_SLIDE_TYPES)})",
-            slide_index=slide_index,
-            field_path="slide_type",
-            severity="warning",
-        ))
+        # GIT-93 Phase 4: a layout_name-targeted slide (unknown slide_type) is
+        # validated via the generic per-field path instead of being skipped.
+        if slide_data.get("layout_name"):
+            _validate_generic_fields(slide_data, slide_index, result)
+        else:
+            # Unknown slide_type: the engine skips these gracefully, so this is a
+            # warning, not a fatal error (keeps backward compatibility).
+            result.add(ValidationIssue(
+                f"unknown slide_type '{slide_type}' — will be skipped "
+                f"(valid types: {list(VALID_SLIDE_TYPES)}, or supply layout_name)",
+                slide_index=slide_index,
+                field_path="slide_type",
+                severity="warning",
+            ))
         return result
 
     schema = SLIDE_SCHEMAS[slide_type]
@@ -312,8 +365,12 @@ def validate_slide_data_list(
 
     if strict:
         # Promote recommended-field warnings (e.g. missing notes) to errors.
+        # GIT-93 MINOR-4: broaden the match so the generic layout_name path
+        # ("missing recommended field 'notes' for layout_name-targeted slide")
+        # is also promoted — previously only the per-type "missing required
+        # field 'notes'" substring matched.
         for issue in result.issues:
-            if not issue.is_error and "missing required field 'notes'" in issue.reason:
+            if not issue.is_error and "missing" in issue.reason and "'notes'" in issue.reason:
                 issue.severity = "error"
 
     # Density budget check (always non-fatal, even in strict mode). Runs on

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/schemas/__init__.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/schemas/__init__.py
@@ -1,4 +1,4 @@
-"""Schema definitions package for the pptx-generate-slide-skill engine.
+"""Schema definitions package for the generate-slide-skill engine.
 
 Exposes the per-slide-type schemas and the standalone validator so callers can
 import a single, stable entry point::
@@ -7,6 +7,7 @@ import a single, stable entry point::
 """
 
 from .slide_schemas import (
+    ALL_FIELD_SPECS,
     CHART_OPTIONS_SPEC,
     CHART_TYPES,
     SLIDE_SCHEMAS,
@@ -15,6 +16,7 @@ from .slide_schemas import (
 
 __all__ = [
     "SLIDE_SCHEMAS",
+    "ALL_FIELD_SPECS",
     "CHART_OPTIONS_SPEC",
     "CHART_TYPES",
     "VALID_SLIDE_TYPES",

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/schemas/slide_schemas.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/schemas/slide_schemas.py
@@ -153,3 +153,28 @@ SLIDE_SCHEMAS: Dict[str, Dict[str, Dict[str, Any]]] = {
 
 # Reverse lookup: every slide_type the engine understands.
 VALID_SLIDE_TYPES = tuple(SLIDE_SCHEMAS.keys())
+
+
+def _build_all_field_specs() -> Dict[str, Dict[str, Any]]:
+    """Union of every field spec across the 8 slide types + extended fields.
+
+    GIT-93 Phase 4: used by the validator's generic per-field path for
+    ``layout_name``-targeted slides (unknown slide_type). First-wins on
+    duplicate field names (specs are consistent across types for a given
+    name — e.g. ``title``/``notes``/``body`` are identical everywhere).
+    """
+    specs: Dict[str, Dict[str, Any]] = {}
+    for schema in SLIDE_SCHEMAS.values():
+        for bucket in ("required", "optional"):
+            for name, spec in schema.get(bucket, {}).items():
+                specs.setdefault(name, spec)
+    # Extended fields (multi-slot backfill + layout_name targeting — not in
+    # the per-type schemas but recognized by the engine/backfill pass).
+    specs["layout_name"] = {"type": "string"}
+    specs["body_slots"] = {"type": "array"}
+    specs["image_paths"] = {"type": "array"}
+    specs["title_slots"] = {"type": "array"}
+    return specs
+
+
+ALL_FIELD_SPECS = _build_all_field_specs()

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/tests/test_layout_name_targeting.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/tests/test_layout_name_targeting.py
@@ -1,0 +1,428 @@
+"""GIT-93 (slide_type decoupling) — layout_name targeting tests.
+
+Covers the 7-phase plan (PLAN-GIT-93 Rev 2). Phase-by-phase accumulation.
+The shared contract layer (``layout_contract``) is importable because
+``conftest.py`` puts ``_common/scripts`` on ``sys.path``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _layout(name, idx, fp, area=0.0):
+    return {"name": name, "index": idx, "fingerprint": list(fp),
+            "content_area_in2": area}
+
+
+def _contract(layouts):
+    return {"layouts": layouts, "slide_size": {"ratio": "16:9"}}
+
+
+# ===========================================================================
+# Phase 1 (#94) — available_layouts() + classify_layout_fingerprint
+# ===========================================================================
+class TestAvailableLayouts:
+    def test_returns_all_layouts(self):
+        from layout_contract import available_layouts
+        layouts = [_layout(f"L{i}", i, ["TITLE"]) for i in range(35)]
+        result = available_layouts(_contract(layouts))
+        assert len(result) == 35
+        assert result[0]["name"] == "L0"
+        assert result[34]["index"] == 34
+
+    def test_entry_has_four_keys(self):
+        from layout_contract import available_layouts
+        result = available_layouts(_contract([_layout("Agenda", 5, ["TITLE", "OBJECT"], 42.3)]))
+        assert set(result[0].keys()) == {"name", "index", "fingerprint", "content_area_in2"}
+        assert result[0]["fingerprint"] == ["TITLE", "OBJECT"]
+        assert result[0]["content_area_in2"] == 42.3
+
+    def test_empty_or_none_contract(self):
+        from layout_contract import available_layouts
+        assert available_layouts({}) == []
+        assert available_layouts(None) == []
+
+    def test_does_not_filter_to_servable_types(self):
+        # A layout whose fingerprint matches NONE of the 8 standard types is
+        # still listed (the whole point of GIT-93).
+        from layout_contract import available_layouts
+        result = available_layouts(_contract([_layout("Weird", 0, ["CHART", "TABLE", "MEDIA"])]))
+        assert len(result) == 1
+        assert result[0]["name"] == "Weird"
+
+    def test_servable_slide_types_still_reports_eight(self):
+        # T1.3 backward-compat gate: servable_slide_types unchanged.
+        from layout_contract import servable_slide_types, _SLIDE_TYPE_FINGERPRINT
+        report = servable_slide_types(_contract([_layout("Content", 0, ["TITLE", "OBJECT"])]))
+        assert set(report.keys()) == set(_SLIDE_TYPE_FINGERPRINT.keys())
+        assert len(report) == 8
+
+
+class TestClassifyLayoutFingerprint:
+    def test_title_object_maps_to_content_slide(self):
+        from layout_contract import classify_layout_fingerprint
+        assert classify_layout_fingerprint(["TITLE", "OBJECT"]) == "content_slide"
+
+    def test_title_only_maps_to_chart_slide(self):
+        from layout_contract import classify_layout_fingerprint
+        # chart_slide's ideal fingerprint is [TITLE] (the only zero-missing match)
+        assert classify_layout_fingerprint(["TITLE"]) == "chart_slide"
+
+    def test_title_subtitle_maps_to_a_subtitle_type(self):
+        from layout_contract import classify_layout_fingerprint
+        # title_slide / closing_slide / section_header_slide all ideal [TITLE, SUBTITLE]
+        assert classify_layout_fingerprint(["TITLE", "SUBTITLE"]) in (
+            "title_slide", "closing_slide", "section_header_slide")
+
+    def test_empty_returns_none(self):
+        from layout_contract import classify_layout_fingerprint
+        assert classify_layout_fingerprint([]) is None
+
+    def test_exotic_layout_picks_nearest(self):
+        from layout_contract import classify_layout_fingerprint
+        # [TITLE, OBJECT, OBJECT] → two_content_slide / comparison_slide (missing 0)
+        result = classify_layout_fingerprint(["TITLE", "OBJECT", "OBJECT"])
+        assert result in ("two_content_slide", "comparison_slide")
+
+
+# ===========================================================================
+# Phase 2 (#95) — layout_name first-class + gate relaxation + AC6 relax
+# ===========================================================================
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_DEFAULT_PPTX = _REPO_ROOT / "template" / "default.pptx"
+# Fallback: BT-142 intentionally removed the bundled default.pptx from this
+# repo. When it's absent, materialise python-pptx's default template — it
+# ships the standard layout names these tests target ("Title Slide",
+# "Title and Content", "Two Content") — into a temp path so the suite stays
+# self-contained and the @_needs_default tests actually run instead of skipping.
+if not _DEFAULT_PPTX.exists():
+    import tempfile
+    from pptx import Presentation as _Presentation
+    _DEFAULT_PPTX = Path(tempfile.gettempdir()) / "git93_test_default.pptx"
+    if not _DEFAULT_PPTX.exists():
+        _Presentation().save(str(_DEFAULT_PPTX))
+_needs_default = pytest.mark.skipif(
+    not _DEFAULT_PPTX.exists(), reason="template/default.pptx not present"
+)
+
+
+@_needs_default
+class TestLayoutNameTargeting:
+    def test_unknown_slide_type_with_layout_name_renders(self, tmp_path):
+        from ppt_builder import generate_ppt_from_data
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "agenda", "layout_name": "Title Slide",
+                 "title": "Agenda Title", "notes": "n"}]
+        result = generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out)
+        prs = Presentation(result)
+        assert len(prs.slides) == 1  # NOT skipped (layout_name rescues it)
+
+    def test_unknown_slide_type_without_layout_name_skipped(self, tmp_path):
+        from ppt_builder import generate_ppt_from_data
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "agenda", "title": "X", "notes": "n"}]
+        generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out)
+        prs = Presentation(out)
+        assert len(prs.slides) == 0  # skipped (unknown type, no layout_name)
+
+    def test_layout_name_overrides_fingerprint(self, tmp_path):
+        from ppt_builder import generate_ppt_from_data
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        # Same slide_type, different layout_name → each uses its named layout
+        data = [
+            {"slide_type": "content_slide", "layout_name": "Title Slide",
+             "title": "A", "notes": "n"},
+            {"slide_type": "content_slide", "layout_name": "Title and Content",
+             "title": "B", "notes": "n"},
+        ]
+        result = generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out)
+        prs = Presentation(result)
+        names = [s.slide_layout.name for s in prs.slides]
+        assert names == ["Title Slide", "Title and Content"]
+
+    def test_pseudo_type_bug_fixed(self, tmp_path):
+        # Pre-GIT-93: pseudo-type + config-pin was silently dropped (gate
+        # rejected it before the config-pin branch). Now it renders.
+        from ppt_builder import generate_ppt_from_data
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "_custom_1", "title": "Pseudo", "notes": "n"}]
+        overrides = {"_custom_1_layout": "Title Slide"}
+        generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out,
+            config_overrides=overrides)
+        prs = Presentation(out)
+        assert len(prs.slides) == 1
+        assert prs.slides[0].slide_layout.name == "Title Slide"
+
+
+@_needs_default
+class TestAC6Relaxation:
+    def test_zero_servable_without_layout_name_raises(self, tmp_path):
+        # A contract serving none of the 8 types + no layout_name → fatal.
+        from ppt_builder import _validate_template
+        from errors import TemplateError
+        from pptx import Presentation
+        prs = Presentation(str(_DEFAULT_PPTX))
+        contract = {"layouts": [{"name": "Weird", "index": 0,
+                                 "fingerprint": ["MEDIA", "TABLE"]}]}
+        with pytest.raises(TemplateError):
+            _validate_template(prs, "fake.pptx", contract,
+                               [{"slide_type": "content_slide"}])
+
+    def test_zero_servable_with_layout_name_warns_not_raises(self, tmp_path):
+        # Same contract + >=1 slide carrying layout_name → warning, not fatal.
+        from ppt_builder import _validate_template
+        from pptx import Presentation
+        prs = Presentation(str(_DEFAULT_PPTX))
+        contract = {"layouts": [{"name": "Weird", "index": 0,
+                                 "fingerprint": ["MEDIA", "TABLE"]}]}
+        # Must NOT raise.
+        _validate_template(prs, "fake.pptx", contract,
+                           [{"slide_type": "x", "layout_name": "Weird"}])
+
+
+# ===========================================================================
+# Phase 3 (#98) — field-driven fill dispatch (MAJOR-1 sweep preserved)
+# ===========================================================================
+@_needs_default
+class TestFieldDrivenFill:
+    def test_field_driven_fill_unknown_type_body(self, tmp_path):
+        # Unknown slide_type + body field → fills the layout's OBJECT/BODY placeholder
+        from ppt_builder import generate_ppt_from_data, _OBJECT_TYPE, _BODY_TYPE
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "agenda", "layout_name": "Title and Content",
+                 "title": "Agenda", "body": "**1.** Intro\n**2.** Demo", "notes": "n"}]
+        generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out)
+        prs = Presentation(out)
+        slide = prs.slides[0]
+        body_texts = [
+            p.text_frame.text for p in slide.placeholders
+            if p.placeholder_format.type in (_OBJECT_TYPE, _BODY_TYPE)
+        ]
+        assert any("Intro" in t for t in body_texts), (
+            f"body not filled; placeholder texts: {body_texts}")
+
+    def test_subtitle_removed_when_empty(self, tmp_path):
+        # MAJOR-1: a title_slide with NO subtitle must REMOVE the subtitle
+        # placeholder (no master-inherited sample-text bleed).
+        from ppt_builder import generate_ppt_from_data, _SUBTITLE_TYPE
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "title_slide", "title": "T", "notes": "n"}]
+        generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out)
+        prs = Presentation(out)
+        slide = prs.slides[0]
+        subtitle_phs = [p for p in slide.placeholders
+                        if p.placeholder_format.type == _SUBTITLE_TYPE]
+        assert len(subtitle_phs) == 0  # removed, not left as inherited sample
+
+    def test_subtitle_filled_when_present(self, tmp_path):
+        # Counter-check: a title_slide WITH subtitle keeps (fills) it.
+        from ppt_builder import generate_ppt_from_data, _SUBTITLE_TYPE
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "title_slide", "title": "T",
+                 "subtitle": "My Subtitle", "notes": "n"}]
+        generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out)
+        prs = Presentation(out)
+        slide = prs.slides[0]
+        subtitle_phs = [p for p in slide.placeholders
+                        if p.placeholder_format.type == _SUBTITLE_TYPE]
+        assert len(subtitle_phs) == 1
+        assert "My Subtitle" in subtitle_phs[0].text_frame.text
+
+
+# ===========================================================================
+# Phase 4 (#96) — generic per-field schema for layout_name path
+# ===========================================================================
+class TestGenericSchema:
+    def test_layout_name_slide_clean_passes(self):
+        from schema_validator import validate_slide_data_list
+        data = [{"slide_type": "agenda", "layout_name": "Agenda",
+                 "title": "T", "body": "b", "notes": "n"}]
+        res = validate_slide_data_list(data)
+        assert res.is_valid
+
+    def test_chart_missing_series_reports_error(self):
+        # chart_type present but no categories/series → hard error (T4.3)
+        from schema_validator import validate_slide_data_list
+        data = [{"slide_type": "custom_chart", "layout_name": "Chart",
+                 "title": "T", "chart_type": "bar", "notes": "n"}]
+        res = validate_slide_data_list(data)
+        assert not res.is_valid
+        msgs = res.error_messages()
+        assert any("series" in m for m in msgs)
+        assert any("categories" in m for m in msgs)
+
+    def test_missing_title_warns(self):
+        # MAJOR-3: title/notes recommended (warn-if-absent) for layout_name slides
+        from schema_validator import validate_slide_data_list
+        data = [{"slide_type": "team", "layout_name": "Team",
+                 "body": "b"}]  # no title, no notes
+        res = validate_slide_data_list(data)
+        # Warnings don't block is_valid, but must be present
+        warns = res.warning_messages()
+        assert any("title" in w for w in warns)
+        assert any("notes" in w for w in warns)
+
+    def test_unknown_field_warns(self):
+        from schema_validator import validate_slide_data_list
+        data = [{"slide_type": "x", "layout_name": "L",
+                 "title": "T", "notes": "n", "bogus_field": 123}]
+        res = validate_slide_data_list(data)
+        warns = res.warning_messages()
+        assert any("bogus_field" in w for w in warns)
+
+    def test_all_field_specs_covers_union(self):
+        from schemas import ALL_FIELD_SPECS
+        # title/body/subtitle/body_left/body_right/chart_type present
+        for f in ("title", "body", "subtitle", "body_left", "body_right",
+                  "chart_type", "categories", "series", "notes"):
+            assert f in ALL_FIELD_SPECS
+        # extended fields
+        for f in ("layout_name", "body_slots", "image_paths", "title_slots"):
+            assert f in ALL_FIELD_SPECS
+
+
+# ===========================================================================
+# Phase 6 (#99) — overflow geometry by layout_name + density regression
+# ===========================================================================
+class TestOverflowGeometryByLayoutName:
+    def test_unknown_type_layout_name_resolves_geometry(self):
+        # NF-1/NF-2: geometry resolved by layout_name → layouts[i], reads "type"
+        from overflow_check import _available_height_for_field
+        contract = {"layouts": [
+            {"name": "Agenda", "index": 0, "fingerprint": ["TITLE", "OBJECT"],
+             "placeholders": [{"type": "OBJECT", "height_in": 2.0}]}
+        ]}
+        slide = {"slide_type": "agenda", "layout_name": "Agenda", "body": "x"}
+        avail = _available_height_for_field("body", slide, contract)
+        assert avail == 2.0  # real geometry, not None
+
+    def test_unknown_type_no_layout_name_returns_none(self):
+        from overflow_check import _available_height_for_field
+        contract = {"layouts": [
+            {"name": "Content", "index": 0, "fingerprint": ["TITLE", "OBJECT"],
+             "placeholders": [{"type": "OBJECT", "height_in": 3.0}]}
+        ]}
+        # Unknown type, no layout_name, and Content's fingerprint won't match
+        # an unknown slide_type → None (defer to image oracle).
+        slide = {"slide_type": "totally_unknown_xyz", "body": "x"}
+        avail = _available_height_for_field("body", slide, contract)
+        assert avail is None
+
+    def test_known_type_fingerprint_fallback(self):
+        # Known slide_type (no layout_name) → fingerprint match resolves geometry
+        from overflow_check import _available_height_for_field
+        contract = {"layouts": [
+            {"name": "Content", "index": 0, "fingerprint": ["TITLE", "OBJECT"],
+             "placeholders": [{"type": "OBJECT", "height_in": 4.5}]}
+        ]}
+        slide = {"slide_type": "content_slide", "body": "x"}
+        avail = _available_height_for_field("body", slide, contract)
+        assert avail == 4.5
+
+
+class TestDensityCountsUnknownType:
+    def test_density_counts_unknown_type_body(self):
+        # MINOR-1: count_slide_words already counts by field unconditionally —
+        # lock the existing correct behavior for unknown types (regression guard).
+        from density_mode import count_slide_words
+        count = count_slide_words({"slide_type": "agenda", "body": "one two three four"})
+        assert count == 4
+
+
+# ===========================================================================
+# Code-review follow-up tests (MINOR/NIT closure)
+# ===========================================================================
+class TestCodeReviewFollowups:
+    def test_body_and_two_body_do_not_double_fill(self, tmp_path):
+        # MINOR-1: a slide carrying BOTH body and body_left/body_right must not
+        # run both fill paths (would overwrite). two-body wins; body is skipped.
+        from ppt_builder import generate_ppt_from_data, _OBJECT_TYPE, _BODY_TYPE
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "content_slide", "layout_name": "Two Content",
+                 "title": "T",
+                 "body": "SHOULD NOT APPEAR",
+                 "body_left": "left content", "body_right": "right content",
+                 "notes": "n"}]
+        generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out)
+        prs = Presentation(out)
+        texts = [p.text_frame.text for p in prs.slides[0].placeholders]
+        joined = " ".join(texts)
+        assert "SHOULD NOT APPEAR" not in joined  # body skipped (two-body wins)
+        assert "left content" in joined
+        assert "right content" in joined
+
+    def test_overflow_layout_name_case_insensitive(self):
+        # MINOR-2: layout_name differing by case still resolves geometry.
+        from overflow_check import _available_height_for_field
+        contract = {"layouts": [
+            {"name": "Title and Content", "index": 0,
+             "fingerprint": ["TITLE", "OBJECT"],
+             "placeholders": [{"type": "OBJECT", "height_in": 3.0}]}
+        ]}
+        slide = {"slide_type": "x", "layout_name": "title and content", "body": "b"}
+        assert _available_height_for_field("body", slide, contract) == 3.0
+
+    def test_overflow_layout_name_prefix_normalized(self):
+        # MINOR-2: layout_name with a numeric prefix (e.g. "1_two content")
+        # matches contract name "Two Content" via normalization.
+        from overflow_check import _available_height_for_field
+        contract = {"layouts": [
+            {"name": "1_Two Content", "index": 0,
+             "fingerprint": ["TITLE", "OBJECT", "OBJECT"],
+             "placeholders": [{"type": "OBJECT", "height_in": 2.5}]}
+        ]}
+        slide = {"slide_type": "x", "layout_name": "two content", "body": "b"}
+        assert _available_height_for_field("body", slide, contract) == 2.5
+
+    def test_layout_name_beats_config_pin(self, tmp_path):
+        # NIT-1 policy: per-slide layout_name wins over deck-wide config-pin.
+        from ppt_builder import generate_ppt_from_data
+        from pptx import Presentation
+        out = str(tmp_path / "out.pptx")
+        data = [{"slide_type": "content_slide",
+                 "layout_name": "Title Slide",   # should win
+                 "title": "T", "notes": "n"}]
+        # config-pin points the OTHER way
+        overrides = {"content_slide_layout": "Title and Content"}
+        generate_ppt_from_data(
+            data, template_path=str(_DEFAULT_PPTX), output_path=out,
+            config_overrides=overrides)
+        prs = Presentation(out)
+        assert prs.slides[0].slide_layout.name == "Title Slide"  # layout_name won
+
+    def test_classify_fingerprint_tiebreak_pinned(self):
+        # NIT-3: lock the deterministic tie-break winner for [TITLE, SUBTITLE].
+        from layout_contract import classify_layout_fingerprint
+        # Three ideals match with missing=0; dict order → title_slide wins.
+        assert classify_layout_fingerprint(["TITLE", "SUBTITLE"]) == "title_slide"
+
+    def test_strict_mode_promotes_layout_name_missing_notes(self):
+        # MINOR-4: strict mode promotes notes-warning to error for layout_name slides too.
+        from schema_validator import validate_slide_data_list
+        data = [{"slide_type": "team", "layout_name": "Team", "title": "T"}]
+        res = validate_slide_data_list(data, strict=True)
+        assert not res.is_valid  # missing notes promoted to error
+        assert any("notes" in m for m in res.error_messages())
+

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/tests/test_multipass_render.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/tests/test_multipass_render.py
@@ -1,109 +1,51 @@
-"""Tests for BT-142 Phase 3.5a multipass_render."""
+"""Tests for GIT-93 Phase 5 — multipass_render single-pass wrapper.
 
+The partition/pseudo-type machinery (``partition_slides`` /
+``_batch_to_engine_slides``) was deleted: ``layout_name`` is native now
+(Phase 2), so a single pass renders N distinct layouts. These tests verify
+``multipass_render`` delegates to ``render_fn`` in a single pass and that the
+deleted symbols are gone.
+"""
 from __future__ import annotations
 
-import sys
+import importlib
 import pathlib
+import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
-from multipass_render import partition_slides, _batch_to_engine_slides
 
-
-def test_partition_single_batch_under_cap():
-    slides = [{"slide_type": f"t{i}"} for i in range(5)]
-    batches = partition_slides(slides, max_layouts=8)
-    assert len(batches) == 1
-    assert batches[0] == slides
-
-
-def test_partition_splits_when_over_cap():
-    slides = [{"slide_type": f"t{i}"} for i in range(10)]
-    batches = partition_slides(slides, max_layouts=8)
-    assert len(batches) == 2
-    assert len(batches[0]) == 8
-    assert len(batches[1]) == 2
-
-
-def test_partition_groups_same_layout_together():
-    """Slides sharing a layout do not consume a new slot in the next batch."""
-    slides = [
-        {"slide_type": "a"},
-        {"slide_type": "b"},
-        {"slide_type": "a"},  # reuse — does not consume new slot
-        {"slide_type": "c"},
-        {"slide_type": "d"},
-        {"slide_type": "e"},
-        {"slide_type": "f"},
-        {"slide_type": "g"},
-        {"slide_type": "h"},
-        {"slide_type": "i"},  # 9th distinct — triggers split
-    ]
-    batches = partition_slides(slides, max_layouts=8)
-    assert len(batches) == 2
-    # First batch has 9 slides (8 distinct + 1 reuse), then 1 slide (i)
-    assert len(batches[0]) == 9
-    assert len(batches[1]) == 1
-
-
-def test_partition_layout_name_overrides_slide_type():
-    slides = [
-        {"slide_type": "content_slide", "layout_name": "Cover"},
-        {"slide_type": "content_slide", "layout_name": "Story"},
-        {"slide_type": "content_slide", "layout_name": "Cover"},  # reuse
-    ]
-    batches = partition_slides(slides, max_layouts=8)
-    assert len(batches) == 1
-    assert len(batches[0]) == 3  # 2 distinct layouts + 1 reuse
-
-
-def test_partition_invalid_cap():
-    import pytest
-    with pytest.raises(ValueError):
-        partition_slides([], max_layouts=0)
-
-
-def test_batch_to_engine_slides_assigns_pseudo_types():
-    batch = [
-        {"slide_type": "x", "layout_name": "Cover"},
-        {"slide_type": "y", "layout_name": "Story"},
-        {"slide_type": "x", "layout_name": "Cover"},  # reuse
-    ]
-    engine, overrides = _batch_to_engine_slides(batch)
-    # Two distinct layouts → two pseudo-types
-    assert len(overrides) == 2
-    assert engine[0]["slide_type"] == "_custom_1"
-    assert engine[1]["slide_type"] == "_custom_2"
-    assert engine[2]["slide_type"] == "_custom_1"  # reuse maps back
-    # Override keys are <pseudo>_layout
-    keys = list(overrides.keys())
-    assert all(k.endswith("_layout") for k in keys)
-
-
-def test_batch_to_engine_preserves_layout_name_pin():
-    batch = [{"slide_type": "x", "layout_name": "Cover"}]
-    engine, overrides = _batch_to_engine_slides(batch)
-    assert overrides["_custom_1_layout"] == "Cover"
-
-
-def test_multipass_render_uses_single_pass_when_under_cap(tmp_path):
-    """When ≤8 layouts, multipass_render calls render_fn exactly once."""
+def test_multipass_render_always_single_pass(tmp_path):
+    """multipass_render calls render_fn exactly once, regardless of layout count."""
     calls = []
 
     def fake_render(slides, tpl, out, overrides):
-        calls.append(out)
-        # Touch the output so the file exists
+        calls.append((len(slides), overrides))
         with open(out, "w") as f:
             f.write("ok")
         return out
 
     from multipass_render import multipass_render
-    out = multipass_render(
-        [{"slide_type": f"t{i}"} for i in range(3)],
+    multipass_render(
+        [{"slide_type": f"t{i}"} for i in range(12)],  # >8, but no batching now
         template_path="/dev/null",
         output_path=str(tmp_path / "out.pptx"),
-        max_layouts=8,
         render_fn=fake_render,
     )
-    assert len(calls) == 1
-    assert calls[0] == out
+    assert len(calls) == 1  # single pass, even with >8 layouts
+    assert calls[0][0] == 12  # all 12 slides in one pass
+    assert calls[0][1] == {}  # no pseudo-type overrides
+
+
+def test_deleted_functions_no_longer_importable():
+    """partition_slides / _batch_to_engine_slides / cap were removed (Phase 5)."""
+    mod = importlib.import_module("multipass_render")
+    assert not hasattr(mod, "partition_slides")
+    assert not hasattr(mod, "_batch_to_engine_slides")
+    assert not hasattr(mod, "DEFAULT_MAX_LAYOUTS_PER_BATCH")
+
+
+def test_merge_decks_still_importable():
+    """merge_decks is retained (independently useful)."""
+    from multipass_render import merge_decks
+    assert callable(merge_decks)

--- a/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/tests/test_multipass_render_merge.py
+++ b/opencode_app/.opencode/skills/pptx-generate-slide-skill/scripts/tests/test_multipass_render_merge.py
@@ -167,11 +167,12 @@ def test_merge_decks_with_shared_image_no_corruption(tmp_path):
 # Test 3: three-batch partition end-to-end
 # ---------------------------------------------------------------------------
 
-def test_multipass_render_three_batches_preserves_all_slides(tmp_path):
-    """End-to-end: 3 distinct valid slide_types → 3 batches → all 3 slides merged.
+def test_multipass_render_single_pass_preserves_all_slides(tmp_path):
+    """GIT-93 Phase 5: 3 distinct slide_types → single pass → all 3 slides.
 
-    Uses real slide_types (not pseudo-types) so the schema validator accepts
-    them. With max_layouts=1, each distinct slide_type becomes its own batch.
+    Previously this forced 3 batches via max_layouts=1; multipass_render is
+    now always single-pass (layout_name native), so all slides render in one
+    generate_ppt_from_data call.
     """
     template_path = _make_minimal_template(tmp_path)
     slide_data = [
@@ -181,18 +182,15 @@ def test_multipass_render_three_batches_preserves_all_slides(tmp_path):
         {"slide_type": "section_header_slide", "title": "S2",
          "notes": GOOD_NOTES},
     ]
-    out = str(tmp_path / "three_batch.pptx")
-    # Force multi-pass by setting max_layouts=1 (so each layout is its own batch)
+    out = str(tmp_path / "single_pass.pptx")
     result = multipass_render(
         slide_data,
         template_path=template_path,
         output_path=out,
-        max_layouts=1,
     )
     prs = Presentation(result)
-    # Each batch renders 1 slide; merge produces 3 total.
     assert len(prs.slides) >= 3, (
-        f"expected ≥3 slides after 3-batch merge, got {len(prs.slides)}"
+        f"expected ≥3 slides after single-pass render, got {len(prs.slides)}"
     )
 
 
@@ -233,25 +231,19 @@ def test_merge_handles_unknown_layout_gracefully(tmp_path):
 # Test 5: idempotency of multipass_render — single-batch optimization
 # ---------------------------------------------------------------------------
 
-def test_multipass_render_single_batch_no_merge_needed(tmp_path):
-    """When all slides fit one batch (≤ max_layouts distinct), no merge happens.
-
-    Uses valid slide_types only (the engine's 8-type enum is the constraint).
-    With 2 distinct types and max_layouts=8, the partition produces one batch
-    and the fast path renders directly (no merge).
-    """
+def test_multipass_render_single_pass_two_slides(tmp_path):
+    """GIT-93 Phase 5: multipass_render renders all slides in one pass (no merge)."""
     template_path = _make_minimal_template(tmp_path)
     slide_data = [
         {"slide_type": "title_slide", "title": "S0", "subtitle": "x",
          "notes": GOOD_NOTES},
         {"slide_type": "closing_slide", "title": "S1", "notes": GOOD_NOTES},
     ]
-    out = str(tmp_path / "single_batch.pptx")
+    out = str(tmp_path / "single_pass.pptx")
     result = multipass_render(
         slide_data,
         template_path=template_path,
         output_path=out,
-        max_layouts=8,  # both fit in one batch
     )
     prs = Presentation(result)
     assert len(prs.slides) >= 2, f"expected ≥2 slides, got {len(prs.slides)}"


### PR DESCRIPTION
## slide_type decoupling — `layout_name` first-class (GIT-93)

Makes `slide_type` a **semantic label** rather than a hard gate for layout selection, and introduces `layout_name` as a first-class field that targets any template layout — so a template with >8 layouts is no longer limited to 8.

### Motivation
- The engine hard-limited `slide_type` to 8 values; templates with more than 8 layouts could only target ~8.
- **Latent bug**: the pseudo-type escape hatch (`_custom_N` via config-pin) was silently broken — `_select_layout`'s gate rejected unknown types *before* the config-pin branch ran, so those slides were dropped. End-to-end tests deliberately avoided pseudo-types.

### Changes (5 atomic commits)
| Commit | Phase | Scope |
|---|---|---|
| `feat(contract)` | P1 | `available_layouts()` + `classify_layout_fingerprint()` |
| `fix(pptx)` | P2/3 | `layout_name` first-class selector + relaxed gate + field-driven fill (+ pseudo-type bug fix) |
| `refactor(pptx)` | P5/6 | multipass simplified to single-pass + overflow resolved by `layout_name` |
| `feat(validator)` | P4 | generic per-field schema for the `layout_name` path |
| `test(pptx)` | all | 34-test GIT-93 suite + multipass tests adapted |

### Verification
`pytest tests/` on the pptx-generate-slide-skill suite: **535 passed, 9 skipped, 0 failed**. The existing 8-type path is unchanged (backward compatible).

### Notes
- No `SKILL.md` / agent prompt / `AGENTS.md` (Phase 7 docs) changes in this PR — code + tests only.
- One test-local adaptation: `test_layout_name_targeting.py` materialises a default template via python-pptx when the repo's bundled `default.pptx` is absent (BT-142 removed it), so the suite stays self-contained.

### Status
Draft — ported for review; do not merge yet.