### PR TITLE
fix(models): repoint reasoning/vision tiers to provider-exposed models + add deploy guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,21 @@ agnostic** — swap to Anthropic/OpenAI/OpenRouter/LM Studio via
 | Tier | Default model (Z.AI) | Use for |
 |------|----------------------|---------|
 | `primary` | `glm-5.2` (1M ctx) | **Primary session only** — holds the long orchestrator context. No subagent uses this. |
-| `reasoning` | `glm-5.1` (200k) | Correctness-critical: reviewers (code/architecture/language incl. java/uiux), repo-ops-specialist, tdd, opentofu-explorer, loop-operator, opencode-tooling, technical-design-specialist, discovery-specialist, requirements-specialist, autoresearch-ml, autoresearch-code |
+| `reasoning` | `glm-5.2` (200k) | Correctness-critical: reviewers (code/architecture/language incl. java/uiux), repo-ops-specialist, tdd, opentofu-explorer, loop-operator, opencode-tooling, technical-design-specialist, discovery-specialist, requirements-specialist, autoresearch-ml, autoresearch-code |
 | `fast` | `glm-5-turbo` (200k) | Exploratory / low-impact / coordination: explorer, testing, specialists (nextjs/cad/m365/google/office-docs), document creators, pr-workflow, autoresearch-research |
 | `docs` | `glm-4.7` (204k) | Docs/lint/reporting: documentation, linting, coverage |
-| `vision` | `glm-5v-turbo` (200k) | **Multimodal required**: image-analyzer, error-resolver. No structured output. |
+| `vision` | `zai/glm-4.6v-flash` (128k, free) | **Multimodal required**: image-analyzer, error-resolver. Served by the **`zai` API provider** (not the coding-plan subscription) — see auth prerequisite below. |
 
 Pick the tier by what the agent *does*: correctness-critical → `reasoning`;
 exploratory/low-impact → `fast`; docs/lint → `docs`; vision → `vision`.
 **Never default a subagent to the `primary` tier.**
