### PR TITLE
fix(deps): bump opencode version pins 1.18.3 → 1.18.11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,9 @@ GEMINI_API_KEY=
 # External port for the OpenCode web endpoint (default: 4097)
 OPENCODE_PORT=4097
 
-# OpenCode CLI version to install in the container (default: 1.18.3)
+# OpenCode CLI version to install in the container (default: 1.18.11)
 # Check https://www.npmjs.com/package/opencode-ai for available versions
-OPENCODE_VERSION=1.18.3
+OPENCODE_VERSION=1.18.11
 
 # ─── Workspace ─────────────────────────────────────────────────────────────────
 # Primary host directory mounted as /workspace in the container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         # OpenCode CLI version — override via .env (OPENCODE_VERSION=1.x.y)
         # Defaults to Dockerfile ARG if unset
-        OPENCODE_VERSION: ${OPENCODE_VERSION:-1.18.3}
+        OPENCODE_VERSION: ${OPENCODE_VERSION:-1.18.11}
     container_name: opencode
     env_file: .env
     ports:

--- a/opencode_app/Dockerfile
+++ b/opencode_app/Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.title="opencode-config-template" \
       org.opencontainers.image.description="OpenCode standalone web endpoint - configurable agent/skill runner" \
       org.opencontainers.image.source="https://github.com/darellchua2/opencode-config-template"
 
-ARG OPENCODE_VERSION=1.18.3
+ARG OPENCODE_VERSION=1.18.11
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary

Aligns the repo's OpenCode version pins with the runtime actually in use (1.18.11). The repo was pinned to `1.18.3` while running `1.18.11`.

## Why this is a drop-in (no MCP migration)

Research confirmed the "stateless MCP server" upgrade does **not** exist in 1.18.11. The MCP SDK v2 / streamable-HTTP work shipped transiently in **v1.18.8** ([PR #39247](https://github.com/anomalyco/opencode/pull/39247)) and was **fully reverted in v1.18.9** ([PR #39373](https://github.com/anomalyco/opencode/pull/39373)) back to `@modelcontextprotocol/sdk@1.29.0` — the revert explicitly fixed an Atlassian OAuth issuer mismatch. So 1.18.11 runs the legacy v1 SDK; the only 1.18.11 MCP change is an SSE reconnect-loop stability fix.

**No MCP config schema changes, no `mcp-remote` bridge migration, no new config keys.** All 26 MCP entries remain valid as-is.

## Changes

| File | Change |
|------|--------|
| `opencode_app/Dockerfile` | `ARG OPENCODE_VERSION` `1.18.3` → `1.18.11` |
| `docker-compose.yml` | default `1.18.3` → `1.18.11` |
| `.env.example` | comment + value `1.18.3` → `1.18.11` |

> Note: `.opencode/package.json` (`@opencode-ai/plugin` `1.14.20` → `1.18.11`) is **gitignored** — it is a local plugin install manifest, not version-controlled. Bumped locally on disk only.

## Verification

- ✅ `test_mcp_count_consistency.bats`: 3/3 pass — MCP count stays 26, auto-start stays 6, markitdown present + disabled.
- ✅ JSON validity confirmed.

## Not in scope (deferred)

- Optional `mcp-remote` → native `type: "remote"` migration (defer until OpenCode re-lands SDK v2; native OAuth path regressed and was reverted).
- `permission.read: { "mcp:*": "deny" }` workaround kept (visibility-bug fix status unverified in 1.18.11).

Full research reports in `research/` (untracked).

🤖 Generated with [opencode](https://opencode.ai)