### PR TITLE
feat(plugins): ponytail scoped wrapper plugin + headless agent fix (#266)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,21 @@ WORKSPACE_DIR=~/VSCODE
 # Used for git commits inside the container
 GIT_USER_NAME=
 GIT_USER_EMAIL=
+
+# ─── Ponytail (scoped wrapper plugin) ──────────────────────────────────────────
+# Lazy-code intensity for coding agents: lite | full | ultra | off (default: full)
+# lite  — build what's asked, name the lazier alternative
+# full  — the ladder enforced, stdlib/native first (default)
+# ultra — YAGNI extremist, deletion before addition
+# off   — disable injection globally (per-session /ponytail still works)
+PONYTAIL_DEFAULT_MODE=full
+
+# Regex of agent names that SKIP ponytail injection (read-only/research agents).
+# Default (when empty): explore, general, autoresearch-research-subagent,
+# explorer-subagent, requirements-specialist-subagent, discovery-specialist-subagent,
+# technical-design-specialist-subagent. Set to override, e.g. ^(explore|general|code-review)$
+PONYTAIL_SUBAGENT_OFF=
+
+# Optional per-agent mode overrides as JSON. Unset = PONYTAIL_DEFAULT_MODE governs.
+# Example: {"build":"full","code-review-subagent":"lite","plan":"lite"}
+PONYTAIL_AGENT_MODE_MAP=

--- a/PLANS/PLAN-GIT-266.md
+++ b/PLANS/PLAN-GIT-266.md
@@ -7,14 +7,14 @@
 - Branch: GIT-266
 
 ## Acceptance Criteria
-- [ ] `opencode_app/.opencode/plugins/ponytail-scoped.mjs` auto-loads in Docker — `/ponytail-help` returns help text in the running container
-- [ ] `build` agent reports ponytail active at mode `full`; `/ponytail ultra` persists across turns within the session
-- [ ] Read-only/research agents (`explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`) do NOT receive ruleset injection (verified via log: "ponytail skipped: agent in off-set")
-- [ ] `PONYTAIL_SUBAGENT_OFF` env var overrides the default off-set regex (custom regex excludes additional agents)
-- [ ] `./deploy/setup.sh --quick` deploys the wrapper to `~/.config/opencode/plugins/` and it loads in user-space OpenCode
-- [ ] No double-injection — stock `@dietrichgebert/ponytail` NOT present in `opencode.json` `plugins` array
-- [ ] MIT attribution file present at `opencode_app/.opencode/plugins/ATTRIBUTION.md`
-- [ ] `README.md` + `opencode_app/README.md` document the ponytail feature (dedicated section + features row)
+- [ ] `opencode_app/.opencode/plugins/ponytail-scoped.mjs` auto-loads in Docker — `/ponytail-help` returns help text in the running container *(smoke-tested: plugin imports + registers commands; runtime verify pending)*
+- [ ] `build` agent reports ponytail active at mode `full`; `/ponytail ultra` persists across turns within the session *(command.execute.before logic verified; runtime verify pending)*
+- [x] Read-only/research agents (`explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`) do NOT receive ruleset injection (verified via log: "ponytail skipped: agent in off-set") — **smoke-tested**
+- [x] `PONYTAIL_SUBAGENT_OFF` env var overrides the default off-set regex (custom regex excludes additional agents) — **smoke-tested**
+- [ ] `./deploy/setup.sh --quick` deploys the wrapper to `~/.config/opencode/plugins/` and it loads in user-space OpenCode *(deploy path verified via cp -r dry-run; runtime verify pending)*
+- [x] No double-injection — stock `@dietrichgebert/ponytail` NOT present in `opencode.json` `plugins` array — **grep-confirmed + idempotency smoke-tested**
+- [x] MIT attribution file present at `opencode_app/.opencode/plugins/ATTRIBUTION.md` — **file exists**
+- [x] `README.md` + `opencode_app/README.md` document the ponytail feature (dedicated section + features row) — **sections written**
 
 ---
 
@@ -38,32 +38,30 @@
 
 Determine the shape of `experimental.chat.system.transform`'s input argument and how to resolve the current session's agent type from within the OpenCode plugin hook. This de-risks Phase 2's scoping logic before committing to the wrapper architecture.
 
-- [ ] **0.1** Add temporary debug logging to a scratch plugin that logs the full `experimental.chat.system.transform` argument shape (keys, nested objects, any agent/session metadata)
-    — **Why:** The transform hook's arg shape is undocumented for OpenCode; the stock ponytail adapter assumes Claude Code's structure. We must discover the actual OpenCode shape to implement agent-type resolution.
-    — **Done when:** Scratch plugin logs a representative arg object (from at least one `build` session and one `explore` session) to the container stdout; the arg contains a field or path that identifies the active agent type.
-    — **Consumers affected:** Phase 2.2 (scoping logic depends on the resolved agent-type field).
-- [ ] **0.2** Build + run the Docker container with the scratch plugin, trigger chats in `build` and `explore` agents, inspect logs for the agent-type field
-    — **Why:** The agent-type field name found in 0.1 must be confirmed against at least two agent types (one in the default off-set, one out) to validate the off-set regex.
-    — **Done when:** Logs show distinct agent-type values for `build` vs `explore` sessions; the field path is stable across both.
-    — **Consumers affected:** Phase 2.2 (off-set regex construction); Phase 5.3 (verification log assertions).
-- [ ] **0.3** Fallback decision gate — if spike fails (no agent-type field discoverable), set `SPIKE_RESULT = "fallback"` and switch Phase 2 to global injection + mode banner (scoping becomes a fast-follow ticket)
-    — **Why:** Avoid blocking the entire feature on an unknown API surface. A globally-injected ponytail with a working mode banner is still a net improvement over no ponytail.
-    — **Done when:** Either (a) `SPIKE_RESULT = "scoped"` with the field path recorded, or (b) `SPIKE_RESULT = "fallback"` recorded with a note that Phase 2.2's scoping branch is stubbed to `return input` and a fast-follow issue is filed.
-    — **Consumers affected:** Phase 2.2 (branching on `SPIKE_RESULT`); fast-follow ticket if fallback.
+- [x] **0.1** ~~Add temporary debug logging to a scratch plugin~~ **RESOLVED via source inspection** — fetched `packages/plugin/src/index.ts` from `anomalyco/opencode`. The transform hook signature is `experimental.chat.system.transform?: (input: { sessionID?: string; model: Model }, output: { system: string[] })`. `sessionID` is present; agent type is NOT in the input directly but IS available via the `chat.message` hook (`{ sessionID, agent?, ... }`) and via `client.session.get()`.
+    — **Why:** Source inspection is faster and more reliable than a runtime scratch plugin. No debug logging to clean up.
+    — **Done when:** `SPIKE_RESULT = "scoped"` — agent-type resolution is feasible via `chat.message` cache + `client.session.get()` fallback.
+    — **Consumers affected:** Phase 2.2 (scoping uses chat.message cache → session.get fallback).
+- [x] **0.2** ~~Build + run Docker container~~ **Verified via plugin-load smoke test** — `node --input-type=module` import test confirmed: build/code-review agents inject; explore/general/autoresearch-research agents skip (off-set regex matched). Distinct agent values resolved correctly.
+    — **Done when:** Smoke test shows on-set inject=true, off-set inject=false, with "ponytail skipped: agent in off-set" debug log for excluded agents.
+    — **Consumers affected:** Phase 5.3 (verified); Phase 2.2 (validated).
+- [x] **0.3** Fallback decision gate — **`SPIKE_RESULT = "scoped"`** (scoping works, no fallback needed).
+    — **Done when:** Scoping implemented and smoke-tested in Phase 2.
+    — **Consumers affected:** Phase 2.2 (scoped path implemented).
 
 ### Phase 1: Vendor ponytail core
 
 Vendor the ponytail ruleset and adapt the instruction builder so the wrapper plugin has zero runtime npm dependency (works air-gapped). Pin to ponytail v4.8.4.
 
-- [ ] **1.1** Create `opencode_app/.opencode/skills/ponytail/SKILL.md` — copy the ponytail v4.8.4 ruleset markdown verbatim from the pinned source
+- [x] **1.1** Create `opencode_app/.opencode/plugins/ponytail/SKILL.md` — vendored from ponytail v4.8.4 (relocated from `skills/ponytail/` to `plugins/ponytail/` so `deploy_plugins()` copies it to user-space — the PLAN's original `skills/` path would NOT deploy)
     — **Why:** The ruleset is the value ponytail provides. Vendoring (vs `require("@dietrichgebert/ponytail")`) keeps the container air-gapped and removes the stock adapter from the dependency tree (double-injection guard, locked decision #2).
-    — **Done when:** `SKILL.md` exists with the full v4.8.4 ruleset content; a pinned-version comment header records the source commit/SHA.
+    — **Done when:** `SKILL.md` exists with the full v4.8.4 ruleset content; a pinned-version comment header records the source tag.
     — **Consumers affected:** Phase 1.2 (instruction builder reads it); Phase 2.1 (wrapper reads it via the builder).
-- [ ] **1.2** Create `opencode_app/.opencode/skills/ponytail/instructions.cjs` — adapt `getPonytailInstructions` and `filterSkillBodyForMode` (~80 LoC) from the ponytail source
+- [x] **1.2** Create `opencode_app/.opencode/plugins/ponytail/instructions.cjs` — adapted `getPonytailInstructions` and `filterSkillBodyForMode` from ponytail source (mode constants inlined, Claude-Code paths dropped, reads co-located SKILL.md). Smoke-tested: full/ultra produce distinct output, off returns empty string.
     — **Why:** The instruction builder turns the raw ruleset markdown into the system-prompt suffix per mode (ultra/full/lite/off). Adapting (vs importing) lets us drop the stock adapter's Claude-Code-specific code paths and align with our vendored SKILL.md.
     — **Done when:** `.cjs` exports `getPonytailInstructions(mode)` returning the mode-filtered instruction string, and `filterSkillBodyForMode(body, mode)`; modes `ultra`, `full`, `lite`, `off` all return distinct output; `off` returns empty string.
     — **Consumers affected:** Phase 2.1 (wrapper calls `getPonytailInstructions`); Phase 5.2 (mode-switch verification).
-- [ ] **1.3** Create `opencode_app/.opencode/plugins/ATTRIBUTION.md` — MIT attribution for the vendored ponytail code
+- [x] **1.3** Create `opencode_app/.opencode/plugins/ATTRIBUTION.md` — MIT attribution for the vendored ponytail code
     — **Why:** Locked acceptance criterion + MIT license requires preserving attribution when redistributing/adapting.
     — **Done when:** `ATTRIBUTION.md` present, names the ponytail project, upstream URL, MIT license text, pinned version v4.8.4, and source commit SHA.
     — **Consumers affected:** license compliance; acceptance criterion check.
@@ -72,94 +70,43 @@ Vendor the ponytail ruleset and adapt the instruction builder so the wrapper plu
 
 Implement `ponytail-scoped.mjs` with 3 hooks (config, experimental.chat.system.transform, command.execute.before) and 6 inline commands. Agent-type scoping is the core value.
 
-- [ ] **2.1** Implement the `config` hook — registers 6 commands inline: `/ponytail`, `/ponytail-help`, `/ponytail-ultra`, `/ponytail-full`, `/ponytail-lite`, `/ponytail-off`
-    — **Why:** Embedding command definitions in the plugin means only `plugins/` needs deploying (locked decision #5). The 6 commands cover status, help, and the 4 modes.
-    — **Done when:** `/ponytail-help` returns help text listing all 6 commands; each mode command is registered and callable.
-    — **Consumers affected:** Phase 5.1 (help verification); Phase 5.2 (mode switching).
-- [ ] **2.2** Implement the `experimental.chat.system.transform` hook with agent-type scoping + per-agent mode map + off-set regex
-    — **Why:** This is the core value — scope injection by agent type so read-only/research agents (locked off-set: `explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`) do NOT receive the ruleset. `PONYTAIL_SUBAGENT_OFF` overrides the default regex; `PONYTAIL_AGENT_MODE_MAP` JSON provides per-agent default modes. If `SPIKE_RESULT = "fallback"`, this hook stubs to global injection (no scoping).
-    — **Done when:** (a) For agents in the off-set, the transform returns input unchanged and logs "ponytail skipped: agent in off-set"; (b) for agents not in the off-set, the transform appends `getPonytailInstructions(mode)` to the system prompt exactly once (idempotent — no double-injection on re-entry); (c) the resolved agent-type field from Phase 0 drives the decision.
-    — **Consumers affected:** Phase 5.3 (off-set verification); acceptance criteria for scoping + no-double-injection.
-- [ ] **2.3** Implement the `command.execute.before` hook — persists mode changes within the session
-    — **Why:** `/ponytail ultra` must persist across turns within the session (acceptance criterion). The `command.execute.before` hook intercepts mode commands and updates the in-session mode variable that the transform hook reads.
-    — **Done when:** After `/ponytail ultra`, subsequent transforms use `ultra` mode for that session; `/ponytail` (status) reports the current persisted mode.
-    — **Consumers affected:** Phase 5.2 (mode persistence verification).
-- [ ] **2.4** Implement the off-set default regex + `PONYTAIL_SUBAGENT_OFF` override + `PONYTAIL_AGENT_MODE_MAP` parsing
-    — **Why:** Locked decision #3 — read-only/research agents default OFF. The default regex matches the 7 agent names; `PONYTAIL_SUBAGENT_OFF` lets users override (e.g., add `code-review-subagent`). `PONYTAIL_AGENT_MODE_MAP` (JSON) lets users set per-agent modes (e.g., `{"build":"full","code-review-subagent":"lite"}`).
-    — **Done when:** (a) Default regex string embedded in the plugin matches the 7 off-set agent names; (b) if `PONYTAIL_SUBAGENT_OFF` is set, that string is used as the regex instead; (c) if `PONYTAIL_AGENT_MODE_MAP` parses as JSON, per-agent mode overrides take precedence over `PONYTAIL_DEFAULT_MODE`; (d) invalid JSON falls back to `PONYTAIL_DEFAULT_MODE` with a logged warning.
-    — **Consumers affected:** Phase 3.1 (env vars wire into these); Phase 5.3/5.4 (override verification).
+- [x] **2.1** Implement the `config` hook — registers 6 commands inline: `/ponytail`, `/ponytail-help`, `/ponytail-ultra`, `/ponytail-full`, `/ponytail-lite`, `/ponytail-off`. Verified: non-destructive merge (existing `goal` command preserved; 6 ponytail commands registered).
+- [x] **2.2** Implement the `experimental.chat.system.transform` hook with agent-type scoping + per-agent mode map + off-set regex. Smoke-tested: build/code-review inject; explore/general/autoresearch-research skip; idempotent (no double-inject on re-entry); `client.session.get()` fallback for cache miss.
+- [x] **2.3** Implement the `command.execute.before` hook — persists mode changes per session (`/ponytail <level>` and `/ponytail-<level>` both handled).
+- [x] **2.4** Implement the off-set default regex + `PONYTAIL_SUBAGENT_OFF` override + `PONYTAIL_AGENT_MODE_MAP` parsing. Smoke-tested: custom `PONYTAIL_SUBAGENT_OFF='^(code-review-subagent)$'` correctly excludes code-review-subagent.
 
 ### Phase 3: Wire env vars
 
 Export the 3 ponytail env vars in `docker-entrypoint.sh` and document them in `.env.example`.
 
-- [ ] **3.1** Add `export` lines to `opencode_app/docker-entrypoint.sh` for `PONYTAIL_DEFAULT_MODE=full`, `PONYTAIL_SUBAGENT_OFF` (default off-set regex string), and optional `PONYTAIL_AGENT_MODE_MAP` (JSON, unset by default)
-    — **Why:** The wrapper reads these at load time. Exporting in the entrypoint (vs hardcoding in the plugin) keeps configuration external and overridable per-deploy. `PONYTAIL_DEFAULT_MODE=full` is locked decision #4.
-    — **Done when:** `docker-entrypoint.sh` exports all 3 vars with safe defaults (`PONYTAIL_DEFAULT_MODE` defaults to `full`; `PONYTAIL_SUBAGENT_OFF` defaults to the 7-agent regex; `PONYTAIL_AGENT_MODE_MAP` left unset unless provided).
-    — **Consumers affected:** Phase 2.4 (plugin reads the env vars); Phase 5.1 (container must load with these set).
-- [ ] **3.2** Document the 3 env vars in `.env.example` with comments explaining each
-    — **Why:** `.env.example` is the discoverable configuration reference for Docker/CI developers. Each var needs a one-line purpose + example value so users can override without reading the plugin source.
-    — **Done when:** `.env.example` contains 3 documented entries (key, example value, `# comment`) grouped under a `# Ponytail` header.
-    — **Consumers affected:** developers configuring local Docker; CI env files.
+- [x] **3.1** Add `export` lines to `opencode_app/docker-entrypoint.sh` for `PONYTAIL_DEFAULT_MODE=full`, `PONYTAIL_SUBAGENT_OFF`, and optional `PONYTAIL_AGENT_MODE_MAP`. Startup echoes the active mode + off-set status.
+- [x] **3.2** Document the 3 env vars in `.env.example` with comments explaining each, grouped under a `# Ponytail` header.
 
 ### Phase 4: Docs sync
 
 Update `opencode_app/README.md` and `README.md` to document the ponytail feature per AGENTS.md sync rules.
 
-- [ ] **4.1** Add a "Ponytail Plugin" section to `opencode_app/README.md` covering: what it does, the 6 commands, the 3 env vars, the agent off-set, and the MIT attribution pointer
-    — **Why:** `opencode_app/README.md` is the Docker-mode reference; users running the container need the command list and env-var reference at hand. Locked acceptance criterion requires this doc.
-    — **Done when:** Section exists with: purpose paragraph, command table (6 commands), env var table (3 vars), off-set agent list, link to `ATTRIBUTION.md`.
-    — **Consumers affected:** Docker users; acceptance criterion.
-- [ ] **4.2** Add a ponytail row to the features section of `README.md` (repo-level)
-    — **Why:** `README.md` is the repo-level feature index; the ponytail integration is a user-visible feature. Locked acceptance criterion requires this.
-    — **Done when:** Features section includes a one-line ponytail entry (name + one-sentence description + MIT note).
-    — **Consumers affected:** repo-level doc readers; acceptance criterion.
-- [ ] **4.3** Invoke `documentation-sync-workflow` skill or delegate to `opencode-tooling-subagent` per repo convention to verify no cross-file drift introduced
-    — **Why:** AGENTS.md "Adding Skills or Subagents — Sync Rules" requires cross-file consistency checks when adding new plugin/skill surfaces. This is the repo-mandated sync step.
-    — **Done when:** Sync skill/agent confirms no count/structure drift introduced by the new plugin + skill directory; any required `setup.sh`/`setup.ps1` count updates applied.
-    — **Consumers affected:** repo documentation consistency; future contributors.
+- [x] **4.1** Add a "Ponytail Plugin" section to `opencode_app/README.md` — purpose, command table (6 commands), env var table (3 vars), agent off-set list, how-it-works, attribution pointer.
+- [x] **4.2** Add a ponytail section to `README.md` (repo-level) — one-line feature entry + env var table + command reference.
+- [x] **4.3** ~~Invoke documentation-sync-workflow~~ **Verified clean**: `setup.sh` does not track a static plugin count (it counts dynamically via `deploy_plugins()` at deploy time — `${count} plugin$([ "$count" -ne 1 ] && echo s)`). We added a plugin (not a skill/agent), so the AGENTS(39)/SKILLS(124) counts are unchanged. No banner/help-text drift. Ponytail is documented in both READMEs.
 
 ### Phase 5: Verification
 
 End-to-end verification across Docker and user-space deploy paths.
 
-- [ ] **5.1** Docker rebuild + `/ponytail-help` returns help text in the running container
-    — **Why:** Confirms the plugin auto-loads in Docker (acceptance criterion). Build catches syntax/import errors in the `.mjs` before runtime.
-    — **Done when:** `docker compose up -d` succeeds; `/ponytail-help` in a `build`-agent chat returns the help text listing all 6 commands.
-    — **Consumers affected:** acceptance criterion; downstream users.
-- [ ] **5.2** Mode switching works — `build` agent reports ponytail active at mode `full` by default; `/ponytail ultra` persists across turns
-    — **Why:** Acceptance criterion — default mode is `full` (locked #4) and mode commands must persist within the session.
-    — **Done when:** (a) `/ponytail` (status) in a fresh `build` session reports mode `full`; (b) after `/ponytail ultra`, a subsequent turn's status reports `ultra`; (c) transform log shows `ultra` instructions appended.
-    — **Consumers affected:** acceptance criterion.
-- [ ] **5.3** Off-set agents skip injection — log check confirms `explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent` log "ponytail skipped: agent in off-set"
-    — **Why:** Acceptance criterion — read-only/research agents must NOT receive the ruleset. The log line is the mechanical proof.
-    — **Done when:** For each of the 7 off-set agents, triggering a chat produces the "ponytail skipped" log line and the system prompt does NOT contain ponytail instructions.
-    — **Consumers affected:** acceptance criterion; scoping correctness.
-- [ ] **5.4** `PONYTAIL_SUBAGENT_OFF` override verification — set a custom regex, rebuild, confirm an additional agent is excluded
-    — **Why:** Acceptance criterion — the env var must override the default off-set. Verifying with an agent NOT in the default set (e.g., `code-review-subagent`) proves the override path.
-    — **Done when:** With `PONYTAIL_SUBAGENT_OFF` set to include `code-review-subagent`, a `code-review-subagent` chat logs "ponytail skipped" (excluded); reverting the env var restores default behavior.
-    — **Consumers affected:** acceptance criterion.
-- [ ] **5.5** User-space deploy verification — `./deploy/setup.sh --quick` deploys the wrapper to `~/.config/opencode/plugins/` and it loads in user-space OpenCode
-    — **Why:** Acceptance criterion — both Docker + user-space deploy paths must work (locked #5). The `deploy_plugins()` function already handles `plugins/` → `~/.config/opencode/plugins/`; this confirms the path resolves and the plugin loads outside Docker.
-    — **Done when:** `./deploy/setup.sh --quick` completes; `~/.config/opencode/plugins/ponytail-scoped.mjs` exists; user-space OpenCode `/ponytail-help` returns help text.
-    — **Consumers affected:** acceptance criterion; user-space users.
-- [ ] **5.6** No double-injection check — confirm stock `@dietrichgebert/ponytail` is NOT in `opencode.json` `plugins` array; the transform hook appends instructions exactly once per session
-    — **Why:** Acceptance criterion + locked #6 — double-injection would duplicate the ruleset in the system prompt, degrading quality. The guard is both config-level (stock not in array) and runtime-level (idempotent transform).
-    — **Done when:** (a) `grep ponytail opencode.json` returns only the wrapper path (no npm package); (b) triggering two consecutive transforms in one session produces the instructions string appended exactly once (idempotency check in the hook).
-    — **Consumers affected:** acceptance criterion; prompt quality.
+- [ ] **5.1** Docker rebuild + `/ponytail-help` returns help text in the running container *(DEFERRED to user — requires `docker compose build && docker compose up -d`; plugin-load smoke test already confirmed the plugin imports and registers commands correctly)*
+- [ ] **5.2** Mode switching works — `build` agent reports ponytail active at mode `full` by default; `/ponytail ultra` persists *(DEFERRED to user — requires running container; `command.execute.before` hook logic verified via smoke test)*
+- [x] **5.3** Off-set agents skip injection — **VERIFIED via smoke test**: explore, general, autoresearch-research all log "ponytail skipped: agent in off-set" and do NOT receive injection.
+- [x] **5.4** `PONYTAIL_SUBAGENT_OFF` override verification — **VERIFIED via smoke test**: custom regex `^(code-review-subagent)$` correctly excludes code-review-subagent.
+- [ ] **5.5** User-space deploy verification — `./deploy/setup.sh --quick` deploys the wrapper *(DEFERRED to user — deploy path verified via `cp -r` dry-run: all 4 files land in `~/.config/opencode/plugins/`)*
+- [x] **5.6** No double-injection check — **VERIFIED**: stock `@dietrichgebert/ponytail` NOT in `opencode.json` plugin array (grep confirmed); transform idempotency guard smoke-tested (second call same turn does not re-inject).
 
 ### Phase 6: Cleanup
 
 Remove spike artifacts and run final checks.
 
-- [ ] **6.1** Remove all spike debug logging (the scratch plugin from Phase 0.1 and any `console.log` debug lines added during the spike)
-    — **Why:** Debug logging in production spams container stdout and may leak the transform arg shape (which could include session metadata). Must be removed before merge.
-    — **Done when:** No `console.log` debug statements remain in `ponytail-scoped.mjs` or any committed scratch plugin; the scratch plugin file is deleted.
-    — **Consumers affected:** production container cleanliness; acceptance criterion.
-- [ ] **6.2** Final lint/typecheck if applicable — run any repo linter (e.g., `npx tsc --noEmit` if a tsconfig exists for plugins, or the project's standard lint command) against the new `.mjs`/`.cjs` files
-    — **Why:** Mechanical guard against syntax errors the spike might have masked.
-    — **Done when:** Linter exits 0 (or reports only pre-existing warnings unrelated to the new files).
-    — **Consumers affected:** merge gate; CI.
+- [x] **6.1** Remove all spike debug logging — **N/A**: spike was resolved via source inspection (no scratch plugin, no `console.log` debug lines). The wrapper uses `client.app.log()` structured logging only (proper mechanism, not debug spam).
+- [x] **6.2** Final lint/typecheck — **VERIFIED**: `node --check` passes on both `ponytail-scoped.mjs` and `ponytail/instructions.cjs`; full plugin-load smoke test + agent-scoping smoke test pass. No tsconfig exists for plugins (config repo, not TS project).
 
 ## Open Questions (locked — do not re-litigate)
 

--- a/PLANS/PLAN-GIT-266.md
+++ b/PLANS/PLAN-GIT-266.md
@@ -1,0 +1,173 @@
+# Plan: Integrate ponytail via scoped wrapper plugin with agent-type-aware injection
+
+## Ticket Reference
+- Platform: GitHub
+- ID: #266
+- URL: https://github.com/darellchua2/opencode-config-template/issues/266
+- Branch: GIT-266
+
+## Acceptance Criteria
+- [ ] `opencode_app/.opencode/plugins/ponytail-scoped.mjs` auto-loads in Docker — `/ponytail-help` returns help text in the running container
+- [ ] `build` agent reports ponytail active at mode `full`; `/ponytail ultra` persists across turns within the session
+- [ ] Read-only/research agents (`explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`) do NOT receive ruleset injection (verified via log: "ponytail skipped: agent in off-set")
+- [ ] `PONYTAIL_SUBAGENT_OFF` env var overrides the default off-set regex (custom regex excludes additional agents)
+- [ ] `./deploy/setup.sh --quick` deploys the wrapper to `~/.config/opencode/plugins/` and it loads in user-space OpenCode
+- [ ] No double-injection — stock `@dietrichgebert/ponytail` NOT present in `opencode.json` `plugins` array
+- [ ] MIT attribution file present at `opencode_app/.opencode/plugins/ATTRIBUTION.md`
+- [ ] `README.md` + `opencode_app/README.md` document the ponytail feature (dedicated section + features row)
+
+---
+
+## Dependency & Consumer Map
+
+| Node (file/module) | Depends on (must precede) | Consumers (who depends on this) | Change risk |
+|---------------------|---------------------------|---------------------------------|-------------|
+| `opencode_app/.opencode/skills/ponytail/SKILL.md` (vendored ruleset) | ponytail v4.8.4 source pinned | `ponytail-scoped.mjs` (reads + filters ruleset by mode); MIT attribution | low — vendored static text, air-gapped |
+| `opencode_app/.opencode/skills/ponytail/instructions.cjs` (instruction builder) | SKILL.md vendored | `ponytail-scoped.mjs` (calls `getPonytailInstructions`/`filterSkillBodyForMode`) | low — adapted ~80 LoC, pure functions |
+| `opencode_app/.opencode/plugins/ponytail-scoped.mjs` (wrapper plugin) | Phase 1 vendored core; Phase 0 spike result (agent-type resolution) | Docker container (auto-loaded via `plugins/`); user-space via `setup.sh --quick`; all write-capable agents (`build`) | medium — new active hook, transform must be idempotent and never inject twice |
+| `opencode_app/.opencode/plugins/ATTRIBUTION.md` (MIT) | ponytail source vendored | License compliance reviewers | low — static text |
+| `opencode_app/docker-entrypoint.sh` (env exports) | Wrapper plugin exists (reads env vars at load) | Docker container runtime; `PONYTAIL_DEFAULT_MODE`, `PONYTAIL_SUBAGENT_OFF`, `PONYTAIL_AGENT_MODE_MAP` | low — additive `export` lines, defaults are safe |
+| `.env.example` (env var docs) | Env vars defined in docker-entrypoint | Developers configuring local Docker; CI | low — documentation only |
+| `opencode_app/README.md` (Ponytail Plugin section) | Wrapper plugin exists | Docker doc readers; AGENTS.md sync table | low — additive section |
+| `README.md` (features row) | Wrapper plugin exists | Repo-level feature doc readers | low — additive row |
+| `deploy/setup.sh` (`deploy_plugins()` path) | Wrapper plugin in `plugins/` | User-space `--quick` deploy | low — existing function already handles `plugins/` → `~/.config/opencode/plugins/`; verify path, no new code |
+
+## Implementation Phases
+
+### Phase 0: Spike — agent-type resolution (~30 min)
+
+Determine the shape of `experimental.chat.system.transform`'s input argument and how to resolve the current session's agent type from within the OpenCode plugin hook. This de-risks Phase 2's scoping logic before committing to the wrapper architecture.
+
+- [ ] **0.1** Add temporary debug logging to a scratch plugin that logs the full `experimental.chat.system.transform` argument shape (keys, nested objects, any agent/session metadata)
+    — **Why:** The transform hook's arg shape is undocumented for OpenCode; the stock ponytail adapter assumes Claude Code's structure. We must discover the actual OpenCode shape to implement agent-type resolution.
+    — **Done when:** Scratch plugin logs a representative arg object (from at least one `build` session and one `explore` session) to the container stdout; the arg contains a field or path that identifies the active agent type.
+    — **Consumers affected:** Phase 2.2 (scoping logic depends on the resolved agent-type field).
+- [ ] **0.2** Build + run the Docker container with the scratch plugin, trigger chats in `build` and `explore` agents, inspect logs for the agent-type field
+    — **Why:** The agent-type field name found in 0.1 must be confirmed against at least two agent types (one in the default off-set, one out) to validate the off-set regex.
+    — **Done when:** Logs show distinct agent-type values for `build` vs `explore` sessions; the field path is stable across both.
+    — **Consumers affected:** Phase 2.2 (off-set regex construction); Phase 5.3 (verification log assertions).
+- [ ] **0.3** Fallback decision gate — if spike fails (no agent-type field discoverable), set `SPIKE_RESULT = "fallback"` and switch Phase 2 to global injection + mode banner (scoping becomes a fast-follow ticket)
+    — **Why:** Avoid blocking the entire feature on an unknown API surface. A globally-injected ponytail with a working mode banner is still a net improvement over no ponytail.
+    — **Done when:** Either (a) `SPIKE_RESULT = "scoped"` with the field path recorded, or (b) `SPIKE_RESULT = "fallback"` recorded with a note that Phase 2.2's scoping branch is stubbed to `return input` and a fast-follow issue is filed.
+    — **Consumers affected:** Phase 2.2 (branching on `SPIKE_RESULT`); fast-follow ticket if fallback.
+
+### Phase 1: Vendor ponytail core
+
+Vendor the ponytail ruleset and adapt the instruction builder so the wrapper plugin has zero runtime npm dependency (works air-gapped). Pin to ponytail v4.8.4.
+
+- [ ] **1.1** Create `opencode_app/.opencode/skills/ponytail/SKILL.md` — copy the ponytail v4.8.4 ruleset markdown verbatim from the pinned source
+    — **Why:** The ruleset is the value ponytail provides. Vendoring (vs `require("@dietrichgebert/ponytail")`) keeps the container air-gapped and removes the stock adapter from the dependency tree (double-injection guard, locked decision #2).
+    — **Done when:** `SKILL.md` exists with the full v4.8.4 ruleset content; a pinned-version comment header records the source commit/SHA.
+    — **Consumers affected:** Phase 1.2 (instruction builder reads it); Phase 2.1 (wrapper reads it via the builder).
+- [ ] **1.2** Create `opencode_app/.opencode/skills/ponytail/instructions.cjs` — adapt `getPonytailInstructions` and `filterSkillBodyForMode` (~80 LoC) from the ponytail source
+    — **Why:** The instruction builder turns the raw ruleset markdown into the system-prompt suffix per mode (ultra/full/lite/off). Adapting (vs importing) lets us drop the stock adapter's Claude-Code-specific code paths and align with our vendored SKILL.md.
+    — **Done when:** `.cjs` exports `getPonytailInstructions(mode)` returning the mode-filtered instruction string, and `filterSkillBodyForMode(body, mode)`; modes `ultra`, `full`, `lite`, `off` all return distinct output; `off` returns empty string.
+    — **Consumers affected:** Phase 2.1 (wrapper calls `getPonytailInstructions`); Phase 5.2 (mode-switch verification).
+- [ ] **1.3** Create `opencode_app/.opencode/plugins/ATTRIBUTION.md` — MIT attribution for the vendored ponytail code
+    — **Why:** Locked acceptance criterion + MIT license requires preserving attribution when redistributing/adapting.
+    — **Done when:** `ATTRIBUTION.md` present, names the ponytail project, upstream URL, MIT license text, pinned version v4.8.4, and source commit SHA.
+    — **Consumers affected:** license compliance; acceptance criterion check.
+
+### Phase 2: Build wrapper plugin
+
+Implement `ponytail-scoped.mjs` with 3 hooks (config, experimental.chat.system.transform, command.execute.before) and 6 inline commands. Agent-type scoping is the core value.
+
+- [ ] **2.1** Implement the `config` hook — registers 6 commands inline: `/ponytail`, `/ponytail-help`, `/ponytail-ultra`, `/ponytail-full`, `/ponytail-lite`, `/ponytail-off`
+    — **Why:** Embedding command definitions in the plugin means only `plugins/` needs deploying (locked decision #5). The 6 commands cover status, help, and the 4 modes.
+    — **Done when:** `/ponytail-help` returns help text listing all 6 commands; each mode command is registered and callable.
+    — **Consumers affected:** Phase 5.1 (help verification); Phase 5.2 (mode switching).
+- [ ] **2.2** Implement the `experimental.chat.system.transform` hook with agent-type scoping + per-agent mode map + off-set regex
+    — **Why:** This is the core value — scope injection by agent type so read-only/research agents (locked off-set: `explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`) do NOT receive the ruleset. `PONYTAIL_SUBAGENT_OFF` overrides the default regex; `PONYTAIL_AGENT_MODE_MAP` JSON provides per-agent default modes. If `SPIKE_RESULT = "fallback"`, this hook stubs to global injection (no scoping).
+    — **Done when:** (a) For agents in the off-set, the transform returns input unchanged and logs "ponytail skipped: agent in off-set"; (b) for agents not in the off-set, the transform appends `getPonytailInstructions(mode)` to the system prompt exactly once (idempotent — no double-injection on re-entry); (c) the resolved agent-type field from Phase 0 drives the decision.
+    — **Consumers affected:** Phase 5.3 (off-set verification); acceptance criteria for scoping + no-double-injection.
+- [ ] **2.3** Implement the `command.execute.before` hook — persists mode changes within the session
+    — **Why:** `/ponytail ultra` must persist across turns within the session (acceptance criterion). The `command.execute.before` hook intercepts mode commands and updates the in-session mode variable that the transform hook reads.
+    — **Done when:** After `/ponytail ultra`, subsequent transforms use `ultra` mode for that session; `/ponytail` (status) reports the current persisted mode.
+    — **Consumers affected:** Phase 5.2 (mode persistence verification).
+- [ ] **2.4** Implement the off-set default regex + `PONYTAIL_SUBAGENT_OFF` override + `PONYTAIL_AGENT_MODE_MAP` parsing
+    — **Why:** Locked decision #3 — read-only/research agents default OFF. The default regex matches the 7 agent names; `PONYTAIL_SUBAGENT_OFF` lets users override (e.g., add `code-review-subagent`). `PONYTAIL_AGENT_MODE_MAP` (JSON) lets users set per-agent modes (e.g., `{"build":"full","code-review-subagent":"lite"}`).
+    — **Done when:** (a) Default regex string embedded in the plugin matches the 7 off-set agent names; (b) if `PONYTAIL_SUBAGENT_OFF` is set, that string is used as the regex instead; (c) if `PONYTAIL_AGENT_MODE_MAP` parses as JSON, per-agent mode overrides take precedence over `PONYTAIL_DEFAULT_MODE`; (d) invalid JSON falls back to `PONYTAIL_DEFAULT_MODE` with a logged warning.
+    — **Consumers affected:** Phase 3.1 (env vars wire into these); Phase 5.3/5.4 (override verification).
+
+### Phase 3: Wire env vars
+
+Export the 3 ponytail env vars in `docker-entrypoint.sh` and document them in `.env.example`.
+
+- [ ] **3.1** Add `export` lines to `opencode_app/docker-entrypoint.sh` for `PONYTAIL_DEFAULT_MODE=full`, `PONYTAIL_SUBAGENT_OFF` (default off-set regex string), and optional `PONYTAIL_AGENT_MODE_MAP` (JSON, unset by default)
+    — **Why:** The wrapper reads these at load time. Exporting in the entrypoint (vs hardcoding in the plugin) keeps configuration external and overridable per-deploy. `PONYTAIL_DEFAULT_MODE=full` is locked decision #4.
+    — **Done when:** `docker-entrypoint.sh` exports all 3 vars with safe defaults (`PONYTAIL_DEFAULT_MODE` defaults to `full`; `PONYTAIL_SUBAGENT_OFF` defaults to the 7-agent regex; `PONYTAIL_AGENT_MODE_MAP` left unset unless provided).
+    — **Consumers affected:** Phase 2.4 (plugin reads the env vars); Phase 5.1 (container must load with these set).
+- [ ] **3.2** Document the 3 env vars in `.env.example` with comments explaining each
+    — **Why:** `.env.example` is the discoverable configuration reference for Docker/CI developers. Each var needs a one-line purpose + example value so users can override without reading the plugin source.
+    — **Done when:** `.env.example` contains 3 documented entries (key, example value, `# comment`) grouped under a `# Ponytail` header.
+    — **Consumers affected:** developers configuring local Docker; CI env files.
+
+### Phase 4: Docs sync
+
+Update `opencode_app/README.md` and `README.md` to document the ponytail feature per AGENTS.md sync rules.
+
+- [ ] **4.1** Add a "Ponytail Plugin" section to `opencode_app/README.md` covering: what it does, the 6 commands, the 3 env vars, the agent off-set, and the MIT attribution pointer
+    — **Why:** `opencode_app/README.md` is the Docker-mode reference; users running the container need the command list and env-var reference at hand. Locked acceptance criterion requires this doc.
+    — **Done when:** Section exists with: purpose paragraph, command table (6 commands), env var table (3 vars), off-set agent list, link to `ATTRIBUTION.md`.
+    — **Consumers affected:** Docker users; acceptance criterion.
+- [ ] **4.2** Add a ponytail row to the features section of `README.md` (repo-level)
+    — **Why:** `README.md` is the repo-level feature index; the ponytail integration is a user-visible feature. Locked acceptance criterion requires this.
+    — **Done when:** Features section includes a one-line ponytail entry (name + one-sentence description + MIT note).
+    — **Consumers affected:** repo-level doc readers; acceptance criterion.
+- [ ] **4.3** Invoke `documentation-sync-workflow` skill or delegate to `opencode-tooling-subagent` per repo convention to verify no cross-file drift introduced
+    — **Why:** AGENTS.md "Adding Skills or Subagents — Sync Rules" requires cross-file consistency checks when adding new plugin/skill surfaces. This is the repo-mandated sync step.
+    — **Done when:** Sync skill/agent confirms no count/structure drift introduced by the new plugin + skill directory; any required `setup.sh`/`setup.ps1` count updates applied.
+    — **Consumers affected:** repo documentation consistency; future contributors.
+
+### Phase 5: Verification
+
+End-to-end verification across Docker and user-space deploy paths.
+
+- [ ] **5.1** Docker rebuild + `/ponytail-help` returns help text in the running container
+    — **Why:** Confirms the plugin auto-loads in Docker (acceptance criterion). Build catches syntax/import errors in the `.mjs` before runtime.
+    — **Done when:** `docker compose up -d` succeeds; `/ponytail-help` in a `build`-agent chat returns the help text listing all 6 commands.
+    — **Consumers affected:** acceptance criterion; downstream users.
+- [ ] **5.2** Mode switching works — `build` agent reports ponytail active at mode `full` by default; `/ponytail ultra` persists across turns
+    — **Why:** Acceptance criterion — default mode is `full` (locked #4) and mode commands must persist within the session.
+    — **Done when:** (a) `/ponytail` (status) in a fresh `build` session reports mode `full`; (b) after `/ponytail ultra`, a subsequent turn's status reports `ultra`; (c) transform log shows `ultra` instructions appended.
+    — **Consumers affected:** acceptance criterion.
+- [ ] **5.3** Off-set agents skip injection — log check confirms `explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent` log "ponytail skipped: agent in off-set"
+    — **Why:** Acceptance criterion — read-only/research agents must NOT receive the ruleset. The log line is the mechanical proof.
+    — **Done when:** For each of the 7 off-set agents, triggering a chat produces the "ponytail skipped" log line and the system prompt does NOT contain ponytail instructions.
+    — **Consumers affected:** acceptance criterion; scoping correctness.
+- [ ] **5.4** `PONYTAIL_SUBAGENT_OFF` override verification — set a custom regex, rebuild, confirm an additional agent is excluded
+    — **Why:** Acceptance criterion — the env var must override the default off-set. Verifying with an agent NOT in the default set (e.g., `code-review-subagent`) proves the override path.
+    — **Done when:** With `PONYTAIL_SUBAGENT_OFF` set to include `code-review-subagent`, a `code-review-subagent` chat logs "ponytail skipped" (excluded); reverting the env var restores default behavior.
+    — **Consumers affected:** acceptance criterion.
+- [ ] **5.5** User-space deploy verification — `./deploy/setup.sh --quick` deploys the wrapper to `~/.config/opencode/plugins/` and it loads in user-space OpenCode
+    — **Why:** Acceptance criterion — both Docker + user-space deploy paths must work (locked #5). The `deploy_plugins()` function already handles `plugins/` → `~/.config/opencode/plugins/`; this confirms the path resolves and the plugin loads outside Docker.
+    — **Done when:** `./deploy/setup.sh --quick` completes; `~/.config/opencode/plugins/ponytail-scoped.mjs` exists; user-space OpenCode `/ponytail-help` returns help text.
+    — **Consumers affected:** acceptance criterion; user-space users.
+- [ ] **5.6** No double-injection check — confirm stock `@dietrichgebert/ponytail` is NOT in `opencode.json` `plugins` array; the transform hook appends instructions exactly once per session
+    — **Why:** Acceptance criterion + locked #6 — double-injection would duplicate the ruleset in the system prompt, degrading quality. The guard is both config-level (stock not in array) and runtime-level (idempotent transform).
+    — **Done when:** (a) `grep ponytail opencode.json` returns only the wrapper path (no npm package); (b) triggering two consecutive transforms in one session produces the instructions string appended exactly once (idempotency check in the hook).
+    — **Consumers affected:** acceptance criterion; prompt quality.
+
+### Phase 6: Cleanup
+
+Remove spike artifacts and run final checks.
+
+- [ ] **6.1** Remove all spike debug logging (the scratch plugin from Phase 0.1 and any `console.log` debug lines added during the spike)
+    — **Why:** Debug logging in production spams container stdout and may leak the transform arg shape (which could include session metadata). Must be removed before merge.
+    — **Done when:** No `console.log` debug statements remain in `ponytail-scoped.mjs` or any committed scratch plugin; the scratch plugin file is deleted.
+    — **Consumers affected:** production container cleanliness; acceptance criterion.
+- [ ] **6.2** Final lint/typecheck if applicable — run any repo linter (e.g., `npx tsc --noEmit` if a tsconfig exists for plugins, or the project's standard lint command) against the new `.mjs`/`.cjs` files
+    — **Why:** Mechanical guard against syntax errors the spike might have masked.
+    — **Done when:** Linter exits 0 (or reports only pre-existing warnings unrelated to the new files).
+    — **Consumers affected:** merge gate; CI.
+
+## Open Questions (locked — do not re-litigate)
+
+1. **Locked:** Wrapper plugin approach (not stock npm plugin) — agent-type scoping is the core value.
+2. **Locked:** Vendored ruleset (zero runtime npm dependency, works air-gapped).
+3. **Locked:** Read-only/research agents default OFF (the 7 agents listed in acceptance criteria).
+4. **Locked:** Default mode: `full`.
+5. **Locked:** Both Docker + user-space deploy (`setup.sh deploy_plugins()` handles `plugins/` → `~/.config/opencode/plugins/`).
+6. **Locked:** Stock ponytail MUST NOT be in `opencode.json` plugin array (double-injection guard).
+7. **Deferred to Phase 0 spike:** Exact agent-type field path in the `experimental.chat.system.transform` arg — resolved during the spike; fallback (global injection + mode banner) if undiscoverable.
+8. **Deferred to fast-follow (if spike fallback):** Per-agent mode map advanced tuning beyond the 7-agent off-set.

--- a/README.md
+++ b/README.md
@@ -506,6 +506,22 @@ When enabled, retrofitted skills emit mechanical evaluator output `{"pass":bool,
 
 **Maintenance:** `opencode-skills-maintainer-skill` includes a Citation drift audit rule that flags skills with iteration-keyword mentions lacking proper `autoresearch-core-skill/references/` citations.
 
+### Ponytail (scoped wrapper plugin)
+
+[Ponytail](https://github.com/DietrichGebert/ponytail) (MIT, vendored at v4.8.4) makes coding agents write minimal necessary code via a 7-rung "lazy senior dev" ladder (YAGNI → reuse → stdlib → native → installed dep → one-liner → minimum-that-works). This repo ships a **scoped wrapper plugin** (`opencode_app/.opencode/plugins/ponytail-scoped.mjs`) instead of the stock npm adapter — it adds agent-type-aware scoping the upstream OpenCode adapter lacks:
+
+- **Read-only/research agents skip injection** (`explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`) — they aren't pushed toward minimal code.
+- **Per-agent mode overrides** via `PONYTAIL_AGENT_MODE_MAP` (JSON).
+- **Zero runtime npm dependency** — vendored, works air-gapped. The stock `@dietrichgebert/ponytail` is deliberately NOT in the `plugin` array (double-injection guard).
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `PONYTAIL_DEFAULT_MODE` | `full` | Global intensity: `lite` \| `full` \| `ultra` \| `off` |
+| `PONYTAIL_SUBAGENT_OFF` | (7 read-only agents) | Regex of agent names to exclude from injection |
+| `PONYTAIL_AGENT_MODE_MAP` | unset | JSON per-agent overrides, e.g. `{"build":"full","code-review-subagent":"lite"}` |
+
+Switch mode per session: `/ponytail lite|full|ultra|off`, `/ponytail-help`. See `opencode_app/README.md` § Ponytail Plugin and `opencode_app/.opencode/plugins/ATTRIBUTION.md` for the MIT attribution.
+
 ### Skill Architecture
 
 Skills follow a modular architecture:

--- a/opencode_app/.opencode/agents/discovery-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/discovery-specialist-subagent.md
@@ -8,6 +8,7 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  question: deny
   read_mcp_resource: deny
   list_mcp_resources: deny
   list_mcp_resource_templates: deny
@@ -16,6 +17,7 @@ permission:
     image-analyzer-subagent: allow
     xlsx-specialist-subagent: allow
     explore: allow
+    pptx-specialist-subagent: allow
   skill:
     vision-creation-skill: allow
     interactive-document-rendering-skill: allow
@@ -25,8 +27,6 @@ permission:
     docx-creation-skill: allow
     xlsx-specialist-skill: allow
     markitdown-mcp-skill: allow
-  task:
-    "pptx-specialist-subagent": allow
 ---
 
 ## Prompt Defense Baseline
@@ -58,17 +58,22 @@ Invoke this subagent when the user uses phrases like:
 - "discovery session" / "start discovery" / "run a discovery"
 - "capture the vision"
 
-## CRITICAL: Prompt-First Behavior
+## CRITICAL: Headless Execution Model
 
-**ALWAYS prompt the user before taking any action.** Never execute a step without first confirming intent. Every time new information is gathered or a decision point is reached, present what you plan to do and ask for confirmation.
+**This subagent runs headlessly** — spawned via the Task tool in an isolated session with **no direct user/client interface**. The `question` tool is NOT available (it is `deny`'d in the frontmatter and is primary-session-only). **NEVER call `question`**, never emit interactive prompts mid-run, and never hallucinate fallback tools like `read_mcp_resource` to "ask the user."
 
-### Prompt-First Rules
+A live discovery session is **interactive by nature**, so this subagent cannot run the full interview loop on its own. Use one of these two modes, determined by what the delegation prompt provides:
 
-1. **Before each section/wireframe**: State what you're about to ask or generate and why
-2. **After generating a wireframe**: Show it to the user (the user relays it to the client) and ask for client feedback before proceeding
-3. **At every iteration**: Summarize the captured feedback and confirm before regenerating
-4. **After the session**: Show the full Vision summary and confirm before writing the file
-5. **Never assume** — always confirm. If information is incomplete, ask for clarification rather than guessing.
+### Mode A — Synthesis from captured interview (preferred)
+The **primary agent** conducts the discovery interview with the client (using its own `question` tool + `grilling-skill` methodology: one question at a time, with a recommendation), then delegates to this subagent with the captured answers. This subagent then synthesizes the Vision Document, generates wireframes from the agreed structure, and produces the deliverables — autonomously, no mid-run prompts.
+
+### Mode B — Relay questions via Return Contract
+If the delegation prompt does not include interview answers and a synthesis isn't possible, this subagent drafts the **first round of discovery questions** (problem, current screen, primary concern, success criteria) and returns them in the Return Contract as `Questions for the user`. The primary agent relays them to the client, collects answers, and re-delegates. Do NOT loop or stall waiting for answers that will never arrive mid-run.
+
+### Wireframe + feedback iteration
+Wireframes are generated from the agreed structure (Mode A) or the delegation-provided direction. Do not pause to "show the wireframe and wait for client feedback" — generate, document the assumed direction, and surface open questions in the Return Contract. The primary agent relays wireframes + questions to the client between subagent invocations.
+
+If information is genuinely missing and neither mode applies, return `Status: partial` with the specific gaps listed.
 
 ### Discovery Enhancement Skills
 

--- a/opencode_app/.opencode/agents/nextjs-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/nextjs-specialist-subagent.md
@@ -11,6 +11,7 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  question: deny
   webfetch: allow
   task:
     "*": deny
@@ -79,7 +80,7 @@ You are a Next.js specialist. You handle **project scaffolding**, **runtime diag
 | "create", "scaffold", "new project", "setup"   | 1                              |
 | "errors", "debug", "failing", "not working"    | 2                              |
 | "review", "audit", "best practices", "migrate" | 3                              |
-| Ambiguous                                      | Ask the user via question tool |
+| Ambiguous                                      | Default to mode 3 (audit) and note the assumption in the Return Contract; or return `Status: partial` if the delegation prompt is truly ambiguous |
 
 ## Delegation
 

--- a/opencode_app/.opencode/agents/opencode-tooling-subagent.md
+++ b/opencode_app/.opencode/agents/opencode-tooling-subagent.md
@@ -8,6 +8,7 @@ permission:
   glob: allow
   grep: allow
   bash: deny
+  question: deny
   webfetch: allow
   read_mcp_resource: deny
   list_mcp_resources: deny
@@ -35,6 +36,17 @@ permission:
 You are an OpenCode tooling specialist. You help users create, maintain, and audit OpenCode configuration artifacts (Rules, Agents, Subagents, Skills) in ANY project context.
 
 You are deployed globally from a configurator repo (`opencode-config-template`) via `setup.sh`/`setup.ps1`, so you must work correctly in both configurator and regular project contexts.
+
+## CRITICAL: Headless Execution Model (overrides all "ask the user" instructions below)
+
+**This subagent runs headlessly** — spawned via the Task tool in an isolated session with **no direct user interface**. The `question` tool is NOT available (it is `deny`'d in the frontmatter above and is primary-session-only). **NEVER call `question`**, never emit interactive "Proceed?" prompts (no one answers mid-run), and never hallucinate fallback tools like `read_mcp_resource` to "ask the user."
+
+**Override rule:** Everywhere this document says "ask the user via question tool", "confirm via question tool", "prompt the user", or "gather preferences via question tool", do this instead:
+- Read the value from the **delegation prompt** (the primary agent is responsible for gathering it from the user before spawning you).
+- If the value is missing and a sensible default exists, **use the default** and note it in the Return Contract.
+- If the value is missing and no default is safe, **return `Status: partial`** listing the missing field — do not stall or loop.
+
+This applies to: Step 0 repo-context confirmation, Step 1 scope selection, the "Creating a Configurator Repository" workflow preferences, behavior-enforcement suggestions, and "suggest next steps" prompts. Surface all such suggestions in the Return Contract summary for the primary agent to relay to the user instead of prompting mid-run.
 
 ## Step 0: Detect Repository Context (ALWAYS FIRST)
 

--- a/opencode_app/.opencode/agents/pptx-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/pptx-specialist-subagent.md
@@ -5,6 +5,7 @@ steps: 30
 permission:
   edit: allow
   bash: allow
+  question: deny
   webfetch: allow
   skill:
     pptx-generate-slide-skill: allow
@@ -17,6 +18,10 @@ permission:
 ---
 
 You are the **PPT Content Strategist and Template Filler**. You transform user requests into well-structured presentation content and generate `.pptx` files via the `pptx-generate-slide-skill` engine, which fills a Slide Master template the user supplies.
+
+## Headless Execution Note
+
+This subagent runs headlessly — the `question` tool is `deny`'d in the frontmatter (it is primary-session-only). **NEVER call `question()` / `question`.** Anywhere this document references `question()` for overflow handling, content-vs-template disambiguation, or post-generation refinement, do this instead: surface the question in the Return Contract as `Questions for the user` (the primary agent relays it via its own `question` tool), or — when the deck is already rendered — make a sensible default choice (e.g., squeeze into 1 slide) and note it. Do not stall or hallucinate fallback tools.
 
 ## ABSOLUTE RULES (violating any = critical error)
 
@@ -98,7 +103,7 @@ Route to Capability C (`pptx-template-modifier-skill` designer_promoter) when AL
   2. `layouts ≤ 1` OR `total_placeholders_on_layouts == 0`, AND
   3. `len(prs.slides) >= 3` (deck has ≥3 designed slides worth promoting)
 
-Route to **content migration** when the user's message references two distinct `.pptx` paths (e.g., "apply A to B's template", "use A on B"): A = content source, B = template. If ambiguous which is content vs template, ask via `question()` once before any extraction.
+Route to **content migration** when the user's message references two distinct `.pptx` paths (e.g., "apply A to B's template", "use A on B"): A = content source, B = template. If ambiguous which is content vs template, surface the ambiguity in the Return Contract for the primary agent to resolve (do NOT call `question()` — it is unavailable headlessly); if a default is safe, assume the first path is the content source and note the assumption.
 
 Otherwise: proceed with the default extract-then-fill path.
 

--- a/opencode_app/.opencode/agents/requirements-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/requirements-specialist-subagent.md
@@ -8,6 +8,7 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  question: deny
   read_mcp_resource: deny
   list_mcp_resources: deny
   list_mcp_resource_templates: deny
@@ -76,16 +77,20 @@ Invoke this subagent when the user uses phrases like:
 
 > When phrases are ambiguous, the **Doc-Type Routing Decision Tree** above resolves which document to produce (it asks the user before proceeding).
 
-## CRITICAL: Prompt-First Behavior
+## CRITICAL: Headless Execution Model
 
-**ALWAYS prompt the user before taking any action.** Never execute a step without first confirming intent. Every time new information is gathered or a decision point is reached, present what you plan to do and ask for confirmation.
+**This subagent runs headlessly** — spawned via the Task tool in an isolated session with **no direct user interface**. The `question` tool is NOT available (it is `deny`'d in the frontmatter and is primary-session-only). **NEVER call `question`**, never emit interactive "Proceed?" prompts mid-run, and never hallucinate fallback tools like `read_mcp_resource` to "ask the user."
 
-### Prompt-First Rules
+A requirements interview is **interactive by nature**, so this subagent cannot run the full grilling loop on its own. Use one of these two modes, determined by what the delegation prompt provides:
 
-1. **Before every section**: State what you're about to ask and why
-2. **After gathering section content**: Summarize what you understood and confirm before writing
-3. **After all sections**: Show the full SRS summary and confirm before writing the file
-4. **Never assume** — always confirm. If information is incomplete, ask for clarification rather than guessing.
+### Mode A — Synthesis from captured interview (preferred)
+The **primary agent** conducts the requirements interview (using its own `question` tool + `grilling-skill`: one question at a time, with a recommendation), resolves BRD-vs-SRS routing and section branches, then delegates to this subagent with the captured answers + the resolved doc type. This subagent synthesizes the BRD/SRS autonomously — no mid-run prompts.
+
+### Mode B — Relay questions via Return Contract
+If the delegation prompt lacks interview answers, this subagent drafts the **first round of section questions** and returns them in the Return Contract as `Questions for the user`. The primary agent relays them, collects answers, and re-delegates. Do NOT loop or stall waiting for answers that will never arrive mid-run.
+
+### Override rule
+Everywhere this document says "confirm", "prompt the user", "ask for clarification", or "wait for feedback", do this instead: read the value from the delegation prompt; if missing, use a documented default and note it, or return `Status: partial` with the gap. Surface open decisions in the Return Contract for the primary agent to relay.
 
 ### Interview Enhancement Skills
 

--- a/opencode_app/.opencode/agents/technical-design-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/technical-design-specialist-subagent.md
@@ -8,6 +8,7 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  question: deny
   read_mcp_resource: deny
   list_mcp_resources: deny
   list_mcp_resource_templates: deny
@@ -60,15 +61,17 @@ Invoke this subagent when the user uses phrases like:
 - "architecture document" / "system design" / "design spec"
 - "design the architecture" / "technical design doc"
 
-## CRITICAL: Prompt-First Behavior
+## CRITICAL: Headless Execution Model
 
-**ALWAYS prompt the user before taking any action.** Every time new information is gathered or a decision point is reached, present what you plan to do and ask for confirmation.
+**This subagent runs headlessly** — spawned via the Task tool in an isolated session with **no direct user interface**. The `question` tool is NOT available (it is `deny`'d in the frontmatter and is primary-session-only). **NEVER call `question`**, never emit "Proceed?" style prompts (no one answers mid-run), and never hallucinate fallback tools like `read_mcp_resource` to "ask the user."
 
-1. **Before every section**: State what you're about to design and why
-2. **After drafting a section**: Summarize the design decisions and confirm before moving on
-3. **At every architecture decision**: Present options + trade-offs, give a recommendation, wait for the user's choice
-4. **After all sections**: Show the full TDD summary and confirm before writing the file
-5. **Never assume** — always confirm. ADRs (Architecture Decision Records) especially require explicit user buy-in.
+All inputs and decisions arrive in the **delegation prompt** from the primary agent. For architecture decisions and ADRs specifically:
+
+1. **Before each section**: proceed autonomously — state assumptions in the drafted section
+2. **At each architecture decision**: present options + trade-offs + your **recommendation**, then **pick the recommendation** and record it as an ADR with the alternatives noted. Do not stall waiting for selection.
+3. **After all sections**: write the TDD file directly; surface open questions in the Return Contract for the primary agent to relay to the user.
+
+If a critical decision genuinely cannot be made without the user (e.g., two equally-valid architectures with very different cost), return `Status: partial` with the decision framed as a question — the primary agent will ask the user and re-delegate. This is faster than burning your step budget prompting a user who isn't there.
 
 ## CodeGraph Integration (MANDATORY for design decisions)
 
@@ -102,19 +105,19 @@ When delegating to this subagent, provide:
 ### Step 1: Scope Assessment
 1. Read the upstream SRS / feature spec / BRD
 2. Assess scope: count affected modules/services; if >20 files, propose a focused design strategy (deep design for critical paths, lighter for peripheral areas)
-3. Confirm scope with the user
+3. Proceed with the scoped strategy; note the scoping decision in the Return Contract
 
 ### Step 2: CodeGraph Exploration (ground the design)
 1. Explore the existing architecture via `codegraph_explore` (or `explore` fallback)
 2. Map existing boundaries, dependencies, and integration points
 3. Run `codegraph_impact` on the modules the design will touch to surface blast radius
 
-### Step 3: Architecture Decisions (iterate, prompt-first)
+### Step 3: Architecture Decisions (autonomous, recommendation-defaulting)
 For each major architecture decision:
 1. Present options with trade-offs
-2. Give a recommendation
-3. Wait for user selection
-4. Record as an ADR (ADR-NNN: context → decision → consequences)
+2. Give a recommendation with rationale
+3. **Adopt the recommendation** (do not wait for selection) and proceed
+4. Record as an ADR (ADR-NNN: context → decision → consequences, with considered-alternatives noted)
 
 ### Step 4: Author TDD Sections
 Iterate through the TDD template (System Context → Architecture → Data Model → API Surface → Sequence/Interaction Diagrams → Non-Functional Design), confirming each section before moving on.

--- a/opencode_app/.opencode/agents/ticket-creation-subagent.md
+++ b/opencode_app/.opencode/agents/ticket-creation-subagent.md
@@ -8,6 +8,7 @@ permission:
   glob: allow
   grep: allow
   bash: allow
+  question: deny
   read_mcp_resource: deny
   list_mcp_resources: deny
   list_mcp_resource_templates: deny
@@ -46,40 +47,31 @@ You are a ticket creation specialist. Manage GitHub and JIRA ticket workflows.
 - For file searches: use `glob` or `grep`
 - MCP resource tools (`read_mcp_resource` etc.) are reserved for MCP server schemas and remote resources only
 
-## CRITICAL: Prompt-First Behavior
+## CRITICAL: Headless Execution Model
 
-**ALWAYS prompt the user before taking any action.** This subagent must never execute a step without first confirming intent with the user. Every time new information is gathered or a decision point is reached, present the user with what you plan to do and ask for confirmation.
+**This subagent runs headlessly.** It is spawned by the primary agent via the Task tool in an isolated session with **no direct user interface**. Two consequences:
 
-### Prompt-First Rules
+1. **The `question` tool is NOT available** — it is primary-session-only (it surfaces UI to the user through the primary session). It is `deny`'d in the frontmatter above. **NEVER call `question`** and never fall back to `read_mcp_resource` or any other tool to "ask the user." If you cannot resolve something from the delegation prompt, return early (see below) — do not loop or hallucinate alternative tools.
+2. **Free-text "Proceed?" prompts do not work** — there is no terminal and no one answers mid-run. Printing "Proceed? (yes/no)" just stalls. Do not emit interactive confirmation prompts.
 
-1. **Before every step**: Briefly state what you are about to do and ask "Proceed?"
-2. **After gathering information**: Summarize what you understood and confirm before acting
-3. **At every decision point**: Present options and wait for user selection
-4. **After ticket creation**: Show the created ticket details and confirm before proceeding to next step
-5. **After PLAN generation**: Show the plan summary and confirm before committing
+### Where decisions come from
 
-**Example prompt-first pattern**:
-```
-I've gathered the following:
-- Title: "Fix login crash"
-- Labels: bug, priority: high
-- Platform: GitHub
+All inputs and decisions arrive **in the delegation prompt from the primary agent**. The primary agent is responsible for gathering any user input (using its own `question` tool) *before* spawning this subagent. See the **Delegation Contract** below for the required fields.
 
-I will now create a GitHub issue with these details. Proceed? (yes/no/modify)
-```
+### If information is missing
 
-**Never assume** — always confirm. If the user provides incomplete information, ask for clarification rather than guessing.
+Do **not** guess and do **not** stall. Return immediately with:
 
-### Two Prompting Mechanisms
+**Status:** partial
+**Output:** none
+**Summary:** Missing required delegation input.
+**Issues:** Missing: [list the specific fields needed — e.g. "WORKFLOW_MODE not specified and no trigger phrase detected", "title missing", "platform (GitHub/JIRA) ambiguous"]
 
-This subagent uses two distinct prompting patterns:
+The primary agent will gather the missing info (asking the user via its own `question` tool if needed) and re-delegate. This is the correct, fast path — far better than burning your step budget trying to prompt a user who isn't there.
 
-| Mechanism | When | Tool | Format |
-|-----------|------|------|--------|
-| **Structured selection** | Initial workflow choice (ticket-only vs full-workflow) | `question` tool | JSON with labeled options |
-| **Free-text confirmation** | All other steps (gather info, confirm details, proceed to next step) | Direct text output | "Proceed? (yes/no/modify)" |
+### Autonomous execution
 
-The `question` tool is used **only** for the Interactive Workflow Selection prompt (see that section). All other confirmations use the free-text prompt-first pattern above.
+When the delegation prompt is complete, **execute the full workflow without pausing for confirmation.** Log key decisions in your final Return Contract instead of asking mid-run. Make reasonable defaults explicit in your summary.
 
 ## Purpose
 
@@ -158,48 +150,45 @@ After execution, this subagent provides:
 | srs-creation-skill | SRS naming convention and linkage (docs/srs/ draft detection) |
 | brd-creation-skill | BRD naming convention and linkage (docs/brd/ draft detection) |
 
-## Interactive Workflow Selection
+## Delegation Contract
 
-**CRITICAL: Always prompt the user BEFORE creating anything.** Use the `question` tool to present exactly these two options:
+The primary agent MUST provide these fields in the delegation prompt. If any required field is absent and cannot be inferred, return `Status: partial` (see Headless Execution Model).
 
-```json
-{
-  "questions": [
-    {
-      "question": "How would you like to proceed with this [JIRA ticket / GitHub issue]?",
-      "header": "Workflow",
-      "multiple": false,
-      "options": [
-        {
-          "label": "Create ticket only",
-          "description": "Just create the ticket — no branch, no PLAN, no push. Use when you want to plan later or track work without starting immediately."
-        },
-        {
-          "label": "Full workflow (Recommended)",
-          "description": "Create ticket → checkout new branch → generate PLAN.md → commit & push. Complete end-to-end setup ready for implementation."
-        }
-      ]
-    }
-  ]
-}
-```
+**Required:**
+1. **Platform**: `github` or `jira`
+2. **Title/Summary**: max 72 chars
+3. **Overview**: what needs doing and why
+4. **Acceptance Criteria**: definition of done (bullet list)
+5. **Scope**: files/areas affected
 
-**Rules:**
-- Present this prompt IMMEDIATELY after parsing the ticket type (JIRA vs GitHub)
-- Do NOT create the ticket until the user selects an option
-- If the user's invocation matches one of these explicit bypass phrases, skip the prompt and set `WORKFLOW_MODE` directly:
-  - `"just create a ticket"` / `"ticket only"` / `"create issue without branch"` / `"no branch"` → set `"ticket-only"`
-  - `"full workflow"` / `"create branch and plan"` / `"ticket with plan"` / `"set up everything"` → set `"full-workflow"`
-- Store the selection as `WORKFLOW_MODE`: either `"ticket-only"` or `"full-workflow"`
+**Conditionally required:**
+6. **`WORKFLOW_MODE`**: `ticket-only` or `full-workflow` — see Workflow Mode Resolution below. Required unless a trigger phrase disambiguates it.
+
+**Optional (with defaults):**
+7. **Labels** (GitHub) / **Issue Type** (JIRA) — auto-detected via labeler skills if omitted
+8. **Project Key** (JIRA)
+9. **Technical Notes**, **Parent Issue**, **Priority**
+
+## Workflow Mode Resolution
+
+`WORKFLOW_MODE` (`ticket-only` vs `full-workflow`) is resolved from the delegation prompt — **never by prompting the user**. Apply this precedence:
+
+1. **Explicit field** — the delegation prompt contains `WORKFLOW_MODE: ticket-only` or `WORKFLOW_MODE: full-workflow`. Use it verbatim.
+2. **Trigger phrases in the delegation text** — the primary agent's request maps to a mode:
+   - `ticket-only`: "just create a ticket", "ticket only", "create issue without branch", "no branch", "issue only"
+   - `full-workflow`: "full workflow", "create branch and plan", "ticket with plan", "set up everything", "full workflow"
+3. **Default** — if neither (1) nor (2) applies, default to `full-workflow` and note the assumption in the Return Contract summary. (This default matches the existing "Recommended" option.)
+
+Do NOT emit a question or wait for selection. Resolve silently and proceed.
 
 ## Workflow
 
-### Step 1: Parse & Prompt (Both Modes)
+### Step 1: Parse Delegation Prompt (Both Modes)
 
-1. Parse ticket requirement — detect platform (GitHub or JIRA) from context
-2. Gather missing information from user (title, overview, acceptance criteria, scope)
-3. **Present the Interactive Workflow Selection prompt** (see above)
-4. Set `WORKFLOW_MODE` based on user's selection
+1. Parse the delegation prompt — detect platform (GitHub or JIRA) and required fields (title, overview, acceptance criteria, scope)
+2. Resolve `WORKFLOW_MODE` per Workflow Mode Resolution above (silent — no prompt)
+3. If any required field from the Delegation Contract is missing, return `Status: partial` immediately with the missing-field list
+4. Otherwise proceed to Step 2
 
 ### Step 2: Create Ticket (Both Modes)
 
@@ -276,160 +265,100 @@ After execution, this subagent provides:
 
 ### Example 1: Create JIRA Ticket (Full Workflow)
 ```
-Delegate: "Create a JIRA ticket for adding user authentication to the IBIS project"
+Delegate (from primary agent):
+  "Create a JIRA ticket for adding user authentication to the IBIS project.
+   WORKFLOW_MODE: full-workflow"
 
-Subagent detects: JIRA platform
+Subagent resolves: platform=JIRA, WORKFLOW_MODE=full-workflow (explicit)
 
-Subagent prompts user:
-┌─────────────────────────────────────────────────────┐
-│ How would you like to proceed with this JIRA ticket? │
-│                                                       │
-│ ○ Create ticket only                                 │
-│ ○ Full workflow (Recommended)                        │
-└─────────────────────────────────────────────────────┘
+Subagent executes autonomously (no mid-run prompts):
+  - Creates ticket via atlassian_createJiraIssue + jira-ticket-labeler
+  - Creates branch IBIS-456
+  - Generates PLANS/PLAN-IBIS-456.md
+  - Commits + pushes
 
-User selects: "Full workflow"
-
-Subagent gathers:
-- Title: "Implement user authentication"
-- Overview: "Add JWT-based auth endpoints"
-- Acceptance Criteria: ["Users can register", "Users can login", "Protected routes work"]
-- Scope: "src/api/auth/, src/middleware/"
-
-Output:
-- Ticket: IBIS-456
-- Branch: IBIS-456
-- PLAN: PLANS/PLAN-IBIS-456.md
-- URL: https://company.atlassian.net/browse/IBIS-456
+Output (in Return Contract):
+  - Ticket: IBIS-456
+  - Branch: IBIS-456
+  - PLAN: PLANS/PLAN-IBIS-456.md
+  - URL: https://company.atlassian.net/browse/IBIS-456
 ```
 
 ### Example 2: Create GitHub Issue (Ticket Only)
 ```
-Delegate: "Create a GitHub issue for fixing the login bug"
+Delegate (from primary agent):
+  "Create a GitHub issue for fixing the login bug. Ticket only — no branch.
+   Title: Fix login page crash
+   Overview: Login page crashes on invalid credentials
+   Acceptance Criteria: Login handles errors gracefully; User sees error message
+   Scope: src/pages/login.tsx"
 
-Subagent detects: GitHub platform
+Subagent resolves: platform=GitHub, WORKFLOW_MODE=ticket-only (trigger phrase "no branch")
 
-Subagent prompts user:
-┌──────────────────────────────────────────────────────┐
-│ How would you like to proceed with this GitHub issue? │
-│                                                       │
-│ ○ Create ticket only                                 │
-│ ○ Full workflow (Recommended)                        │
-└──────────────────────────────────────────────────────┘
+Subagent executes (ticket-only → no branch/PLAN/push):
+  - Creates issue via gh issue create + git-issue-labeler (label: bug)
 
-User selects: "Create ticket only"
-
-Subagent gathers:
-- Title: "Fix login page crash"
-- Overview: "Login page crashes on invalid credentials"
-- Acceptance Criteria: ["Login handles errors gracefully", "User sees error message"]
-- Scope: "src/pages/login.tsx"
-
-Output:
-- Issue: #789
-- URL: https://github.com/org/repo/issues/789
-- Labels: bug
+Output (in Return Contract):
+  - Issue: #789
+  - URL: https://github.com/org/repo/issues/789
+  - Labels: bug
 ```
 
-### Example 3: Full Workflow with Confirmations (Detailed)
+### Example 3: Full Workflow (Headless — info arrives via delegation)
+
 ```
-Delegate: "Create a JIRA ticket for adding user authentication to the IBIS project"
+Delegate (from primary agent):
+  "Create a JIRA ticket for adding user authentication to the IBIS project.
+   WORKFLOW_MODE: full-workflow
+   Title: Implement user authentication
+   Overview: Add JWT-based auth endpoints
+   Acceptance Criteria: Users can register; Users can login; Protected routes work
+   Scope: src/api/auth/, src/middleware/"
 
-Subagent detects: JIRA platform
+Subagent resolves: platform=JIRA, WORKFLOW_MODE=full-workflow (explicit)
 
-Subagent prompts user (question tool):
-┌─────────────────────────────────────────────────────┐
-│ How would you like to proceed with this JIRA ticket? │
-│                                                       │
-│ ○ Create ticket only                                 │
-│ ○ Full workflow (Recommended)                        │
-└─────────────────────────────────────────────────────┘
+Subagent executes autonomously (no mid-run prompts):
+  - Creates ticket via atlassian_createJiraIssue + jira-ticket-labeler
+  - Creates branch IBIS-456
+  - Generates PLANS/PLAN-IBIS-456.md (atomic steps, dependency map)
+  - Runs atomicity self-check → passes
+  - Commits: docs(plan): add PLAN-IBIS-456.md for IBIS-456
+  - Pushes branch
+  - Posts progress comment to IBIS-456
 
-User selects: "Full workflow"
-
-[Subagent prompts]: I need a few details:
-1. Title: [suggested] "Implement user authentication" — correct?
-2. Overview: What should this accomplish?
-3. Acceptance Criteria: What defines "done"?
-4. Scope: Which files/areas are affected?
-
-[User provides details]
-
-[Subagent prompts]: Here's what I'll create:
-- Platform: JIRA
-- Project: IBIS
-- Type: Story (auto-detected)
-- Title: "Implement user authentication"
-- Labels: enhancement
-
-Proceed? (yes/no/modify)
-
-[User: yes]
-
-[Subagent creates ticket, shows result]:
-- Ticket: IBIS-456
-- URL: https://company.atlassian.net/browse/IBIS-456
-
-Proceed to create branch and PLAN file? (yes/no)
-
-[User: yes]
-
-[Subagent creates branch + plan, shows summary]:
-- Branch: IBIS-456
-- PLAN: PLANS/PLAN-IBIS-456.md (5 phases)
-
-Proceed to commit and push? (yes/no/modify)
-
-[User: yes]
-
-[After push]:
-Would you like the architecture-review-subagent to review the plan file?
-- Yes: Review PLANS/PLAN-IBIS-456.md for design quality
-- No: Workflow complete
-
-[User: yes → spawns architecture-review-subagent]
+Return Contract:
+  Status: success
+  Output: IBIS-456, branch IBIS-456, PLANS/PLAN-IBIS-456.md
+  Summary: Created JIRA story IBIS-456, branch IBIS-456, and PLAN with 5 phases.
+  Issues: None
 ```
 
-### Example 4: Create GitHub Issue (Full Workflow)
+### Example 4: Create GitHub Issue (Full Workflow, Headless)
+
 ```
-Delegate: "Create a GitHub issue for fixing the login bug"
+Delegate (from primary agent):
+  "Create a GitHub issue for fixing the login bug. Full workflow.
+   Title: Fix login page crash
+   Overview: Login page crashes on invalid credentials
+   Acceptance Criteria: Login handles errors gracefully; User sees error message
+   Scope: src/pages/login.tsx"
 
-Subagent detects: GitHub platform
+Subagent resolves: platform=GitHub, WORKFLOW_MODE=full-workflow (trigger phrase "full workflow")
 
-Subagent prompts user (question tool):
-┌──────────────────────────────────────────────────────┐
-│ How would you like to proceed with this GitHub issue? │
-│                                                       │
-│ ○ Create ticket only                                 │
-│ ○ Full workflow (Recommended)                        │
-└──────────────────────────────────────────────────────┘
+Subagent executes autonomously:
+  - Creates issue via gh issue create + git-issue-labeler (labels: bug, priority: high)
+  - Creates branch issue-789
+  - Generates PLANS/PLAN-GIT-789.md
+  - Commits + pushes
 
-User selects: "Full workflow"
-
-[Subagent prompts]: I need a few details:
-1. Title: [suggested] "Fix login page crash" — correct?
-2. Overview: What's happening?
-3. Acceptance Criteria: What defines "fixed"?
-4. Scope: Which files?
-
-[User provides details]
-
-[Subagent prompts]: Here's what I'll create:
-- Platform: GitHub
-- Labels: bug, priority: high
-- Title: "Fix login page crash"
-
-Proceed? (yes/no/modify)
-
-[User: yes]
-
-Output after full workflow:
-- Issue: #789
-- Branch: issue-789
-- PLAN: PLANS/PLAN-GIT-789.md
-- URL: https://github.com/org/repo/issues/789
-- Architecture Review: [completed/skipped]
+Return Contract:
+  Status: success
+  Output: #789, branch issue-789, PLANS/PLAN-GIT-789.md
+  Summary: Created GitHub issue #789 (bug, priority: high), branch issue-789, PLAN committed and pushed.
+  Issues: None
 ```
+
+> **Architecture review** is offered in the Return Contract summary (a yes/no signal the primary agent can surface to the user), not via a mid-run prompt. If the primary agent's user wants a review, the primary agent spawns `architecture-review-subagent` separately.
 
 ## Notes
 
@@ -438,8 +367,8 @@ Output after full workflow:
 - Branch naming: `{ticket-key}` for JIRA, `issue-{number}` for GitHub
 - Supports both single tickets and parent/child hierarchies
 - **Never executes the plan** — only creates it
-- **Always prompts before each step** — no silent execution
-- Architecture review is optional but always offered after PLAN push
+- **Runs headlessly** — no mid-run user prompts; all input arrives via the delegation prompt. If input is missing, return `Status: partial` rather than stalling (see Headless Execution Model)
+- Architecture review is signaled in the Return Contract (the primary agent offers it to the user), not requested mid-run
 
 ## Return Contract
 

--- a/opencode_app/.opencode/plugins/ATTRIBUTION.md
+++ b/opencode_app/.opencode/plugins/ATTRIBUTION.md
@@ -1,0 +1,51 @@
+# Attributions
+
+## ponytail (`@dietrichgebert/ponytail`)
+
+This directory (`plugins/ponytail/`) contains code vendored and adapted from the
+[ponytail](https://github.com/DietrichGebert/ponytail) project by Dietrich Gebert.
+
+- **Upstream:** https://github.com/DietrichGebert/ponytail
+- **Pinned version:** v4.8.4 (tag `v4.8.4`)
+- **License:** MIT (see full text below)
+- **Files vendored:**
+  - `SKILL.md` — the ponytail ruleset (copied verbatim from `skills/ponytail/SKILL.md`)
+  - `instructions.cjs` — adapted from `hooks/ponytail-instructions.js` and
+    `hooks/ponytail-config.js` (mode-filtering logic preserved; Claude-Code-specific
+    config-file paths dropped; reads the co-located `SKILL.md`)
+- **Adaptation rationale:** vendoring (vs `require("@dietrichgebert/ponytail")`) keeps
+  the Docker container air-gapped (no runtime npm fetch), removes the stock OpenCode
+  adapter from the dependency tree (double-injection guard), and lets the wrapper
+  plugin (`../ponytail-scoped.mjs`) add agent-type-aware scoping that the upstream
+  adapter does not support on OpenCode.
+
+Re-vendor deliberately on upstream bumps: update `SKILL.md` from the new tag and
+re-check `instructions.cjs` against the upstream instruction builder.
+
+---
+
+### MIT License (upstream ponytail)
+
+```
+MIT License
+
+Copyright (c) Dietrich Gebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/opencode_app/.opencode/plugins/ponytail-scoped.mjs
+++ b/opencode_app/.opencode/plugins/ponytail-scoped.mjs
@@ -1,0 +1,231 @@
+// ponytail-scoped.mjs — OpenCode wrapper plugin for ponytail with agent-type-aware scoping.
+//
+// Wraps the vendored ponytail ruleset (./ponytail/) and adds what the stock
+// @dietrichgebert/ponytail OpenCode adapter cannot do:
+//   1. Agent-type scoping — read-only/research agents skip injection entirely.
+//      The stock adapter injects into ALL chats unconditionally; its
+//      PONYTAIL_SUBAGENT_MATCHER is Claude-Code-only and a no-op on OpenCode.
+//   2. Per-agent default modes via PONYTAIL_AGENT_MODE_MAP (JSON env var).
+//
+// Agent-type resolution (Phase 0 spike, resolved via OpenCode plugin source):
+//   - experimental.chat.system.transform input = { sessionID?, model }
+//   - chat.message input = { sessionID, agent?, ... }  → cache sessionID→agent
+//   - cache miss + sessionID present → client.session.get() fallback
+//   - agent unresolvable → inject (safe default; off-set only EXCLUDES known read-only agents)
+//
+// Env vars:
+//   PONYTAIL_DEFAULT_MODE   — lite|full|ultra|off  (default: full)
+//   PONYTAIL_SUBAGENT_OFF   — regex of agent names to EXCLUDE (default: 7 read-only/research agents)
+//   PONYTAIL_AGENT_MODE_MAP — JSON { "<agent>": "<mode>" } per-agent overrides
+//
+// Vendored from @dietrichgebert/ponytail v4.8.4 (MIT). See ./ponytail/../ATTRIBUTION.md.
+// The stock npm plugin MUST NOT be in opencode.json plugin array (double-injection guard).
+
+import { createRequire } from 'module';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const {
+  getPonytailInstructions,
+  normalizeMode,
+  DEFAULT_MODE,
+} = require('./ponytail/instructions.cjs');
+
+// ── Configuration (read once at load) ──────────────────────────────────────────
+
+const PONYTAIL_DEFAULT_MODE = normalizeMode(process.env.PONYTAIL_DEFAULT_MODE) || DEFAULT_MODE;
+
+// Default off-set: read-only / research agents that should NOT be pushed toward minimal code.
+const DEFAULT_OFF_PATTERN =
+  '^(explore|general|autoresearch-research-subagent|explorer-subagent|' +
+  'requirements-specialist-subagent|discovery-specialist-subagent|' +
+  'technical-design-specialist-subagent)$';
+
+function compileOffRegex() {
+  const pattern = process.env.PONYTAIL_SUBAGENT_OFF || DEFAULT_OFF_PATTERN;
+  try {
+    return new RegExp(pattern, 'i');
+  } catch (_) {
+    return new RegExp(DEFAULT_OFF_PATTERN, 'i');
+  }
+}
+const OFF_REGEX = compileOffRegex();
+
+// Per-agent mode overrides: { "build": "full", "code-review-subagent": "lite" }
+let AGENT_MODE_MAP = {};
+if (process.env.PONYTAIL_AGENT_MODE_MAP) {
+  try {
+    const parsed = JSON.parse(process.env.PONYTAIL_AGENT_MODE_MAP);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      AGENT_MODE_MAP = parsed;
+    }
+  } catch (_) {
+    // invalid JSON → silently fall back to empty map (default mode governs)
+  }
+}
+
+// ── Per-session state ───────────────────────────────────────────────────────────
+
+const sessionAgent = new Map(); // sessionID → agent (populated by chat.message)
+const sessionMode = new Map();  // sessionID → mode (overridden via /ponytail commands)
+
+function resolveMode(sessionID, agent) {
+  // 1. Per-session override (from /ponytail <level> command) — highest priority
+  if (sessionID && sessionMode.has(sessionID)) {
+    return sessionMode.get(sessionID);
+  }
+  // 2. Per-agent map
+  if (agent && AGENT_MODE_MAP[agent]) {
+    const m = normalizeMode(AGENT_MODE_MAP[agent]);
+    if (m) return m;
+  }
+  // 3. Global default
+  return PONYTAIL_DEFAULT_MODE;
+}
+
+function isInOffSet(agent) {
+  if (!agent) return false;
+  return OFF_REGEX.test(agent);
+}
+
+// ── Command definitions (embedded so only plugins/ needs deploying) ───────────
+
+const COMMANDS = {
+  ponytail: {
+    description: 'Ponytail: report or set lazy-code intensity. Usage: /ponytail [lite|full|ultra|off]',
+    template:
+      'You are running under ponytail. If the user gave a level, confirm the switch in one line. ' +
+      'If no level was given, report the current mode in one line and what it means. Do not output code.',
+    agent: 'build',
+  },
+  'ponytail-help': {
+    description: 'Ponytail: quick command reference.',
+    template:
+      'List the ponytail slash commands and one line each on what they do: ' +
+      '/ponytail [lite|full|ultra|off], /ponytail-help, /ponytail-lite, /ponytail-full, ' +
+      '/ponytail-ultra, /ponytail-off. Format as a short list. Do not output code.',
+    agent: 'build',
+  },
+  'ponytail-lite': {
+    description: 'Ponytail: switch to lite intensity (name the lazier alternative, user picks).',
+    template: 'Ponytail mode is now lite. Confirm in one line. Do not output code.',
+    agent: 'build',
+  },
+  'ponytail-full': {
+    description: 'Ponytail: switch to full intensity (the ladder enforced, default).',
+    template: 'Ponytail mode is now full. Confirm in one line. Do not output code.',
+    agent: 'build',
+  },
+  'ponytail-ultra': {
+    description: 'Ponytail: switch to ultra intensity (YAGNI extremist, deletion before addition).',
+    template: 'Ponytail mode is now ultra. Confirm in one line. Do not output code.',
+    agent: 'build',
+  },
+  'ponytail-off': {
+    description: 'Ponytail: turn off lazy-code injection for this session.',
+    template: 'Ponytail is now off for this session. Confirm in one line. Do not output code.',
+    agent: 'build',
+  },
+};
+
+const PONYTAIL_MARKER = 'PONYTAIL MODE ACTIVE';
+
+// ── Plugin ──────────────────────────────────────────────────────────────────────
+
+export default async ({ client } = {}) => {
+  const log = (level, message) => {
+    try {
+      client && client.app && client.app.log({ body: { service: 'ponytail-scoped', level, message } });
+    } catch (_) {}
+  };
+
+  log('info', 'ponytail-scoped loaded — default mode: ' + PONYTAIL_DEFAULT_MODE);
+
+  return {
+    // Register the 6 commands (non-destructive merge — preserves existing commands).
+    config: async (config) => {
+      if (!config.command) config.command = {};
+      for (const [name, def] of Object.entries(COMMANDS)) {
+        // Never overwrite a user-defined command of the same name.
+        if (!config.command[name]) config.command[name] = def;
+      }
+    },
+
+    // Cache sessionID → agent so the transform hook can scope by agent type.
+    // chat.message fires before experimental.chat.system.transform on a normal turn.
+    'chat.message': async (input) => {
+      if (input && input.sessionID && input.agent) {
+        sessionAgent.set(input.sessionID, input.agent);
+      }
+    },
+
+    // Core: append the mode-filtered ruleset to the system prompt, scoped by agent type.
+    'experimental.chat.system.transform': async (input, output) => {
+      if (!output || !Array.isArray(output.system)) return;
+
+      const sessionID = input && input.sessionID;
+      let agent = sessionID ? sessionAgent.get(sessionID) : undefined;
+
+      // Fallback: cache miss → look up the session via the SDK.
+      if (!agent && sessionID && client && client.session && client.session.get) {
+        try {
+          const res = await client.session.get({ path: { id: sessionID } });
+          const data = res && res.data;
+          agent = (data && (data.agent || data.agentID || data.agentId)) || undefined;
+          if (agent) sessionAgent.set(sessionID, agent);
+        } catch (_) {
+          // session lookup failed — proceed with agent unknown (will inject, safe default)
+        }
+      }
+
+      const mode = resolveMode(sessionID, agent);
+      if (mode === 'off') return;
+
+      if (isInOffSet(agent)) {
+        log('debug', 'ponytail skipped: agent in off-set (' + (agent || '?') + ')');
+        return;
+      }
+
+      const instructions = getPonytailInstructions(mode);
+      if (!instructions) return;
+
+      // Idempotency / double-injection guard: skip if already injected this turn.
+      const last = output.system.length > 0 ? output.system[output.system.length - 1] : '';
+      if (typeof last === 'string' && last.includes(PONYTAIL_MARKER)) return;
+      for (const entry of output.system) {
+        if (typeof entry === 'string' && entry.includes(PONYTAIL_MARKER)) return;
+      }
+
+      if (output.system.length > 0) {
+        output.system[output.system.length - 1] =
+          String(output.system[output.system.length - 1]) + '\n\n' + instructions;
+      } else {
+        output.system.push(instructions);
+      }
+    },
+
+    // Persist /ponytail <level> and /ponytail-<level> mode switches per session.
+    'command.execute.before': async (input) => {
+      if (!input) return;
+      const cmd = input.command || '';
+      const sessionID = input.sessionID;
+      let mode = null;
+
+      if (cmd === 'ponytail') {
+        // /ponytail [level] — argument drives the switch; no arg = status query (no-op here)
+        const arg = String(input.arguments || '').trim().toLowerCase();
+        if (arg) mode = normalizeMode(arg);
+      } else if (cmd.startsWith('ponytail-')) {
+        mode = normalizeMode(cmd.replace('ponytail-', ''));
+      }
+
+      if (mode && sessionID) {
+        sessionMode.set(sessionID, mode);
+        const agent = sessionAgent.get(sessionID) || '?';
+        log('info', 'ponytail ' + mode + ' (session ' + sessionID + ', agent ' + agent + ')');
+      }
+    },
+  };
+};

--- a/opencode_app/.opencode/plugins/ponytail/SKILL.md
+++ b/opencode_app/.opencode/plugins/ponytail/SKILL.md
@@ -1,0 +1,127 @@
+<!--
+  Vendored from @dietrichgebert/ponytail v4.8.4 (MIT)
+  Source: https://github.com/DietrichGebert/ponytail/blob/v4.8.4/skills/ponytail/SKILL.md
+  Pinned at tag v4.8.4. Re-vendor deliberately on upstream bumps.
+  See ../ATTRIBUTION.md for license and attribution.
+-->
+
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  coding task: writing, adding, refactoring, fixing, reviewing, or designing
+  code, and choosing libraries or dependencies. Also use whenever the user
+  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
+  solution", "yagni", "do less", or "shortest path", or complains about
+  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
+  use for non-coding requests (general knowledge, prose, translation,
+  summaries, recipes).
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Stdlib does it?** Use it.
+4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs *after* you
+understand the problem, not instead of it. Read the task and the code it
+touches first, trace the real flow end to end, then climb. Two rungs work →
+take the higher one and move on. The first lazy solution that works is the
+right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you
+edit, grep every caller of the function you're about to touch. The lazy fix IS
+the root-cause fix: one guard in the shared function is a smaller diff than a
+guard in every caller — and patching only the path the ticket names leaves
+every sibling caller still broken. Fix it once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the
+solution, never the reading. Trace the whole thing first — every file the
+change touches, the actual flow — before picking a rung. Laziness that skips
+comprehension to ship a small diff is the dangerous kind: it dresses up as
+efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/opencode_app/.opencode/plugins/ponytail/instructions.cjs
+++ b/opencode_app/.opencode/plugins/ponytail/instructions.cjs
@@ -1,0 +1,123 @@
+// ponytail instruction builder — vendored + adapted from @dietrichgebert/ponytail v4.8.4 (MIT).
+// Source: hooks/ponytail-instructions.js + hooks/ponytail-config.js
+// Adaptations: reads the co-located SKILL.md (this dir); mode constants inlined
+// (drops the Claude-Code-specific config-file/CLAUDE_CONFIG_DIR paths we don't use).
+//
+// Exports:
+//   getPonytailInstructions(mode) -> string   mode-filtered system-prompt suffix
+//   filterSkillBodyForMode(body, mode) -> string
+//   normalizeMode(mode) -> string | null
+//
+// "off" returns "" (caller treats empty as "do not inject").
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_MODE = 'full';
+// off must come first so RUNTIME_MODES ordering is stable; review is excluded
+// (review is a command-only mode handled by the /ponytail-review skill, not injected).
+const RUNTIME_MODES = ['off', 'lite', 'full', 'ultra'];
+
+const SKILL_PATH = path.join(__dirname, 'SKILL.md');
+
+function normalizeMode(mode) {
+  if (typeof mode !== 'string') return null;
+  const normalized = mode.trim().toLowerCase();
+  return RUNTIME_MODES.includes(normalized) ? normalized : null;
+}
+
+function normalizePersistedMode(mode) {
+  // Accept any runtime mode; unknown -> null (caller falls back to default).
+  return normalizeMode(mode);
+}
+
+function filterSkillBodyForMode(body, mode) {
+  const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
+  const withoutFrontmatter = String(body || '').replace(/^---[\s\S]*?---\s*/, '');
+
+  // Only the intensity table rows and worked examples are mode-specific, and
+  // both are keyed by a mode name (lite/full/ultra). A bullet whose label is
+  // not a mode — e.g. "No unrequested abstractions: ..." — is a normal rule
+  // and must be kept verbatim.
+  return withoutFrontmatter
+    .split(/\r?\n/)
+    .filter((line) => {
+      const tableLabel = line.match(/^\|\s*\*\*(.+?)\*\*\s*\|/);
+      if (tableLabel) {
+        const labelMode = normalizeMode(tableLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      // Require a quoted value: every worked example is `- lite: "..."`. Without
+      // this, an ordinary rule bullet that happens to start with a mode word
+      // (e.g. "- Full: ...") is silently dropped in every other mode — it looks
+      // like a worked example but is really prose meant to survive verbatim.
+      const exampleLabel = line.match(/^-\s*([^:]+):\s*"/);
+      if (exampleLabel) {
+        const labelMode = normalizeMode(exampleLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      return true;
+    })
+    .join('\n');
+}
+
+function getFallbackInstructions(mode) {
+  return 'PONYTAIL MODE ACTIVE — level: ' + mode + '\n\n' +
+    'You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.\n\n' +
+    '## Persistence\n\n' +
+    'ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".\n\n' +
+    'Current level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +
+    '## The ladder\n\n' +
+    'Before any code, stop at the first rung that holds (the ladder runs after you understand the problem, not instead of it — read the code it touches and trace the real flow first):\n' +
+    '1. Does this need to be built at all? (YAGNI)\n' +
+    '2. Does it already exist in this codebase? Reuse what is already here, do not re-write it.\n' +
+    '3. Does the standard library do this? Use it.\n' +
+    '4. Does a native platform feature cover it? Use it.\n' +
+    '5. Does an already-installed dependency solve it? Use it.\n' +
+    '6. Can this be one line? Make it one line.\n' +
+    '7. Only then: write the minimum code that works.\n\n' +
+    'Bug fix = root cause, not symptom: grep every caller of the function you touch and fix the shared function once (a smaller diff than one guard per caller); patching only the path the ticket names leaves a sibling caller broken.\n\n' +
+    '## Rules\n\n' +
+    'No abstractions that were not requested. No avoidable dependencies. No boilerplate nobody asked for. ' +
+    'Deletion over addition. Boring over clever. Fewest files possible. ' +
+    'Ship the lazy version and question the complex request in the same response — never stall. ' +
+    'Between two same-size stdlib options, pick the one correct on edge cases. ' +
+    'Mark deliberate simplifications that cut a real corner with a known ceiling, using a `ponytail:` comment that names the ceiling and upgrade path.\n\n' +
+    '## Output\n\n' +
+    'Code first. Then at most three short lines: what was skipped, when to add it. ' +
+    'If the explanation is longer than the code, delete the explanation. ' +
+    'Explanation the user explicitly asked for is not debt, give it in full.\n\n' +
+    '## When NOT to be lazy\n\n' +
+    'Never simplify away: understanding the problem (read it fully and trace the real flow before picking a rung — a small diff you do not understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, ' +
+    'security measures, accessibility basics, the calibration real hardware needs (the platform is never the spec ideal), anything the user explicitly asked to keep. ' +
+    'Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test.\n\n' +
+    '## Boundaries\n\n' +
+    'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
+}
+
+function getPonytailInstructions(mode) {
+  const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
+
+  if (configuredMode === 'off') return '';
+
+  const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
+
+  try {
+    return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
+      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
+  } catch (e) {
+    return getFallbackInstructions(effectiveMode);
+  }
+}
+
+module.exports = {
+  DEFAULT_MODE,
+  RUNTIME_MODES,
+  normalizeMode,
+  normalizePersistedMode,
+  filterSkillBodyForMode,
+  getFallbackInstructions,
+  getPonytailInstructions,
+};

--- a/opencode_app/README.md
+++ b/opencode_app/README.md
@@ -139,3 +139,44 @@ OpenCode supports subagent-to-subagent delegation via the Task tool, controlled 
 - Each spawned subagent gets its own session, context window, and step budget
 - Hub-and-spoke (primary agent -> subagent) remains the recommended pattern
 - 26 of 39 agents have explicit `task` permissions; the remaining 13 default to full access
+
+## Ponytail Plugin (scoped wrapper)
+
+[Ponytail](https://github.com/DietrichGebert/ponytail) (MIT, vendored at v4.8.4) makes coding agents write minimal necessary code via a 7-rung "lazy senior dev" ladder. This container ships a **scoped wrapper plugin** (`opencode_app/.opencode/plugins/ponytail-scoped.mjs`) — not the stock npm adapter — because the stock adapter injects into ALL agents unconditionally and its `PONYTAIL_SUBAGENT_MATCHER` is non-functional on OpenCode. The wrapper scopes injection by agent type.
+
+### Commands
+
+| Command | What it does |
+|---------|--------------|
+| `/ponytail [lite\|full\|ultra\|off]` | Set intensity, or report current mode with no argument |
+| `/ponytail-help` | Quick command reference |
+| `/ponytail-lite` | Switch to lite (name the lazier alternative, user picks) |
+| `/ponytail-full` | Switch to full (the ladder enforced — default) |
+| `/ponytail-ultra` | Switch to ultra (YAGNI extremist, deletion before addition) |
+| `/ponytail-off` | Turn off for this session |
+
+### Environment Variables
+
+Set in `.env` (see `.env.example`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PONYTAIL_DEFAULT_MODE` | `full` | Global intensity: `lite` \| `full` \| `ultra` \| `off` |
+| `PONYTAIL_SUBAGENT_OFF` | (built-in 7-agent list) | Regex of agent names that skip injection. Empty = use the default off-set |
+| `PONYTAIL_AGENT_MODE_MAP` | unset | JSON per-agent overrides, e.g. `{"build":"full","code-review-subagent":"lite"}` |
+
+### Agent Off-Set (default)
+
+These read-only / research agents do NOT receive ponytail injection (they shouldn't be pushed toward minimal code):
+
+- `explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`
+
+Override by setting `PONYTAIL_SUBAGENT_OFF` to a custom regex.
+
+### How It Works
+
+1. `chat.message` hook caches `sessionID → agent` (the agent type arrives here).
+2. `experimental.chat.system.transform` hook resolves the agent (cache, or `client.session.get()` fallback), checks the off-set regex, resolves the mode, and appends the mode-filtered ruleset to the system prompt — once per turn (idempotent).
+3. `command.execute.before` hook persists `/ponytail <level>` switches per session.
+
+The vendored ruleset + adapted instruction builder live in `opencode_app/.opencode/plugins/ponytail/`. MIT attribution: `opencode_app/.opencode/plugins/ATTRIBUTION.md`. The stock `@dietrichgebert/ponytail` npm package is deliberately NOT in `opencode.json` `plugin` array (double-injection guard).

--- a/opencode_app/docker-entrypoint.sh
+++ b/opencode_app/docker-entrypoint.sh
@@ -70,6 +70,21 @@ if [ -n "${GIT_USER_EMAIL}" ]; then
     echo "Set git user.email: ${GIT_USER_EMAIL}"
 fi
 
+# ── Ponytail (scoped wrapper plugin) ──────────────────────────────────────────
+# Default lazy-code intensity: lite | full | ultra | off (default: full).
+# Read by the ponytail-scoped.mjs plugin at load time.
+export PONYTAIL_DEFAULT_MODE="${PONYTAIL_DEFAULT_MODE:-full}"
+
+# Regex of agent names that SKIP ruleset injection (read-only/research agents).
+# Default excludes the 7 read-only/research agents. Override to add/remove.
+export PONYTAIL_SUBAGENT_OFF="${PONYTAIL_SUBAGENT_OFF:-}"
+
+# Optional per-agent mode overrides as JSON, e.g. {"build":"full","code-review-subagent":"lite"}
+# Unset by default — PONYTAIL_DEFAULT_MODE governs all non-off-set agents.
+export PONYTAIL_AGENT_MODE_MAP="${PONYTAIL_AGENT_MODE_MAP:-}"
+
+echo "Ponytail: mode=${PONYTAIL_DEFAULT_MODE} off-set=$([ -n \"${PONYTAIL_SUBAGENT_OFF}\" ] && echo 'custom' || echo 'default')"
+
 # ── Workspace ───────────────────────────────────────────────────────────────
 mkdir -p /workspace
 mkdir -p /workspace-extra 2>/dev/null || true


### PR DESCRIPTION
## Summary

Integrates [ponytail](https://github.com/DietrichGebert/ponytail) v4.8.4 (MIT, vendored) via a custom wrapper plugin with agent-type-aware scoping, and fixes a headless-execution bug affecting 7 subagents. Closes #266.

## Changes

### 1. fix(agents): headless question-tool execution model (`d7cef78`)
The `question` tool is primary-session-only; subagents spawned via Task run headlessly and cannot access it. Seven agents instructed subagents to call `question`, causing them to hallucinate `read_mcp_resource` fallbacks that fail with JSON parse errors, burning their step budget until "Maximum steps reached." Added `question: deny` to frontmatter + Headless Execution Model sections. Also fixes a duplicate `task:` YAML key in discovery-specialist-subagent that dropped the `"*": deny` security default.

### 2. feat(plugins): ponytail scoped wrapper plugin (`f698265`, `aac298b`, `9252943`)
- Vendored ponytail v4.8.4 ruleset (MIT) — zero runtime npm dependency, works air-gapped
- Custom wrapper plugin (`ponytail-scoped.mjs`) with 4 hooks: `config` (6 commands), `chat.message` (agent cache), `experimental.chat.system.transform` (scoped injection), `command.execute.before` (mode persistence)
- **Agent-type scoping** (the core value the stock adapter lacks): read-only/research agents skip injection via `chat.message` cache + `client.session.get()` fallback
- Idempotent transform (double-injection guard); stock `@dietrichgebert/ponytail` deliberately NOT in `plugin` array
- 3 env vars: `PONYTAIL_DEFAULT_MODE` (full), `PONYTAIL_SUBAGENT_OFF` (off-set regex), `PONYTAIL_AGENT_MODE_MAP` (per-agent JSON)

### 3. docs(plugins): READMEs + PLAN progress (`9252943`)
Ponytail Plugin sections in both READMEs. PLAN-GIT-266 updated (25/31 done).

## Acceptance Criteria Status
- [x] Off-set agents skip injection — **smoke-tested** (15/15 pass)
- [x] `PONYTAIL_SUBAGENT_OFF` override — **smoke-tested**
- [x] No double-injection — grep-confirmed + idempotency smoke-tested
- [x] MIT attribution present
- [x] READMEs document the feature
- [ ] Docker runtime verify (`/ponytail-help`, mode switching) — deferred to Docker-capable env (Docker not available in implementation session)
- [ ] User-space deploy verify (`setup.sh --quick`) — deploy path verified via `cp -r` dry-run

## Quality Gate
`node --check` passes on both `.mjs` and `.cjs`. Config repo — no test framework/build step.