+
+> **Vision-tier auth prerequisite:** the `vision` tier uses `zai/glm-4.6v-flash`
+> (Z.AI's free vision model), served by the **`zai` API provider** — separate from
+> the `zai-coding-plan` subscription. Authenticate it once: `opencode auth login`
+> (select Z.AI), or export `ZAI_API_KEY` (Docker injects this automatically via
+> `opencode_app/docker-entrypoint.sh`). Without it, vision subagents fail with a
+> provider-auth error.
 
 ### Resolution precedence (highest wins)
 1. `<project>/.opencode/agent-overrides.json` (per-agent, project-local)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -130,7 +130,7 @@ hand:
 {
   "primary": "zai-coding-plan/glm-5.2",
   "tiers": {
-    "reasoning": "zai-coding-plan/glm-5.1",
+    "reasoning": "zai-coding-plan/glm-5.2",
     "fast": "zai-coding-plan/glm-5-turbo",
     "docs": "zai-coding-plan/glm-4.7",
     "vision": "openai/gpt-5"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -40,6 +40,13 @@ migration, and how to revert.
   4. `~/.config/opencode/models.json` (tier map, global)
   5. `deploy/models.default.json` (Z.AI defaults)
 
+> **Default tier models (updated #281):** `reasoning` → `zai-coding-plan/glm-5.2`
+> and `vision` → `zai/glm-4.6v-flash` (Z.AI's free vision model, served by the
+> `zai` API provider — not the coding-plan subscription; needs `opencode auth
+> login` or `ZAI_API_KEY`). The resolver also runs an **exposed-model guard** at
+> deploy (`--provider-models deploy/provider-models.json`): it fails fast if a
+> tier or source-config pin references a model its provider doesn't serve.
+
 ---
 
 ## Automatic migration (on first v2.0 setup)

--- a/PLANS/PLAN-GIT-281.md
+++ b/PLANS/PLAN-GIT-281.md
@@ -1,0 +1,165 @@
+# PLAN-GIT-281: Fix models.default.json tier→model pins the zai-coding-plan provider doesn't expose (~20 subagents fail to spawn)
+
+**Issue**: https://github.com/darellchua2/opencode-config-template/issues/281
+**Branch**: `GIT-281`
+**Created**: 2026-08-02
+
+## Problem
+
+`deploy/models.default.json` maps the **`reasoning`** and **`vision`** tiers to models
+the configured `zai-coding-plan` provider does **not** expose, so every subagent on those
+two tiers fails to spawn at runtime with `Model not found`. The agent `.md` sources are
+model-free and compliant — the defect is purely in the tier→model map.
+
+- `reasoning` → `zai-coding-plan/glm-5.1`   not exposed (coding plan exposes only `glm-4.7`, `glm-5-turbo`, `glm-5.2`) → **18 agents** fail
+- `vision` → `zai-coding-plan/glm-5v-turbo`  not exposed (no vision model is on the coding-plan subscription) → **2 agents** fail
+
+**~20 of ~39 subagents are non-functional**, blocking all code/architecture reviews,
+requirements/discovery work, ticket-creation chains that delegate to reviewers, and all
+image/screenshot analysis.
+
+## Root Cause (verified)
+
+1. `zai-coding-plan` is OpenCode's flat Z.AI coding-plan **subscription**; it exposes exactly
+   three text models: `glm-4.7`, `glm-5-turbo`, `glm-5.2`. Neither `glm-5.1` nor any vision
+   model is served by it.
+2. Vision models (incl. the free `glm-4.6v-flash`) live only on the **pay-/free-tier Z.AI API**
+   provider (`zai`), authenticated by a separate Z.AI API key — not on the coding-plan subscription.
+3. `resolve-models.mjs` performs **no validation** that a resolved tier model is actually
+   exposed by its provider, so the bad pins surfaced at first subagent spawn instead of at deploy.
+
+## Model Selection (authoritative source: https://docs.z.ai/guides/overview/pricing)
+
+### Vision tier → `zai/glm-4.6v-flash`
+Z.AI's official pricing lists exactly **one free vision model**: `GLM-4.6V-Flash`
+(Input/Output/Cached = Free). It is a recent 4.6V-series model (128k ctx), adequate for the
+sporadic image/screenshot analysis done by `image-analyzer-subagent` and `error-resolver-subagent`.
+No `glm-4.5v-flashx` / `glm-4.6v-flashx` exists (the `flashx` suffix is text-only); the free
+vision model is `glm-4.6v-flash`. models.dev omits it (stale) — the Z.AI pricing page is the
+source of truth.
+
+| Vision model   | Price (in/out per 1M) | Chosen? |
+| --------------- | --------------------: | :-----: |
+| GLM-4.6V-Flash  | **Free / Free**       |       |
+| GLM-4.6V-FlashX | $0.04 / $0.40         |         |
+| GLM-4.6V        | $0.30 / $0.90         |         |
+| GLM-4.5V        | $0.60 / $1.80         |         |
+| GLM-5V-Turbo    | $1.20 / $4.00         |         |
+
+### Reasoning tier → `zai-coding-plan/glm-5.2`
+`glm-5.1` (the canonical reasoning model) is not on the coding plan and is pay-per-token on the
+API ($1.4/$4.4) — too costly for 18 heavily-used agents. `glm-5.2` is exposed by the coding-plan
+subscription, has the strongest reasoning of the three exposed models, and matches the issue's
+suggested fix. Reasoning agents will share the primary model, which is acceptable.
+
+## Resolution
+
+| Tier           | Before (broken)                  | After                                 | Provider        |
+| -------------- | -------------------------------- | ------------------------------------- | --------------- |
+| `primary`      | `zai-coding-plan/glm-5.2`        | `zai-coding-plan/glm-5.2` (unchanged) | coding plan     |
+| `reasoning`    | `zai-coding-plan/glm-5.1`      | `zai-coding-plan/glm-5.2`             | coding plan     |
+| `fast`         | `zai-coding-plan/glm-5-turbo`    | unchanged                             | coding plan     |
+| `docs`         | `zai-coding-plan/glm-4.7`        | unchanged                             | coding plan     |
+| `vision`       | `zai-coding-plan/glm-5v-turbo` | `zai/glm-4.6v-flash`                  | Z.AI API (free) |
+| `long-context` | `zai-coding-plan/glm-5.2`        | unchanged                             | coding plan     |
+
+**Prerequisite (user action):** authenticate the `zai` API provider once — `opencode auth login`
+(select Z.AI) or export `ZAI_API_KEY`. This is separate from the coding-plan subscription and is
+required only because the free vision model is not on the subscription.
+
+---
+
+## Dependency & Consumer Map
+
+| Node (file/module)                       | Depends on (must precede) | Consumers (who depends on this)                                          | Change risk |
+| ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------ | ----------- |
+| `deploy/models.default.json`             | —                         | `resolve-models.mjs` (reads tier map); `provider-presets.json` mirrors it | low         |
+| `deploy/provider-presets.json`           | —                         | `setup.sh --provider/--mix` (writes user `models.json`); `resolve-models.mjs --provider` | low |
+| `deploy/provider-models.json` (NEW)      | —                         | `resolve-models.mjs` guard (validates exposed set)                       | low         |
+| `deploy/resolve-models.mjs`              | `provider-models.json` (Phase 3) | `deploy/setup.sh`, `deploy/setup.ps1` (invoke at deploy)            | med (logic) |
+| `deploy/setup.sh` / `setup.ps1`          | resolver changes          | end-user deploy                                                          | low         |
+| `opencode_app/opencode.json`             | —                         | vision agent spawn needs `zai` provider resolvable (built-in)            | low         |
+| `README.md` / `opencode_app/README.md`   | tier-map changes          | user docs                                                                | low         |
+| `AGENTS.md` (repo) + `deploy/.AGENTS.md` | tier-map changes          | agent routing docs (tier table)                                          | low         |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Repoint broken tiers
+
+- [ ] **1.1** Edit `deploy/models.default.json`: set `tiers.reasoning` → `zai-coding-plan/glm-5.2` and `tiers.vision` → `zai/glm-4.6v-flash`; keep `primary`/`fast`/`docs`/`long-context` unchanged; refresh `$comment` if it mentions glm-5.1/glm-5v-turbo.
+    — **Why:** These two pins are the defect; all other tiers are exposed and working.
+    — **Done when:** `node -e "console.log(Object.entries(require('./deploy/models.default.json').tiers))"` prints no `glm-5.1`/`glm-5v-turbo`.
+    — **Consumers affected:** `resolve-models.mjs`, `provider-presets.json` (mirrored next).
+
+- [ ] **1.2** Edit `deploy/provider-presets.json` `zai` preset: set `tiers.reasoning` → `zai-coding-plan/glm-5.2` and `tiers.vision` → `zai/glm-4.6v-flash` to mirror `models.default.json`.
+    — **Why:** The `--provider zai` / `--mix` flows write user `models.json` from this preset; it must not reintroduce the bad pins.
+    — **Done when:** `jq '.zai.tiers' deploy/provider-presets.json` shows the two new values and no glm-5.1/glm-5v-turbo.
+    — **Consumers affected:** `setup.sh --provider/--mix`, `resolve-models.mjs --provider`.
+
+- [ ] **1.3** Grep the whole repo for residual `glm-5.1` / `glm-5v-turbo` references in deploy/config/docs; repoint or annotate any found (excluding `MIGRATION.md` history notes).
+    — **Why:** A stale reference anywhere (banner, help text, AGENTS table) would mislead users or re-break a re-resolve.
+    — **Done when:** `rg -n 'glm-5\.1|glm-5v-turbo' deploy/ opencode_app/ README.md AGENTS.md MIGRATION.md` returns only intentional historical mentions.
+    — **Consumers affected:** none.
+
+### Phase 2: Make the `zai` API provider available + documented
+
+- [ ] **2.1** Confirm `zai` is a built-in OpenCode provider (no custom block needed) OR add an explicit minimal `provider.zai` entry to `opencode_app/opencode.json` using the Z.AI OpenAI-compatible endpoint (`https://api.z.ai/api/paas/v4/`) keyed off a `ZAI_API_KEY` env var.
+    — **Why:** Vision tier now resolves to `zai/glm-4.6v-flash`; without an authenticatable `zai` provider, vision agents fail with a provider-auth error instead of the model-not-found error.
+    — **Done when:** After `opencode auth login` (Z.AI) or `ZAI_API_KEY=…`, `image-analyzer-subagent` spawns without a provider/model error.
+    — **Consumers affected:** `image-analyzer-subagent`, `error-resolver-subagent`.
+
+- [ ] **2.2** Document the prerequisite in `README.md`, `opencode_app/README.md`, and the Subagent Model Tiering table in both `AGENTS.md` (repo) and `deploy/.AGENTS.md`: vision tier uses `zai/glm-4.6v-flash` (free) and requires a one-time Z.AI API auth separate from the coding-plan subscription.
+    — **Why:** Users will otherwise hit an opaque auth failure with no guidance; the tiering table currently advertises `glm-5v-turbo`.
+    — **Done when:** All four docs show `vision → zai/glm-4.6v-flash` and mention the API-key prerequisite.
+    — **Consumers affected:** end-user onboarding/deploy.
+
+### Phase 3: Add the deploy-time exposed-model guard (issue fix #3)
+
+- [ ] **3.1** Create `deploy/provider-models.json` mapping provider-prefix → exposed model id array, seeding `zai-coding-plan: [glm-4.7, glm-5-turbo, glm-5.2]` and `zai: [glm-4.6v-flash, glm-4.5-flash, glm-4.7-flash, …]` (free-tier + key Z.AI API models).
+    — **Why:** Gives the resolver a static, offline source of truth for "is this model actually served by its provider?" without a live network probe (fragile in offline/CI deploys).
+    — **Done when:** File exists, is valid JSON, and lists `glm-4.6v-flash` under `zai` and `glm-5.2` under `zai-coding-plan`.
+    — **Consumers affected:** `resolve-models.mjs` guard (3.2).
+
+- [ ] **3.2** Extend `deploy/resolve-models.mjs`: after resolving each agent model and the primary/explore/general models, split `provider/model`, look the provider up in `provider-models.json` (loaded via a new `--provider-models <file>` arg), and collect any model not in the exposed set; if non-empty, print a clear `error: tier <T> pins <model> which is not exposed by provider <P>` per offender and `process.exit(1)`. Skip when the arg is absent (back-compat) or `--force` is set.
+    — **Why:** Surfaces bad pins at deploy (fail-fast) instead of at first subagent spawn, preventing a regression like this from ever shipping silently again.
+    — **Done when:** `node deploy/resolve-models.mjs … --provider-models deploy/provider-models.json` exits non-zero when a tier is deliberately repinned to an unexposed model (verified by a temporary bad pin), and exits 0 on the corrected map.
+    — **Consumers affected:** `setup.sh`, `setup.ps1`.
+
+- [ ] **3.3** Wire the guard into `deploy/setup.sh` and `deploy/setup.ps1`: pass `--provider-models deploy/provider-models.json` to the resolver invocation (apply + dry-run paths), so every deploy runs the check.
+    — **Why:** The guard only protects users if it actually runs during their deploy flow.
+    — **Done when:** A `grep provider-models deploy/setup.sh deploy/setup.ps1` shows the flag passed on the resolver call in both scripts.
+    — **Consumers affected:** all deploys.
+
+### Phase 4: Sync docs + verify
+
+- [ ] **4.1** Update counts/listings if any changed (model-tier banner in `setup.sh`/`setup.ps1`, README tier table) and add a one-line `MIGRATION.md` note: "vision tier moved to free `zai/glm-4.6v-flash`; reasoning moved to `glm-5.2`".
+    — **Why:** Keeps the documentation-sync invariant (repo convention) intact; the migration note explains the behavior change to existing deployers.
+    — **Done when:** No doc still advertises `glm-5v-turbo`/`glm-5.1` as a current tier pin; `MIGRATION.md` has the note.
+    — **Consumers affected:** none (docs).
+
+- [ ] **4.2** Verify end-to-end: run the resolver dry-run and confirm 0 unexposed-model errors, all `reasoning` agents resolve to `zai-coding-plan/glm-5.2`, and both `vision` agents resolve to `zai/glm-4.6v-flash`; optionally spawn `image-analyzer-subagent` on a sample image once `zai` is authenticated.
+    — **Why:** Proves the defect is fixed and the guard is green before opening the PR.
+    — **Done when:** Dry-run table shows the expected models and `Summary: N written, 0 skipped(unresolved)` with no guard error.
+    — **Consumers affected:** none (verification).
+
+---
+
+## Risks & Mitigation
+
+- **Vision provider not authenticated** → vision agents fail with a *different* (auth) error. Mitigation: Phase 2.2 docs + a one-line warning in the resolver when a `zai/*` model is resolved but `ZAI_API_KEY` is absent (non-fatal hint).
+- **Mixed-provider default surprises users** → the shipped `models.default.json` now spans two Z.AI auth methods. Mitigation: this matches the existing `--mix` capability and stays "Z.AI everywhere"; documented in Phase 2.2.
+- **Guard false-positive on a legitimate new model** → deploy blocked. Mitigation: `--force` bypass and a single source file (`provider-models.json`) that's trivial to update as Z.AI exposes more models.
+- **Reasoning agents share the primary model (glm-5.2)** → slightly less specialized than glm-5.1. Mitigation: acceptable per the issue; revisit when coding plan exposes glm-5.1.
+
+## Success Metrics
+
+- All ~39 subagents spawn without a `Model not found` error.
+- `resolve-models.mjs --provider-models …` exits 0 on the corrected map and non-zero on a deliberately bad pin.
+- Zero doc/banner references advertising `glm-5.1`/`glm-5v-turbo` as current tier pins.
+
+## Dependencies
+
+- User obtains a Z.AI API key and authenticates the `zai` provider (one-time, user action) for the vision tier to function.
+

--- a/PLANS/PLAN-GIT-281.md
+++ b/PLANS/PLAN-GIT-281.md
@@ -141,29 +141,29 @@ required only because the free vision model is not on the subscription.
 
 ### Phase 3: Add the deploy-time exposed-model guard (issue fix #3)
 
-- [ ] **3.1** Create `deploy/provider-models.json` mapping provider-prefix → exposed model id array, seeding `zai-coding-plan: [glm-4.7, glm-5-turbo, glm-5.2]` and `zai: [glm-4.6v-flash, glm-4.5-flash, glm-4.7-flash, …]` (free-tier + key Z.AI API models).
+- [x] **3.1** Create `deploy/provider-models.json` mapping provider-prefix → exposed model id array, seeding `zai-coding-plan: [glm-4.7, glm-5-turbo, glm-5.2]` and `zai: [glm-4.6v-flash, glm-4.5-flash, glm-4.7-flash, …]` (free-tier + key Z.AI API models).
     — **Why:** Gives the resolver a static, offline source of truth for "is this model actually served by its provider?" without a live network probe (fragile in offline/CI deploys).
     — **Done when:** File exists, is valid JSON, and lists `glm-4.6v-flash` under `zai` and `glm-5.2` under `zai-coding-plan`.
     — **Consumers affected:** `resolve-models.mjs` guard (3.2).
 
-- [ ] **3.2** Extend `deploy/resolve-models.mjs`: after resolving each agent model **and** the primary/explore/general models (computed at `:265-288`), split `provider/model`, look the provider up in `provider-models.json` (loaded via a new `--provider-models <file>` arg), and collect any model not in the exposed set; if non-empty, print `error: tier <T> pins <model> which is not exposed by provider <P>` per offender and `process.exit(1)`. The guard MUST also validate the **source** `opencode_app/opencode.json` pins (primary + explore + general), not only per-agent tier models, so a stale source pin is caught. Edge cases: (a) a model string with no `/` → skip-with-warning (don't crash on split); (b) a provider prefix **absent** from `provider-models.json` (e.g. `anthropic`/`openai`/`openrouter` presets) → warn-and-skip (cannot validate unknown providers; avoids false-positive deploy failures). Skip the whole check when the arg is absent (back-compat) or `--force` is set (flag already exists + is wired).
+- [x] **3.2** Extend `deploy/resolve-models.mjs`: after resolving each agent model **and** the primary/explore/general models (computed at `:265-288`), split `provider/model`, look the provider up in `provider-models.json` (loaded via a new `--provider-models <file>` arg), and collect any model not in the exposed set; if non-empty, print `error: tier <T> pins <model> which is not exposed by provider <P>` per offender and `process.exit(1)`. The guard MUST also validate the **source** `opencode_app/opencode.json` pins (primary + explore + general), not only per-agent tier models, so a stale source pin is caught. Edge cases: (a) a model string with no `/` → skip-with-warning (don't crash on split); (b) a provider prefix **absent** from `provider-models.json` (e.g. `anthropic`/`openai`/`openrouter` presets) → warn-and-skip (cannot validate unknown providers; avoids false-positive deploy failures). Skip the whole check when the arg is absent (back-compat) or `--force` is set (flag already exists + is wired).
     — **Why:** Surfaces bad pins at deploy (fail-fast) instead of at first subagent spawn, preventing a regression like this from ever shipping silently again. Source-config validation closes the Docker gap (Root Cause #4).
     — **Done when:** `node deploy/resolve-models.mjs … --provider-models deploy/provider-models.json` exits non-zero when a tier is deliberately repinned to an unexposed model (verified by a temporary bad pin), and exits 0 on the corrected map; a deliberately stale `opencode_app/opencode.json` source pin is also flagged.
     — **Consumers affected:** `setup.sh`, `setup.ps1`.
 
-- [ ] **3.3** Wire the guard into `deploy/setup.sh` and `deploy/setup.ps1`: pass `--provider-models deploy/provider-models.json` to the resolver invocation (apply + dry-run paths — resolver script var at `setup.sh:98` / `setup.ps1:102`), so every deploy runs the check.
+- [x] **3.3** Wire the guard into `deploy/setup.sh`, `deploy/setup.ps1`, **and `opencode_app/Dockerfile`** (build-time RUN — added beyond the original plan since the Docker path is a deploy entrypoint per Root Cause #4): pass `--provider-models deploy/provider-models.json` to every resolver invocation (file-existence-guarded for back-compat), so every deploy runs the check.
     — **Why:** The guard only protects users if it actually runs during their deploy flow.
     — **Done when:** `grep -n provider-models deploy/setup.sh deploy/setup.ps1` shows the flag passed on the resolver call in both scripts.
     — **Consumers affected:** all deploys.
 
 ### Phase 4: Sync docs + verify
 
-- [ ] **4.1** Update counts/listings if any changed (model-tier banner in `setup.sh`/`setup.ps1` — confirmed they do NOT hardcode model names, so likely no banner edit) and add a one-line `MIGRATION.md` note: "vision tier moved to free `zai/glm-4.6v-flash`; reasoning moved to `glm-5.2`".
+- [x] **4.1** Update counts/listings if any changed (model-tier banner in `setup.sh`/`setup.ps1` — confirmed they do NOT hardcode model names, so likely no banner edit) and add a one-line `MIGRATION.md` note: "vision tier moved to free `zai/glm-4.6v-flash`; reasoning moved to `glm-5.2`".
     — **Why:** Keeps the documentation-sync invariant (repo convention) intact; the migration note explains the behavior change to existing deployers.
     — **Done when:** No doc still advertises `glm-5v-turbo`/`glm-5.1` as a current tier pin; `MIGRATION.md` has the note.
     — **Consumers affected:** none (docs).
 
-- [ ] **4.2** Verify end-to-end: run the resolver dry-run with `--provider-models` and confirm 0 unexposed-model errors, all `reasoning` agents resolve to `zai-coding-plan/glm-5.2`, and both `vision` agents resolve to `zai/glm-4.6v-flash`; confirm the source `opencode_app/opencode.json` pins pass the guard; optionally spawn `image-analyzer-subagent` on a sample image once `zai` is authenticated.
+- [x] **4.2** Verify end-to-end: run the resolver dry-run with `--provider-models` and confirm 0 unexposed-model errors, all `reasoning` agents resolve to `zai-coding-plan/glm-5.2`, and both `vision` agents resolve to `zai/glm-4.6v-flash`; confirm the source `opencode_app/opencode.json` pins pass the guard; optionally spawn `image-analyzer-subagent` on a sample image once `zai` is authenticated.
     — **Why:** Proves the defect is fixed and the guard is green before opening the PR.
     — **Done when:** Dry-run table shows the expected models, `Summary: N written, 0 skipped(unresolved)`, and no guard error (including for source-config pins).
     — **Consumers affected:** none (verification).
@@ -207,3 +207,8 @@ required only because the free vision model is not on the subscription.
 - Phase 1 complete: all tier-map sources + hardcoded pins repointed; residual grep clean except the AGENTS.md tier table (fixed in 2.2).
 - **Phase 2.1 deviation:** `zai` confirmed **built-in** via `docker-entrypoint.sh:18` (`auth["zai"]` write) + existing `{env:ZAI_API_KEY}` interpolation in `opencode.json` — **no custom `provider.zai` block added** (would conflict with built-in). Corrects the plan's original hedge.
 - Phase 2.2 complete: AGENTS.md tier table updated (reasoning→`glm-5.2`, vision→`zai/glm-4.6v-flash`) + vision-auth prerequisite note; README note added.
+
+**2026-08-02 (execution — Phase 3+4 applied, COMPLETE)** —
+- Phase 3 complete: `deploy/provider-models.json` created; exposed-model guard added to `resolve-models.mjs` (`--provider-models`, fail-fast exit 1, warn-skip for no-slash/unknown-provider, `--force` bypass, back-compat when absent); wired into `setup.sh`, `setup.ps1`, **and `opencode_app/Dockerfile`** (file-existence-guarded). Verified: corrected map → exit 0; deliberately-bad tier pin → exit 1; bad source-config pin → exit 1; `--force` → bypass; no-arg → back-compat.
+- Phase 4 complete: MIGRATION.md note added; setup banners need no edit (confirmed they don't hardcode model names).
+- **End-to-end verified:** all 38 agents resolve to provider-exposed models (reasoning×18→`glm-5.2`, vision×2→`zai/glm-4.6v-flash`, fast×12, docs×3, long-context×3, primary/explore/general); guard green; zero stale `glm-5.1`/`glm-5v-turbo` pins outside `provider-models.json` (the legitimate `zai` API catalog) and the PLAN before/after table.

--- a/PLANS/PLAN-GIT-281.md
+++ b/PLANS/PLAN-GIT-281.md
@@ -1,22 +1,24 @@
-# PLAN-GIT-281: Fix models.default.json tier→model pins the zai-coding-plan provider doesn't expose (~20 subagents fail to spawn)
+# PLAN-GIT-281: Fix models.default.json tier→model pins the zai-coding-plan provider doesn't expose (20 of 38 subagents fail to spawn)
 
 **Issue**: https://github.com/darellchua2/opencode-config-template/issues/281
 **Branch**: `GIT-281`
 **Created**: 2026-08-02
+**Revised**: 2026-08-02 (incorporates opencode-tooling review — see Revision Log)
 
 ## Problem
 
 `deploy/models.default.json` maps the **`reasoning`** and **`vision`** tiers to models
 the configured `zai-coding-plan` provider does **not** expose, so every subagent on those
 two tiers fails to spawn at runtime with `Model not found`. The agent `.md` sources are
-model-free and compliant — the defect is purely in the tier→model map.
+model-free and compliant — the defect is purely in the tier→model map (plus a few stale
+hardcoded pins — see Root Cause #4).
 
 - `reasoning` → `zai-coding-plan/glm-5.1`   not exposed (coding plan exposes only `glm-4.7`, `glm-5-turbo`, `glm-5.2`) → **18 agents** fail
 - `vision` → `zai-coding-plan/glm-5v-turbo`  not exposed (no vision model is on the coding-plan subscription) → **2 agents** fail
 
-**~20 of ~39 subagents are non-functional**, blocking all code/architecture reviews,
-requirements/discovery work, ticket-creation chains that delegate to reviewers, and all
-image/screenshot analysis.
+**20 of 38 subagents are non-functional** (the issue's "~20 of ~39" rounds the 38 total),
+blocking all code/architecture reviews, requirements/discovery work, ticket-creation chains
+that delegate to reviewers, and all image/screenshot analysis.
 
 ## Root Cause (verified)
 
@@ -27,6 +29,11 @@ image/screenshot analysis.
    provider (`zai`), authenticated by a separate Z.AI API key — not on the coding-plan subscription.
 3. `resolve-models.mjs` performs **no validation** that a resolved tier model is actually
    exposed by its provider, so the bad pins surfaced at first subagent spawn instead of at deploy.
+4. **Stale hardcoded pins** (not caught by the original plan — found in review): the `general`
+   built-in agent is pinned `zai-coding-plan/glm-5.1` in `opencode_app/opencode.json:401`
+   (used directly by the **Docker standalone** path, which does not run the resolver), and the
+   `opencode-agent-creation-skill` teaches the broken `glm-5.1`/`glm-5v-turbo` pins — a
+   propagation source that re-creates the bug on every agent it generates.
 
 ## Model Selection (authoritative source: https://docs.z.ai/guides/overview/pricing)
 
@@ -40,7 +47,7 @@ source of truth.
 
 | Vision model   | Price (in/out per 1M) | Chosen? |
 | --------------- | --------------------: | :-----: |
-| GLM-4.6V-Flash  | **Free / Free**       |       |
+| GLM-4.6V-Flash  | **Free / Free**       |    ✓    |
 | GLM-4.6V-FlashX | $0.04 / $0.40         |         |
 | GLM-4.6V        | $0.30 / $0.90         |         |
 | GLM-4.5V        | $0.60 / $1.80         |         |
@@ -75,21 +82,28 @@ required only because the free vision model is not on the subscription.
 | ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------ | ----------- |
 | `deploy/models.default.json`             | —                         | `resolve-models.mjs` (reads tier map); `provider-presets.json` mirrors it | low         |
 | `deploy/provider-presets.json`           | —                         | `setup.sh --provider/--mix` (writes user `models.json`); `resolve-models.mjs --provider` | low |
+| `opencode_app/opencode.json:401` (`general`) | —                     | Docker standalone uses it **directly** (no resolver); user-space deploy is patched by resolver | low |
+| `opencode_app/opencode.json` (`provider.zai` block) | —          | vision agent spawn needs `zai` provider resolvable + authed              | med (auth)  |
+| `opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md` | — | generates new agents — stale pins propagate the bug                  | low         |
 | `deploy/provider-models.json` (NEW)      | —                         | `resolve-models.mjs` guard (validates exposed set)                       | low         |
 | `deploy/resolve-models.mjs`              | `provider-models.json` (Phase 3) | `deploy/setup.sh`, `deploy/setup.ps1` (invoke at deploy)            | med (logic) |
 | `deploy/setup.sh` / `setup.ps1`          | resolver changes          | end-user deploy                                                          | low         |
-| `opencode_app/opencode.json`             | —                         | vision agent spawn needs `zai` provider resolvable (built-in)            | low         |
-| `README.md` / `opencode_app/README.md`   | tier-map changes          | user docs                                                                | low         |
-| `AGENTS.md` (repo) + `deploy/.AGENTS.md` | tier-map changes          | agent routing docs (tier table)                                          | low         |
+| `AGENTS.md` (repo root, lines 26-43)     | tier-map changes          | **only file** with the Subagent Model Tiering table                      | low         |
+| `README.md` / `opencode_app/README.md`   | tier-map changes          | user docs (verify `opencode_app/README.md` has tier content first)       | low         |
+| `deploy/.AGENTS.md`                      | —                         | routing/rules only — **NO tier table, NO model refs**; optional auth note at line 16 | low |
+
+> **Note:** `deploy/.AGENTS.md` (92 lines) contains only routing/rules sections and references
+> `image-analyzer-subagent` solely at line 16 (delegation routing). It has no model-tier table,
+> so it is **not** a tier-table edit target — at most it gets an optional one-line `zai` auth note.
 
 ---
 
 ## Implementation Phases
 
-### Phase 1: Repoint broken tiers
+### Phase 1: Repoint broken tiers + stale hardcoded pins
 
 - [ ] **1.1** Edit `deploy/models.default.json`: set `tiers.reasoning` → `zai-coding-plan/glm-5.2` and `tiers.vision` → `zai/glm-4.6v-flash`; keep `primary`/`fast`/`docs`/`long-context` unchanged; refresh `$comment` if it mentions glm-5.1/glm-5v-turbo.
-    — **Why:** These two pins are the defect; all other tiers are exposed and working.
+    — **Why:** These two pins are the core defect; all other tiers are exposed and working.
     — **Done when:** `node -e "console.log(Object.entries(require('./deploy/models.default.json').tiers))"` prints no `glm-5.1`/`glm-5v-turbo`.
     — **Consumers affected:** `resolve-models.mjs`, `provider-presets.json` (mirrored next).
 
@@ -98,21 +112,31 @@ required only because the free vision model is not on the subscription.
     — **Done when:** `jq '.zai.tiers' deploy/provider-presets.json` shows the two new values and no glm-5.1/glm-5v-turbo.
     — **Consumers affected:** `setup.sh --provider/--mix`, `resolve-models.mjs --provider`.
 
-- [ ] **1.3** Grep the whole repo for residual `glm-5.1` / `glm-5v-turbo` references in deploy/config/docs; repoint or annotate any found (excluding `MIGRATION.md` history notes).
-    — **Why:** A stale reference anywhere (banner, help text, AGENTS table) would mislead users or re-break a re-resolve.
-    — **Done when:** `rg -n 'glm-5\.1|glm-5v-turbo' deploy/ opencode_app/ README.md AGENTS.md MIGRATION.md` returns only intentional historical mentions.
-    — **Consumers affected:** none.
+- [ ] **1.3** Repoint the `general` built-in agent in `opencode_app/opencode.json:401` from `zai-coding-plan/glm-5.1` → `zai-coding-plan/glm-5.2` (leave `explore` at `:392` = `glm-5-turbo`, already correct; leave top-level `model` at `:3` = `glm-5.2`).
+    — **Why:** The Docker standalone path consumes this source file directly without running the resolver, so the `general` agent stays broken in Docker unless the source pin is fixed. (User-space deploy is patched at runtime by the resolver, but the source must be correct for Docker parity.)
+    — **Done when:** `grep -n '"model"' opencode_app/opencode.json` shows `glm-5.2`, `glm-5-turbo`, `glm-5.2` (no `glm-5.1`).
+    — **Consumers affected:** Docker standalone `general` agent; user-space `general` (already patched, now source-consistent).
+
+- [ ] **1.4** Repoint the stale pins in `opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md`: update the 4 `glm-5.1` references (lines 54, 81, 153, 387) and the `glm-5v-turbo` reference (line 54) to the new tier models (`reasoning`→`glm-5.2`, `vision`→`zai/glm-4.6v-flash`).
+    — **Why:** This skill **generates new agents**; leaving it stale re-creates the bug on every agent it produces — a propagation source, not a passive doc.
+    — **Done when:** `grep -nE 'glm-5\.1|glm-5v-turbo' opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md` returns nothing.
+    — **Consumers affected:** all future agents created via this skill.
+
+- [ ] **1.5** Sweep for remaining stale references and **edit** (not annotate) any runtime/prose/doc hit: at minimum `technical-design-specialist-subagent.md:54` ("runs at `glm-5.1`" → `glm-5.2` or make model-agnostic) and `README.md:461` ("(glm-5.1)" → `glm-5.2`). `MIGRATION.md:133` is an *example* block — update for consistency (optional but recommended); other MIGRATION.md mentions are historical and left as-is.
+    — **Why:** A stale reference anywhere (banner, help text, agent prose, README) misleads users or contradicts the live config; prose like "runs at glm-5.1" is factually wrong post-repoint.
+    — **Done when:** `grep -rn --exclude-dir=.git -E 'glm-5\.1|glm-5v-turbo' .` returns only intentional historical mentions in `MIGRATION.md` (and the PLAN's own before/after table).
+    — **Consumers affected:** none (docs/prose consistency).
 
 ### Phase 2: Make the `zai` API provider available + documented
 
-- [ ] **2.1** Confirm `zai` is a built-in OpenCode provider (no custom block needed) OR add an explicit minimal `provider.zai` entry to `opencode_app/opencode.json` using the Z.AI OpenAI-compatible endpoint (`https://api.z.ai/api/paas/v4/`) keyed off a `ZAI_API_KEY` env var.
-    — **Why:** Vision tier now resolves to `zai/glm-4.6v-flash`; without an authenticatable `zai` provider, vision agents fail with a provider-auth error instead of the model-not-found error.
-    — **Done when:** After `opencode auth login` (Z.AI) or `ZAI_API_KEY=…`, `image-analyzer-subagent` spawns without a provider/model error.
+- [ ] **2.1** Add an explicit `provider.zai` block to `opencode_app/opencode.json` using the Z.AI OpenAI-compatible endpoint (`npm: "@ai-sdk/openai-compatible"`, `baseURL: "https://api.z.ai/api/paas/v4/"`, `apiKey` from `$ZAI_API_KEY`). Confirm the provider id + base URL at execution via `opencode auth login`'s provider list or the Z.AI OpenAI-SDK doc page before writing.
+    — **Why:** Whether `zai` is a built-in OpenCode provider is unconfirmed (the config currently only declares `lmstudio` as custom; `zai-coding-plan` is built-in but serves no vision model). An **explicit block works regardless** of built-in status and is self-documenting — the robust default. Vision tier resolves to `zai/glm-4.6v-flash`; without an authenticatable `zai` provider, vision agents fail with a provider-auth error instead of model-not-found.
+    — **Done when:** After `opencode auth login` (Z.AI) or `ZAI_API_KEY=…`, `image-analyzer-subagent` spawns without a provider/model error; `provider.zai` block is present in `opencode_app/opencode.json`.
     — **Consumers affected:** `image-analyzer-subagent`, `error-resolver-subagent`.
 
-- [ ] **2.2** Document the prerequisite in `README.md`, `opencode_app/README.md`, and the Subagent Model Tiering table in both `AGENTS.md` (repo) and `deploy/.AGENTS.md`: vision tier uses `zai/glm-4.6v-flash` (free) and requires a one-time Z.AI API auth separate from the coding-plan subscription.
-    — **Why:** Users will otherwise hit an opaque auth failure with no guidance; the tiering table currently advertises `glm-5v-turbo`.
-    — **Done when:** All four docs show `vision → zai/glm-4.6v-flash` and mention the API-key prerequisite.
+- [ ] **2.2** Document the prerequisite in `README.md`, repo-root `AGENTS.md` (the **only** file with the Subagent Model Tiering table, lines 26-43), and `opencode_app/README.md` (verify it has tier content first; if not, skip). State: vision tier uses `zai/glm-4.6v-flash` (free) and requires a one-time Z.AI API auth separate from the coding-plan subscription. **Do NOT** edit `deploy/.AGENTS.md` for a tier table (it has none) — optionally add a one-line `zai` auth note near `deploy/.AGENTS.md:16` where image-analysis routing to `image-analyzer-subagent` is mentioned.
+    — **Why:** Users will otherwise hit an opaque auth failure with no guidance; the repo tier table currently advertises `glm-5v-turbo`. (`deploy/.AGENTS.md` was incorrectly listed as a tier-table target in the original plan — corrected: it has no model/tier content.)
+    — **Done when:** Repo `AGENTS.md` + `README.md` (and `opencode_app/README.md` if applicable) show `vision → zai/glm-4.6v-flash` and mention the API-key prerequisite; no file falsely claims `deploy/.AGENTS.md` has a tier table.
     — **Consumers affected:** end-user onboarding/deploy.
 
 ### Phase 3: Add the deploy-time exposed-model guard (issue fix #3)
@@ -122,26 +146,26 @@ required only because the free vision model is not on the subscription.
     — **Done when:** File exists, is valid JSON, and lists `glm-4.6v-flash` under `zai` and `glm-5.2` under `zai-coding-plan`.
     — **Consumers affected:** `resolve-models.mjs` guard (3.2).
 
-- [ ] **3.2** Extend `deploy/resolve-models.mjs`: after resolving each agent model and the primary/explore/general models, split `provider/model`, look the provider up in `provider-models.json` (loaded via a new `--provider-models <file>` arg), and collect any model not in the exposed set; if non-empty, print a clear `error: tier <T> pins <model> which is not exposed by provider <P>` per offender and `process.exit(1)`. Skip when the arg is absent (back-compat) or `--force` is set.
-    — **Why:** Surfaces bad pins at deploy (fail-fast) instead of at first subagent spawn, preventing a regression like this from ever shipping silently again.
-    — **Done when:** `node deploy/resolve-models.mjs … --provider-models deploy/provider-models.json` exits non-zero when a tier is deliberately repinned to an unexposed model (verified by a temporary bad pin), and exits 0 on the corrected map.
+- [ ] **3.2** Extend `deploy/resolve-models.mjs`: after resolving each agent model **and** the primary/explore/general models (computed at `:265-288`), split `provider/model`, look the provider up in `provider-models.json` (loaded via a new `--provider-models <file>` arg), and collect any model not in the exposed set; if non-empty, print `error: tier <T> pins <model> which is not exposed by provider <P>` per offender and `process.exit(1)`. The guard MUST also validate the **source** `opencode_app/opencode.json` pins (primary + explore + general), not only per-agent tier models, so a stale source pin is caught. Edge cases: (a) a model string with no `/` → skip-with-warning (don't crash on split); (b) a provider prefix **absent** from `provider-models.json` (e.g. `anthropic`/`openai`/`openrouter` presets) → warn-and-skip (cannot validate unknown providers; avoids false-positive deploy failures). Skip the whole check when the arg is absent (back-compat) or `--force` is set (flag already exists + is wired).
+    — **Why:** Surfaces bad pins at deploy (fail-fast) instead of at first subagent spawn, preventing a regression like this from ever shipping silently again. Source-config validation closes the Docker gap (Root Cause #4).
+    — **Done when:** `node deploy/resolve-models.mjs … --provider-models deploy/provider-models.json` exits non-zero when a tier is deliberately repinned to an unexposed model (verified by a temporary bad pin), and exits 0 on the corrected map; a deliberately stale `opencode_app/opencode.json` source pin is also flagged.
     — **Consumers affected:** `setup.sh`, `setup.ps1`.
 
-- [ ] **3.3** Wire the guard into `deploy/setup.sh` and `deploy/setup.ps1`: pass `--provider-models deploy/provider-models.json` to the resolver invocation (apply + dry-run paths), so every deploy runs the check.
+- [ ] **3.3** Wire the guard into `deploy/setup.sh` and `deploy/setup.ps1`: pass `--provider-models deploy/provider-models.json` to the resolver invocation (apply + dry-run paths — resolver script var at `setup.sh:98` / `setup.ps1:102`), so every deploy runs the check.
     — **Why:** The guard only protects users if it actually runs during their deploy flow.
-    — **Done when:** A `grep provider-models deploy/setup.sh deploy/setup.ps1` shows the flag passed on the resolver call in both scripts.
+    — **Done when:** `grep -n provider-models deploy/setup.sh deploy/setup.ps1` shows the flag passed on the resolver call in both scripts.
     — **Consumers affected:** all deploys.
 
 ### Phase 4: Sync docs + verify
 
-- [ ] **4.1** Update counts/listings if any changed (model-tier banner in `setup.sh`/`setup.ps1`, README tier table) and add a one-line `MIGRATION.md` note: "vision tier moved to free `zai/glm-4.6v-flash`; reasoning moved to `glm-5.2`".
+- [ ] **4.1** Update counts/listings if any changed (model-tier banner in `setup.sh`/`setup.ps1` — confirmed they do NOT hardcode model names, so likely no banner edit) and add a one-line `MIGRATION.md` note: "vision tier moved to free `zai/glm-4.6v-flash`; reasoning moved to `glm-5.2`".
     — **Why:** Keeps the documentation-sync invariant (repo convention) intact; the migration note explains the behavior change to existing deployers.
     — **Done when:** No doc still advertises `glm-5v-turbo`/`glm-5.1` as a current tier pin; `MIGRATION.md` has the note.
     — **Consumers affected:** none (docs).
 
-- [ ] **4.2** Verify end-to-end: run the resolver dry-run and confirm 0 unexposed-model errors, all `reasoning` agents resolve to `zai-coding-plan/glm-5.2`, and both `vision` agents resolve to `zai/glm-4.6v-flash`; optionally spawn `image-analyzer-subagent` on a sample image once `zai` is authenticated.
+- [ ] **4.2** Verify end-to-end: run the resolver dry-run with `--provider-models` and confirm 0 unexposed-model errors, all `reasoning` agents resolve to `zai-coding-plan/glm-5.2`, and both `vision` agents resolve to `zai/glm-4.6v-flash`; confirm the source `opencode_app/opencode.json` pins pass the guard; optionally spawn `image-analyzer-subagent` on a sample image once `zai` is authenticated.
     — **Why:** Proves the defect is fixed and the guard is green before opening the PR.
-    — **Done when:** Dry-run table shows the expected models and `Summary: N written, 0 skipped(unresolved)` with no guard error.
+    — **Done when:** Dry-run table shows the expected models, `Summary: N written, 0 skipped(unresolved)`, and no guard error (including for source-config pins).
     — **Consumers affected:** none (verification).
 
 ---
@@ -149,17 +173,32 @@ required only because the free vision model is not on the subscription.
 ## Risks & Mitigation
 
 - **Vision provider not authenticated** → vision agents fail with a *different* (auth) error. Mitigation: Phase 2.2 docs + a one-line warning in the resolver when a `zai/*` model is resolved but `ZAI_API_KEY` is absent (non-fatal hint).
+- **`zai` provider id / base URL wrong** → explicit block doesn't connect. Mitigation: Phase 2.1 confirms via `opencode auth login` provider list / Z.AI OpenAI-SDK doc before writing; explicit block is still safer than relying on an unconfirmed built-in.
 - **Mixed-provider default surprises users** → the shipped `models.default.json` now spans two Z.AI auth methods. Mitigation: this matches the existing `--mix` capability and stays "Z.AI everywhere"; documented in Phase 2.2.
-- **Guard false-positive on a legitimate new model** → deploy blocked. Mitigation: `--force` bypass and a single source file (`provider-models.json`) that's trivial to update as Z.AI exposes more models.
+- **Guard false-positive on a legitimate new model / unknown provider** → deploy blocked. Mitigation: warn-and-skip for unknown provider prefixes; `--force` bypass; single source file (`provider-models.json`) trivial to update as Z.AI exposes more models; `knownDefaults` preserve logic (`resolve-models.mjs:210-211,247`) is unaffected since new model strings are just different values, not new keys.
 - **Reasoning agents share the primary model (glm-5.2)** → slightly less specialized than glm-5.1. Mitigation: acceptable per the issue; revisit when coding plan exposes glm-5.1.
 
 ## Success Metrics
 
-- All ~39 subagents spawn without a `Model not found` error.
-- `resolve-models.mjs --provider-models …` exits 0 on the corrected map and non-zero on a deliberately bad pin.
-- Zero doc/banner references advertising `glm-5.1`/`glm-5v-turbo` as current tier pins.
+- All 38 subagents spawn without a `Model not found` error.
+- `resolve-models.mjs --provider-models …` exits 0 on the corrected map (incl. source `opencode_app/opencode.json` pins) and non-zero on a deliberately bad pin.
+- Zero doc/banner/prose references advertising `glm-5.1`/`glm-5v-turbo` as current tier pins (except intentional `MIGRATION.md` history).
 
 ## Dependencies
 
 - User obtains a Z.AI API key and authenticates the `zai` provider (one-time, user action) for the vision tier to function.
 
+---
+
+## Revision Log
+
+**2026-08-02 (post opencode-tooling review)** — review could not delegate to `opencode-tooling-subagent`
+(reasoning-tier victim of #281 itself); performed in primary session. Findings applied:
+- **M1** (new 1.3): repoint `general` pin at `opencode_app/opencode.json:401` (Docker uses source directly).
+- **M2** (new 1.4): repoint stale pins in `opencode-agent-creation-skill/SKILL.md` (propagation source).
+- **M3** (2.2 + map): `deploy/.AGENTS.md` has no tier table — removed as a tier-table target; optional auth note at its line 16 instead.
+- **M4** (2.1): resolved the `zai` built-in-vs-custom hedge → add an explicit `provider.zai` block (robust default), confirm id/URL at execution.
+- **m1/m2** (1.5): `technical-design-specialist-subagent.md:54` prose + `README.md:461` edited, not annotated.
+- **m3/m4** (3.2): guard edge cases (no-slash model, unknown provider → warn-skip) + source-config pin validation.
+- **n1**: counts corrected to 38 total / 20 broken.
+- **n2**: `MIGRATION.md:133` example block flagged for optional update.

--- a/PLANS/PLAN-GIT-281.md
+++ b/PLANS/PLAN-GIT-281.md
@@ -102,39 +102,39 @@ required only because the free vision model is not on the subscription.
 
 ### Phase 1: Repoint broken tiers + stale hardcoded pins
 
-- [ ] **1.1** Edit `deploy/models.default.json`: set `tiers.reasoning` → `zai-coding-plan/glm-5.2` and `tiers.vision` → `zai/glm-4.6v-flash`; keep `primary`/`fast`/`docs`/`long-context` unchanged; refresh `$comment` if it mentions glm-5.1/glm-5v-turbo.
+- [x] **1.1** Edit `deploy/models.default.json`: set `tiers.reasoning` → `zai-coding-plan/glm-5.2` and `tiers.vision` → `zai/glm-4.6v-flash`; keep `primary`/`fast`/`docs`/`long-context` unchanged; refresh `$comment` if it mentions glm-5.1/glm-5v-turbo.
     — **Why:** These two pins are the core defect; all other tiers are exposed and working.
     — **Done when:** `node -e "console.log(Object.entries(require('./deploy/models.default.json').tiers))"` prints no `glm-5.1`/`glm-5v-turbo`.
     — **Consumers affected:** `resolve-models.mjs`, `provider-presets.json` (mirrored next).
 
-- [ ] **1.2** Edit `deploy/provider-presets.json` `zai` preset: set `tiers.reasoning` → `zai-coding-plan/glm-5.2` and `tiers.vision` → `zai/glm-4.6v-flash` to mirror `models.default.json`.
+- [x] **1.2** Edit `deploy/provider-presets.json` `zai` preset: set `tiers.reasoning` → `zai-coding-plan/glm-5.2` and `tiers.vision` → `zai/glm-4.6v-flash` to mirror `models.default.json`.
     — **Why:** The `--provider zai` / `--mix` flows write user `models.json` from this preset; it must not reintroduce the bad pins.
     — **Done when:** `jq '.zai.tiers' deploy/provider-presets.json` shows the two new values and no glm-5.1/glm-5v-turbo.
     — **Consumers affected:** `setup.sh --provider/--mix`, `resolve-models.mjs --provider`.
 
-- [ ] **1.3** Repoint the `general` built-in agent in `opencode_app/opencode.json:401` from `zai-coding-plan/glm-5.1` → `zai-coding-plan/glm-5.2` (leave `explore` at `:392` = `glm-5-turbo`, already correct; leave top-level `model` at `:3` = `glm-5.2`).
+- [x] **1.3** Repoint the `general` built-in agent in `opencode_app/opencode.json:401` from `zai-coding-plan/glm-5.1` → `zai-coding-plan/glm-5.2` (leave `explore` at `:392` = `glm-5-turbo`, already correct; leave top-level `model` at `:3` = `glm-5.2`).
     — **Why:** The Docker standalone path consumes this source file directly without running the resolver, so the `general` agent stays broken in Docker unless the source pin is fixed. (User-space deploy is patched at runtime by the resolver, but the source must be correct for Docker parity.)
     — **Done when:** `grep -n '"model"' opencode_app/opencode.json` shows `glm-5.2`, `glm-5-turbo`, `glm-5.2` (no `glm-5.1`).
     — **Consumers affected:** Docker standalone `general` agent; user-space `general` (already patched, now source-consistent).
 
-- [ ] **1.4** Repoint the stale pins in `opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md`: update the 4 `glm-5.1` references (lines 54, 81, 153, 387) and the `glm-5v-turbo` reference (line 54) to the new tier models (`reasoning`→`glm-5.2`, `vision`→`zai/glm-4.6v-flash`).
+- [x] **1.4** Repoint the stale pins in `opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md`: update the 4 `glm-5.1` references (lines 54, 81, 153, 387) and the `glm-5v-turbo` reference (line 54) to the new tier models (`reasoning`→`glm-5.2`, `vision`→`zai/glm-4.6v-flash`).
     — **Why:** This skill **generates new agents**; leaving it stale re-creates the bug on every agent it produces — a propagation source, not a passive doc.
     — **Done when:** `grep -nE 'glm-5\.1|glm-5v-turbo' opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md` returns nothing.
     — **Consumers affected:** all future agents created via this skill.
 
-- [ ] **1.5** Sweep for remaining stale references and **edit** (not annotate) any runtime/prose/doc hit: at minimum `technical-design-specialist-subagent.md:54` ("runs at `glm-5.1`" → `glm-5.2` or make model-agnostic) and `README.md:461` ("(glm-5.1)" → `glm-5.2`). `MIGRATION.md:133` is an *example* block — update for consistency (optional but recommended); other MIGRATION.md mentions are historical and left as-is.
+- [x] **1.5** Sweep for remaining stale references and **edit** (not annotate) any runtime/prose/doc hit: at minimum `technical-design-specialist-subagent.md:54` ("runs at `glm-5.1`" → `glm-5.2` or make model-agnostic) and `README.md:461` ("(glm-5.1)" → `glm-5.2`). `MIGRATION.md:133` is an *example* block — update for consistency (optional but recommended); other MIGRATION.md mentions are historical and left as-is.
     — **Why:** A stale reference anywhere (banner, help text, agent prose, README) misleads users or contradicts the live config; prose like "runs at glm-5.1" is factually wrong post-repoint.
     — **Done when:** `grep -rn --exclude-dir=.git -E 'glm-5\.1|glm-5v-turbo' .` returns only intentional historical mentions in `MIGRATION.md` (and the PLAN's own before/after table).
     — **Consumers affected:** none (docs/prose consistency).
 
 ### Phase 2: Make the `zai` API provider available + documented
 
-- [ ] **2.1** Add an explicit `provider.zai` block to `opencode_app/opencode.json` using the Z.AI OpenAI-compatible endpoint (`npm: "@ai-sdk/openai-compatible"`, `baseURL: "https://api.z.ai/api/paas/v4/"`, `apiKey` from `$ZAI_API_KEY`). Confirm the provider id + base URL at execution via `opencode auth login`'s provider list or the Z.AI OpenAI-SDK doc page before writing.
-    — **Why:** Whether `zai` is a built-in OpenCode provider is unconfirmed (the config currently only declares `lmstudio` as custom; `zai-coding-plan` is built-in but serves no vision model). An **explicit block works regardless** of built-in status and is self-documenting — the robust default. Vision tier resolves to `zai/glm-4.6v-flash`; without an authenticatable `zai` provider, vision agents fail with a provider-auth error instead of model-not-found.
-    — **Done when:** After `opencode auth login` (Z.AI) or `ZAI_API_KEY=…`, `image-analyzer-subagent` spawns without a provider/model error; `provider.zai` block is present in `opencode_app/opencode.json`.
+- [x] **2.1** **CONFIRMED `zai` is built-in — no custom block needed (deviation from plan hedge).** Evidence: `opencode_app/docker-entrypoint.sh:18` writes opencode's auth store `auth["zai"]={"type":"api","key":ZAI_API_KEY}` (same mechanism as `opencode auth login`); `opencode_app/opencode.json` already interpolates `{env:ZAI_API_KEY}` for MCP servers (lines 164-189); `.env.example:3` + `setup.sh` (lines 1890-1921) + `docker-entrypoint.sh` already wire `ZAI_API_KEY` end-to-end. The resolver injects `zai/glm-4.6v-flash`, the built-in `zai` provider serves it (Z.AI OpenAI-compatible endpoint `https://api.z.ai/api/paas/v4/`, per docs.z.ai). Adding a `provider.zai` block would conflict with the built-in, so this step is a no-op.
+    — **Why:** The plan hedged "built-in OR add block"; execution evidence resolves it to built-in → no block, avoiding a conflicting custom-provider override.
+    — **Done when:** (Met) `zai` confirmed built-in via the entrypoint auth-write + existing `{env:ZAI_API_KEY}` usage; no `provider.zai` block added; auth prerequisite documented in 2.2.
     — **Consumers affected:** `image-analyzer-subagent`, `error-resolver-subagent`.
 
-- [ ] **2.2** Document the prerequisite in `README.md`, repo-root `AGENTS.md` (the **only** file with the Subagent Model Tiering table, lines 26-43), and `opencode_app/README.md` (verify it has tier content first; if not, skip). State: vision tier uses `zai/glm-4.6v-flash` (free) and requires a one-time Z.AI API auth separate from the coding-plan subscription. **Do NOT** edit `deploy/.AGENTS.md` for a tier table (it has none) — optionally add a one-line `zai` auth note near `deploy/.AGENTS.md:16` where image-analysis routing to `image-analyzer-subagent` is mentioned.
+- [x] **2.2** Document the prerequisite in `README.md`, repo-root `AGENTS.md` (the **only** file with the Subagent Model Tiering table, lines 26-43), and `opencode_app/README.md` (verify it has tier content first; if not, skip). State: vision tier uses `zai/glm-4.6v-flash` (free) and requires a one-time Z.AI API auth separate from the coding-plan subscription. **Do NOT** edit `deploy/.AGENTS.md` for a tier table (it has none) — optionally add a one-line `zai` auth note near `deploy/.AGENTS.md:16` where image-analysis routing to `image-analyzer-subagent` is mentioned.
     — **Why:** Users will otherwise hit an opaque auth failure with no guidance; the repo tier table currently advertises `glm-5v-turbo`. (`deploy/.AGENTS.md` was incorrectly listed as a tier-table target in the original plan — corrected: it has no model/tier content.)
     — **Done when:** Repo `AGENTS.md` + `README.md` (and `opencode_app/README.md` if applicable) show `vision → zai/glm-4.6v-flash` and mention the API-key prerequisite; no file falsely claims `deploy/.AGENTS.md` has a tier table.
     — **Consumers affected:** end-user onboarding/deploy.
@@ -202,3 +202,8 @@ required only because the free vision model is not on the subscription.
 - **m3/m4** (3.2): guard edge cases (no-slash model, unknown provider → warn-skip) + source-config pin validation.
 - **n1**: counts corrected to 38 total / 20 broken.
 - **n2**: `MIGRATION.md:133` example block flagged for optional update.
+
+**2026-08-02 (execution — Phase 1+2 applied)** —
+- Phase 1 complete: all tier-map sources + hardcoded pins repointed; residual grep clean except the AGENTS.md tier table (fixed in 2.2).
+- **Phase 2.1 deviation:** `zai` confirmed **built-in** via `docker-entrypoint.sh:18` (`auth["zai"]` write) + existing `{env:ZAI_API_KEY}` interpolation in `opencode.json` — **no custom `provider.zai` block added** (would conflict with built-in). Corrects the plan's original hedge.
+- Phase 2.2 complete: AGENTS.md tier table updated (reasoning→`glm-5.2`, vision→`zai/glm-4.6v-flash`) + vision-auth prerequisite note; README note added.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Override files (precedence highest-first; see `MIGRATION.md`):
 | `~/.config/opencode/models.json` | tier map, global (written by `--provider`) |
 | `deploy/models.default.json` | Z.AI defaults |
 
+> **Vision tier (Z.AI):** uses `zai/glm-4.6v-flash` (free), served by the `zai` API
+> provider — separate from the `zai-coding-plan` subscription. Requires
+> `opencode auth login` (Z.AI) or `ZAI_API_KEY` (auto-injected in Docker via
+> `docker-entrypoint.sh`). See `AGENTS.md` § Subagent Model Tiering.
+
 ### Windows (PowerShell)
 
 ```powershell
@@ -458,7 +463,7 @@ This repository implements **skill modularization** with 123 skills organized ac
 | **pr-workflow-subagent** | Pull request creation | pr-creation-workflow, nextjs-pr-workflow | `explore`, `general` |
 | **discovery-specialist-subagent** | Customer-facing discovery: Vision docs + wireframes | vision-creation-skill | `explore`, `image-analyzer-subagent`, `xlsx-specialist-subagent` |
 | **requirements-specialist-subagent** | BRD + SRS drafting (BABOK/IIBA + IEEE 830) | brd-creation-skill, srs-creation-skill | `explore`, `image-analyzer-subagent`, `xlsx-specialist-subagent` |
-| **technical-design-specialist-subagent** | Technical design + ADRs (engineering 'how' stage, glm-5.1) | technical-design-creation-skill | `explore`, `image-analyzer-subagent`, `architecture-review-subagent` |
+| **technical-design-specialist-subagent** | Technical design + ADRs (engineering 'how' stage) | technical-design-creation-skill | `explore`, `image-analyzer-subagent`, `architecture-review-subagent` |
 | **documentation-subagent** | Documentation generation | docstring-generator, coverage-readme-workflow | — |
 | **coverage-subagent** | Coverage reporting | coverage-readme-workflow | — |
 | **opentofu-explorer-subagent** | Infrastructure as code | 7 OpenTofu skills (AWS, K8s, Keycloak, Neon, ECR) | — |

--- a/deploy/models.default.json
+++ b/deploy/models.default.json
@@ -2,10 +2,10 @@
   "$comment": "Canonical default tier->model map (z.ai). Used when no user override (models.json) or per-agent override (agent-overrides.json) applies. `primary` is the orchestrator model patched into opencode.json top-level `model` plus the explore/general built-in agents — subagents never use the `primary` tier directly. `long-context` shares the same model as `primary` (1M ctx) but is the designated tier for large-context subagents (autoresearch research/code/ml loops). Shipped with the repo; do not edit to personalize - create ~/.config/opencode/models.json instead.",
   "primary": "zai-coding-plan/glm-5.2",
   "tiers": {
-    "reasoning": "zai-coding-plan/glm-5.1",
+    "reasoning": "zai-coding-plan/glm-5.2",
     "fast": "zai-coding-plan/glm-5-turbo",
     "docs": "zai-coding-plan/glm-4.7",
-    "vision": "zai-coding-plan/glm-5v-turbo",
+    "vision": "zai/glm-4.6v-flash",
     "long-context": "zai-coding-plan/glm-5.2"
   }
 }

--- a/deploy/provider-models.json
+++ b/deploy/provider-models.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Provider-prefix -> exposed model id array. Consumed by resolve-models.mjs via --provider-models to fail-fast at deploy when a tier (or source-config pin) references a model its provider does not serve. Model ids are lowercase API form (e.g. glm-4.6v-flash), matching the suffix after the provider/ prefix in resolved model strings. A provider prefix absent here => the guard warns and skips it (cannot validate unknown providers, e.g. anthropic/openai/openrouter presets). Update zai-coding-plan only if the subscription catalog changes; append to zai as new Z.AI API models ship.",
+  "zai-coding-plan": ["glm-4.7", "glm-5-turbo", "glm-5.2"],
+  "zai": [
+    "glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo",
+    "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx",
+    "glm-4.6", "glm-4.5", "glm-4.5-x", "glm-4.5-air", "glm-4.5-airx", "glm-4.5-flash",
+    "glm-4-32b-0414-128k",
+    "glm-5v-turbo", "glm-4.6v", "glm-4.6v-flash", "glm-4.6v-flashx", "glm-4.5v", "glm-ocr"
+  ]
+}

--- a/deploy/provider-presets.json
+++ b/deploy/provider-presets.json
@@ -4,10 +4,10 @@
     "label": "Z.AI (default)",
     "primary": "zai-coding-plan/glm-5.2",
     "tiers": {
-      "reasoning": "zai-coding-plan/glm-5.1",
+      "reasoning": "zai-coding-plan/glm-5.2",
       "fast": "zai-coding-plan/glm-5-turbo",
       "docs": "zai-coding-plan/glm-4.7",
-      "vision": "zai-coding-plan/glm-5v-turbo"
+      "vision": "zai/glm-4.6v-flash"
     }
   },
   "anthropic": {

--- a/deploy/resolve-models.mjs
+++ b/deploy/resolve-models.mjs
@@ -27,7 +27,7 @@
 //     [--config-src <opencode.json>] [--config-dest <deployed config.json>] \
 //     [--state <.resolved-models.json sidecar>] \
 //     [--provider <name> --presets <provider-presets.json>] \
-//     [--force] [--dry-run] [--preview-dir <path>] [--verbose] [--json]
+//     [--force] [--dry-run] [--preview-dir <path>] [--provider-models <file>] [--verbose] [--json]
 
 import { readFile, writeFile, readdir, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -43,7 +43,7 @@ function parseArgsCamel(argv) {
     userMap: null, projectMap: null,
     overrides: null, projectOverrides: null,
     configSrc: null, configDest: null,
-    state: null, provider: null, presets: null,
+    state: null, provider: null, presets: null, providerModels: null,
     force: false, dryRun: false, verbose: false, json: false,
   };
   const boolKeys = new Set(["force", "dryRun", "verbose", "json", "liftOnly"]);
@@ -132,6 +132,7 @@ async function main() {
   const overrides = (await readJsonMaybe(O.overrides)) || {};
   const projectOverrides = (await readJsonMaybe(O.projectOverrides)) || {};
   const state = (await readJsonMaybe(O.state)) || {};
+  const providerModelsMap = await readJsonMaybe(O.providerModels);
 
   // Provider shortcut: presets[provider] acts as a (global) tier map override.
   let providerMap = null;
@@ -267,6 +268,7 @@ async function main() {
   const generalModel = tierModel("reasoning");
   let configPatched = false;
   let configObj = null;
+  let sourceConfigPins = null;
   if (O.configDest && primary) {
     if (O.configSrc && existsSync(O.configSrc)) {
       configObj = await readJsonMaybe(O.configSrc);
@@ -274,6 +276,12 @@ async function main() {
       configObj = await readJsonMaybe(O.configDest);
     }
     if (configObj) {
+      // Snapshot raw source-config pins BEFORE patching, for the exposed-model guard.
+      sourceConfigPins = {
+        "source opencode.json model": configObj.model,
+        "source opencode.json agent.explore": configObj.agent && configObj.agent.explore && configObj.agent.explore.model,
+        "source opencode.json agent.general": configObj.agent && configObj.agent.general && configObj.agent.general.model,
+      };
       configObj.model = primary;
       configObj.agent = configObj.agent || {};
       if (exploreModel) {
@@ -322,6 +330,55 @@ async function main() {
     if (visionStems.length && O.verbose) {
       console.error(`Note: vision-tier agents [${visionStems.join(", ")}] require a multimodal model.`);
     }
+  }
+
+  // ── exposed-model guard (deploy-time fail-fast) ──
+  // Validates every resolved model (per-agent + primary/explore/general + raw
+  // source-config pins) against provider-models.json, so a tier pinned to a model
+  // its provider doesn't serve is caught at deploy — not at first subagent spawn.
+  // Skipped when --provider-models is absent (back-compat) or --force is set.
+  let guardOffenders = [];
+  const guardWarns = [];
+  if (providerModelsMap && !O.force) {
+    const checkModel = (label, modelStr) => {
+      if (!modelStr || modelStr === "(preserved)") return;
+      const s = String(modelStr);
+      const slash = s.indexOf("/");
+      if (slash === -1) {
+        guardWarns.push(`guard: ${label} model "${s}" has no provider/ prefix — skipped`);
+        return;
+      }
+      const prov = s.slice(0, slash);
+      const mdl = s.slice(slash + 1);
+      const list = providerModelsMap[prov];
+      if (!list) {
+        guardWarns.push(`guard: ${label} provider "${prov}" not in provider-models map — skipped (cannot validate)`);
+        return;
+      }
+      const exposed = new Set(list.map((m) => (typeof m === "string" && m.includes("/") ? m.slice(m.indexOf("/") + 1) : m)));
+      if (!exposed.has(mdl)) {
+        guardOffenders.push(`${label} pins "${s}" — "${mdl}" NOT exposed by provider "${prov}"`);
+      }
+    };
+    for (const stem of Object.keys(newState)) {
+      checkModel(`agent ${stem} (${tierOf[stem] || "?"})`, newState[stem] && newState[stem].model);
+    }
+    if (primary) checkModel("primary", primary);
+    if (exploreModel) checkModel("explore (fast tier)", exploreModel);
+    if (generalModel) checkModel("general (reasoning tier)", generalModel);
+    if (sourceConfigPins) {
+      for (const [label, val] of Object.entries(sourceConfigPins)) checkModel(label, val);
+    }
+  }
+  if (providerModelsMap && guardWarns.length && !O.json) {
+    for (const w of guardWarns) console.error(w);
+  }
+  if (guardOffenders.length) {
+    console.error(`\nerror: ${guardOffenders.length} resolved model(s) pinned to a model its provider does not expose:`);
+    for (const o of guardOffenders) console.error(`  - ${o}`);
+    console.error("Fix the tier map (deploy/models.default.json / deploy/provider-presets.json) or the source opencode.json pin,");
+    console.error("or update deploy/provider-models.json. Bypass with --force (not recommended).");
+    process.exit(1);
   }
 
   // Determine where resolved files go and whether to write at all.

--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -1919,6 +1919,10 @@ function Invoke-Resolver {
     if (Test-Path $ProjectOverrides) { $resolverArgs += @("--project-overrides", $ProjectOverrides) }
     if ($Force) { $resolverArgs += "--force" }
     if ($Provider) { $resolverArgs += @("--provider", $Provider, "--presets", $ProviderPresets) }
+    # Deploy-time exposed-model guard (#281): fail-fast if a tier/source pin
+    # references a model its provider doesn't serve. Guarded by file presence.
+    $ProviderModelsFile = Join-Path $DeployDir "provider-models.json"
+    if (Test-Path $ProviderModelsFile) { $resolverArgs += @("--provider-models", $ProviderModelsFile) }
     if ($DryRun) { $resolverArgs += "--dry-run" }
     & node $ResolverScript @resolverArgs
 }

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -2619,6 +2619,12 @@ run_resolver() {
     if [ -n "$PROVIDER" ]; then
         extra_args="$extra_args --provider ${PROVIDER} --presets ${PROVIDER_PRESETS}"
     fi
+    # Deploy-time exposed-model guard (#281): fail-fast if a tier/source pin
+    # references a model its provider doesn't serve. Guarded by file presence so
+    # older deploys without provider-models.json are unaffected.
+    if [ -f "${DEPLOY_DIR}/provider-models.json" ]; then
+        extra_args="$extra_args --provider-models ${DEPLOY_DIR}/provider-models.json"
+    fi
 
     local project_map_arg=""
     [ -f "$PROJECT_MODELS_MAP" ] && project_map_arg="--project-map ${PROJECT_MODELS_MAP}"

--- a/opencode_app/.opencode/agents/technical-design-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/technical-design-specialist-subagent.md
@@ -51,7 +51,7 @@ This subagent produces **TDD drafts** (`docs/technical-design/TDD-{key}.md`). It
 
 ## Model Tier
 
-This subagent runs at `glm-5.1` (sound-reasoning tier), the same tier as the reviewers (`code-review`, `architecture-review`, language reviewers). It is the **first non-reviewer** at this tier — justified because design **authoring** requires the same reasoning depth as design **review** (architecture decisions, trade-off analysis, data modeling, ADR authoring are correctness-critical, not low-impact transcription).
+This subagent runs on the **reasoning** tier, the same tier as the reviewers (`code-review`, `architecture-review`, language reviewers). It is the **first non-reviewer** at this tier — justified because design **authoring** requires the same reasoning depth as design **review** (architecture decisions, trade-off analysis, data modeling, ADR authoring are correctness-critical, not low-impact transcription).
 
 ## Trigger Phrases
 

--- a/opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md
@@ -51,7 +51,7 @@ Prompt the user for the following information:
 - **Mode**: `primary` or `subagent`
 
 **Configuration Options**:
-- **Model**: Provider/model-id — primary agents use `zai-coding-plan/glm-5.2` (1M context); subagents tier by purpose: `glm-5.1` (reasoning/review/refactor), `glm-5-turbo` (explore/low-impact), `glm-5v-turbo` (vision), `glm-4.7` (docs/lint)
+- **Model**: Provider/model-id — primary agents use `zai-coding-plan/glm-5.2` (1M context); subagents tier by purpose: `glm-5.2` (reasoning/review/refactor), `glm-5-turbo` (explore/low-impact), `zai/glm-4.6v-flash` (vision, free Z.AI API — separate auth), `glm-4.7` (docs/lint)
 - **Temperature**: 0.0-1.0 (default: 0.7)
 - **Steps**: Max agentic iterations (default: 5)
 - **Hidden**: Hide from @ autocomplete (default: false, subagents only)
@@ -78,7 +78,7 @@ Example:
   - Name: code-reviewer
   - Description: Review code for quality, security, and best practices
   - Mode: subagent
-  - Model: zai-coding-plan/glm-5.1
+  - Model: zai-coding-plan/glm-5.2
   - Temperature: 0.3
   - Steps: 3
   - Scope: project
@@ -150,7 +150,7 @@ color: primary
 ---
 description: Review code for quality and security issues
 mode: subagent
-model: zai-coding-plan/glm-5.1
+model: zai-coding-plan/glm-5.2
 temperature: 0.3
 steps: 3
 hidden: true
@@ -384,7 +384,7 @@ grep -E "^(description|mode):" .opencode/agents/<name>.md
 ---
 description: Review code for quality, security, and best practices
 mode: subagent
-model: zai-coding-plan/glm-5.1
+model: zai-coding-plan/glm-5.2
 temperature: 0.3
 steps: 3
 hidden: true

--- a/opencode_app/Dockerfile
+++ b/opencode_app/Dockerfile
@@ -55,6 +55,7 @@ RUN node /app/deploy/resolve-models.mjs \
         --agents-dest /app/.opencode/agents \
         --tiers /app/deploy/agent-tiers.json \
         --default-map /app/deploy/models.default.json \
+        --provider-models /app/deploy/provider-models.json \
         --presets /app/deploy/provider-presets.json \
         $([ -n "$OPENCODE_PROVIDER" ] && echo "--provider $OPENCODE_PROVIDER") \
         --config-dest /app/opencode.json \

--- a/opencode_app/opencode.json
+++ b/opencode_app/opencode.json
@@ -398,7 +398,7 @@
       }
     },
     "general": {
-      "model": "zai-coding-plan/glm-5.1",
+      "model": "zai-coding-plan/glm-5.2",
       "permission": {
         "read": {
           "*": "allow",


### PR DESCRIPTION
## Summary

Fixes the broken reasoning/vision tier pins in `deploy/models.default.json` that caused **20 of 38 subagents to fail spawning** (provider returned 404 for non-exposed models), and adds a deploy-time guard that fails fast if any tier or agent-config pin references a model its provider doesn't serve.

Closes #281 · Plan: [`PLANS/PLAN-GIT-281.md`](https://github.com/darellchua2/opencode-config-template/blob/GIT-281/PLANS/PLAN-GIT-281.md)

## Tier repoints

| Tier | Before (broken) | After |
|------|------------------|-------|
| **reasoning** | `glm-5.1` (pay-per-token, not on `zai-coding-plan`) | `zai-coding-plan/glm-5.2` |
| **vision** | (assorted non-exposed pins) | `zai/glm-4.6v-flash` (Z.AI free vision model, built-in provider) |

**Vision model rationale:** `glm-4.6v-flash` is Z.AI's only free vision model (confirmed at https://docs.z.ai/guides/overview/pricing). It lives on the built-in `zai` API provider, not the `zai-coding-plan` subscription, so vision subagents need a one-time `zai` auth (`opencode auth login` or `ZAI_API_KEY` — auto-injected in Docker via `docker-entrypoint.sh`).

## Changed files (by concern)

**Model tier pins**
- `deploy/models.default.json` — reasoning → `zai-coding-plan/glm-5.2`, vision → `zai/glm-4.6v-flash`
- `deploy/provider-presets.json` — same repoint in the `zai` preset
- `opencode_app/opencode.json` — `general` agent pin `glm-5.1` → `glm-5.2`

**Deploy guard (new)**
- `deploy/provider-models.json` (NEW) — provider → exposed-model catalog
- `deploy/resolve-models.mjs` — `--provider-models` fail-fast guard
- `deploy/setup.sh` / `deploy/setup.ps1` — wire guard into resolver invocation
- `opencode_app/Dockerfile` — wire guard into build-time resolver RUN

**Docs & prose**
- `AGENTS.md` — tier table + vision-auth prerequisite note
- `README.md` — vision-tier auth note
- `MIGRATION.md` — tier-model change + guard note
- `opencode_app/.opencode/skills/opencode-agent-creation-skill/SKILL.md` — repoint 5 stale example pins
- `opencode_app/.opencode/agents/technical-design-specialist-subagent.md` — de-stale prose

**Plan**
- `PLANS/PLAN-GIT-281.md` — all phases marked done

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Shell syntax | `bash -n deploy/setup.sh` | ✅ exit 0 |
| JS syntax | `node --check deploy/resolve-models.mjs` | ✅ exit 0 |
| JSON validity | `python3 -c "import json; …"` (4 files) | ✅ all valid |
| Resolver smoke (corrected map) | `resolve-models.mjs --provider-models … --dry-run` | ✅ exit 0 |

## User prerequisite

Vision subagents require the **`zai`** API provider to be authenticated (separate from `zai-coding-plan`):
- **Interactive:** `opencode auth login` → select Z.AI
- **Docker:** set `ZAI_API_KEY` (auto-injected by `docker-entrypoint.sh`)