### PR TITLE
docs(research): add opencode 1.18.11 + glm-5v-turbo access research

### DIFF
--- a/research/mcp-11811-implementation-audit.md
+++ b/research/mcp-11811-implementation-audit.md
@@ -1,0 +1,342 @@
+# MCP Server Implementation Audit — OpenCode 1.18.11 Target
+
+**Audited:** `opencode-config-template` repo @ HEAD
+**Target runtime:** OpenCode `1.18.11` (repo currently pins `1.18.3`)
+**Date:** 2026-08-03
+**Source of truth:** `opencode_app/opencode.json` (`mcp` block, `tools` block, `permission` block)
+**Method:** Verified against the canonical OpenCode docs (`https://opencode.ai/docs/mcp-servers/`), the GitHub release notes for v1.18.4–v1.18.11, and the npm registry (`@opencode-ai/plugin@1.18.11`).
+**Scope:** this is a **read-only audit + checklist**. No repo files were edited. The primary agent decides what to apply.
+
+---
+
+## 0. Executive verdict
+
+> **UPGRADE SEVERITY: DROP-IN** (trivial version-bump edits only; zero MCP config changes required).
+
+The single most important finding of this audit is a **negative result**:
+
+**There is no "stateless MCP server model" in OpenCode 1.18.11, or anywhere in the 1.18.x line.** This was checked against three independent, canonical sources:
+
+| Source | URL | Result |
+|---|---|---|
+| Release notes v1.18.4–v1.18.11 | `https://github.com/anomalyco/opencode/releases` | **No** mention of "stateless MCP". v1.18.11 ships exactly two core bugfixes (see §1). |
+| MCP servers doc (current) | `https://opencode.ai/docs/mcp-servers/` | **No** mention of "stateless". Schema is identical to what the repo uses today (`type: local\|remote` + `command`/`url`/`headers`/`oauth`/`environment`/`enabled`/`timeout`). |
+| Repo-wide grep | `stateless` across repo | Only matches are `stateless-cookie-cache-maxage-match-session` (an unrelated auth/session learning). Zero MCP hits. |
+
+The 1.18.x line improved MCP **robustness** (reconnect handling, OAuth flows, SDK compatibility) — these are **bugfixes that make the existing config work *better*, not schema changes that *require* config edits.** Therefore:
+
+- **No MCP server entry needs a schema change to run on 1.18.11.** All 26 entries are valid as-is.
+- **No `mcp-remote` bridge must be removed** for 1.18.11. Bridge elimination is an *optional modernization* (§6), gated on empirical OAuth testing, not a requirement.
+- The only **required** edits are the four **version-pin bumps** in §2.
+- The `permission.read: { "mcp:*": "deny" }` workaround should be **kept** (§7).
+
+If you were told 1.18.11 mandates an MCP migration: **that premise is unfounded.** Do not invent `stateless: true` or any new config key — none is documented.
+
+---
+
+## 1. What 1.18.x actually changed for MCP (verified)
+
+Compiled from `https://github.com/anomalyco/opencode/releases`:
+
+| Version | MCP-relevant change | Type |
+|---|---|---|
+| **v1.18.11** | "Stopped MCP SSE connections from getting stuck in reconnect loops after server error responses." | bugfix |
+| **v1.18.11** | "Fixed provider model configs that use interleaved reasoning fields like `reasoningtext`..." | bugfix (provider, not MCP) |
+| v1.18.9 | "Restored compatibility with legacy MCP SDK clients." | bugfix |
+| v1.18.8 | "Improved compatibility with newer MCP servers and OAuth flows." | improvement |
+| v1.18.8 | "Reconnects MCP servers after expired SDK sessions, including concurrent requests." | bugfix |
+| v1.18.8 | "Honors configured MCP OAuth callback ports in `mcp debug`." | bugfix |
+| v1.18.6 | "Fixed legacy MCP state refreshing when opening a V1 workspace." | bugfix |
+
+**Interpretation:** every one of these is a connection-lifetime / OAuth-flow robustness fix. None alters the `opencode.json` `mcp` schema. Notably, v1.18.11's SSE-reconnect fix and v1.18.8's SSE/OAuth improvements **directly benefit** this repo's SSE-bridged servers (Google `/v1/sse`, Microsoft `/v1/sse`) — they simply become more stable, with no config action.
+
+The MCP servers doc (`https://opencode.ai/docs/mcp-servers/`) confirms the **live schema** is unchanged and documents real native capabilities this repo can optionally adopt:
+- **Native remote transport** (`type: "remote"`) handles streamable-HTTP *and* (per v1.18.8/1.18.11 fixes) SSE endpoints.
+- **Native OAuth**: automatic Dynamic Client Registration (RFC 7591), `opencode mcp auth <server>`, `opencode mcp list`, `opencode mcp logout`, `opencode mcp debug`.
+- **`oauth: false`** to disable OAuth auto-detection for Bearer-header (API-key) remotes — *not yet used* in this repo's native remotes (§6.2).
+
+---
+
+## 2. Required version-pin bumps (HIGH priority)
+
+These are the **only edits strictly required** to target 1.18.11. They are low-risk string changes.
+
+| # | File | Line | Current | Recommended | Why |
+|---|---|---|---|---|---|
+| 1 | `opencode_app/Dockerfile` | 7 | `ARG OPENCODE_VERSION=1.18.3` | `ARG OPENCODE_VERSION=1.18.11` | Primary CLI pin (npm `opencode-ai@1.18.3` → `1.18.11`) |
+| 2 | `docker-compose.yml` | 9 | `OPENCODE_VERSION: ${OPENCODE_VERSION:-1.18.3}` | `OPENCODE_VERSION: ${OPENCODE_VERSION:-1.18.11}` | Compose default; aligns with Dockerfile ARG |
+| 3 | `.env.example` | 12 (comment) | `# OpenCode CLI version to install in the container (default: 1.18.3)` | `... (default: 1.18.11)` | Keep comment accurate |
+| 3 | `.env.example` | 14 | `OPENCODE_VERSION=1.18.3` | `OPENCODE_VERSION=1.18.11` | Example override value |
+| 4 | `.opencode/package.json` | 3 | `"@opencode-ai/plugin": "1.14.20"` | `"@opencode-ai/plugin": "1.18.11"` | Plugin dev-dep; see §5 |
+
+> **Note on count discrepancy:** the task brief stated "30+ servers". The verified total is **26** (matches README "ships 26 MCP server entries" L295, `setup.sh` "MCP SERVERS (26):" L646, and the bats dynamic count). 26 is correct; "30+" is inaccurate.
+
+---
+
+## 3. Full MCP server inventory (26 entries)
+
+Source: `opencode_app/opencode.json` lines 139–346. Counts: **26 total, 6 enabled (auto-start).**
+
+| # | Key | type | command / url | enabled | Transport-implied class |
+|---|-----|------|---------------|:---:|---|
+| 1 | `codegraph` | local | `npx -y @colbymchenry/codegraph serve --mcp` |  | stdio |
+| 2 | `atlassian` | local | `npx -y mcp-remote https://mcp.atlassian.com/v1/mcp` |  | bridge → streamable-HTTP (`/v1/mcp`) |
+| 3 | `zai-web-reader` | remote | `https://api.z.ai/api/mcp/web_reader/mcp` + Bearer |  | native streamable-HTTP |
+| 4 | `zai-web-search-prime` | remote | `https://api.z.ai/api/mcp/web_search_prime/mcp` + Bearer |  | native streamable-HTTP |
+| 5 | `zai-vision-mcp-server` | local | `npx -y @z_ai/mcp-server` |  | stdio |
+| 6 | `zai-zread` | remote | `https://api.z.ai/api/mcp/zread/mcp` + Bearer |  | native streamable-HTTP |
+| 7 | `google-bigquery` | local | `npx -y mcp-remote https://mcp.googleapis.com/bigquery/v1/sse` |  | bridge → SSE |
+| 8 | `google-maps` | local | `npx -y mcp-remote https://mcp.googleapis.com/maps/v1/sse` |  | bridge → SSE |
+| 9 | `google-gce` | local | `npx -y mcp-remote https://mcp.googleapis.com/compute/v1/sse` |  | bridge → SSE |
+| 10 | `google-gke` | local | `npx -y mcp-remote https://mcp.googleapis.com/kubernetes-engine/v1/sse` |  | bridge → SSE |
+| 11 | `autodesk-revit` | remote | `https://mcp.autodesk.com/revit/v1` + Bearer |  | native streamable-HTTP |
+| 12 | `autodesk-model-data` | remote | `https://mcp.autodesk.com/model-data/v1` + Bearer |  | native streamable-HTTP |
+| 13 | `autodesk-fusion` | remote | `https://mcp.autodesk.com/fusion/v1` + Bearer |  | native streamable-HTTP |
+| 14 | `autodesk-help` | remote | `https://mcp.autodesk.com/help/v1` + Bearer |  | native streamable-HTTP |
+| 15 | `next-devtools` | local | `npx -y next-devtools-mcp@latest` |  | stdio |
+| 16 | `microsoft-teams` | local | `npx -y mcp-remote https://mcp.cloud.microsoft/teams/v1/sse` |  | bridge → SSE |
+| 17 | `microsoft-mail` | local | `... mcp-remote .../mail/v1/sse` |  | bridge → SSE |
+| 18 | `microsoft-calendar` | local | `... mcp-remote .../calendar/v1/sse` |  | bridge → SSE |
+| 19 | `microsoft-sharepoint` | local | `... mcp-remote .../sharepoint/v1/sse` |  | bridge → SSE |
+| 20 | `microsoft-onedrive` | local | `... mcp-remote .../onedrive/v1/sse` |  | bridge → SSE |
+| 21 | `microsoft-user` | local | `... mcp-remote .../me/v1/sse` |  | bridge → SSE |
+| 22 | `microsoft-word` | local | `... mcp-remote .../word/v1/sse` |  | bridge → SSE |
+| 23 | `microsoft-copilot` | local | `... mcp-remote .../copilot/v1/sse` |  | bridge → SSE |
+| 24 | `microsoft-dataverse` | local | `... mcp-remote .../dataverse/v1/sse` (+ env) |  | bridge → SSE |
+| 25 | `mermaid` | local | `npx -y @peng-shawn/mermaid-mcp-server` |  | stdio |
+| 26 | `markitdown` | local | `markitdown-local-mcp` (vendored Python launcher) |  | stdio |
+
+**Pattern summary:** 3 config patterns in use —
+1. `type: "remote"` + `url` + `headers.Authorization` → 8 servers (Z.AI ×3, Autodesk ×4, +web-search-prime).
+2. `type: "local"` + `mcp-remote` bridge → HTTPS URL → 14 servers (Atlassian `/v1/mcp`, Google `*/v1/sse` ×4, Microsoft `*/v1/sse` ×9).
+3. `type: "local"` + native `npx`/binary stdio → 4 servers (codegraph, zai-vision-mcp-server, mermaid, next-devtools) + 1 vendored Python stdio (markitdown).
+
+---
+
+## 4. Per-server required action under 1.18.11
+
+Actions are classified: `NO_CHANGE` (works as-is), `EDIT` (schema field change), `MIGRATE` (pattern change), `DEPRECATE/REMOVE`, `INVESTIGATE` (docs unclear, needs empirical test).
+
+**Legend:** Action here means *required to function on 1.18.11*. Optional modernizations are in §6 and explicitly tagged OPTIONAL.
+
+| # | Key | Current pattern | Action | New JSON? | Risk | Priority |
+|---|-----|-----------------|:---:|---|---|:---:|
+| 1 | `codegraph` | local stdio | **NO_CHANGE** | — | none — stdio servers are transport-agnostic | — |
+| 2 | `atlassian` | local → `mcp-remote` → `/v1/mcp` | **NO_CHANGE** (OPTIONAL MIGRATE, §6) | — | bridge works; native is an optional enhancement | — |
+| 3 | `zai-web-reader` | remote + Bearer | **NO_CHANGE** | — | none; benefits from SSE/HTTP robustness | — |
+| 4 | `zai-web-search-prime` | remote + Bearer | **NO_CHANGE** | — | none | — |
+| 5 | `zai-vision-mcp-server` | local stdio | **NO_CHANGE** | — | none | — |
+| 6 | `zai-zread` | remote + Bearer | **NO_CHANGE** | — | none | — |
+| 7–10 | `google-*` (4) | local → `mcp-remote` → `/v1/sse` | **NO_CHANGE** (OPTIONAL MIGRATE, §6) | — | none required; 1.18.11 SSE fix *improves* them if/when enabled | — |
+| 11–14 | `autodesk-*` (4) | remote + Bearer | **NO_CHANGE** | — | none | — |
+| 15 | `next-devtools` | local stdio | **NO_CHANGE** | — | none | — |
+| 16–24 | `microsoft-*` (9) | local → `mcp-remote` → `/v1/sse` | **NO_CHANGE** (OPTIONAL MIGRATE, §6) | — | none required | — |
+| 25 | `mermaid` | local stdio | **NO_CHANGE** | — | none | — |
+| 26 | `markitdown` | local vendored stdio | **NO_CHANGE** | — | none; launcher install unchanged | — |
+
+**Net: 0 required MCP edits.** Every entry is schema-valid for 1.18.11. This is the expected outcome given §0/§1 — there is no schema-level change to satisfy.
+
+---
+
+## 5. Plugin compatibility note
+
+**Finding:** `@opencode-ai/plugin` latest on npm is **`1.18.11`** (`https://registry.npmjs.org/@opencode-ai/plugin`), version-locked to the CLI. Its dependency tree is `@opencode-ai/sdk: 1.18.11`, `effect: 4.0.0-beta.83`, `zod: 4.1.8`, `@ai-sdk/provider: 3.0.8`.
+
+The repo pins `@opencode-ai/plugin: 1.14.20` (`.opencode/package.json:3`) — **4 minor versions stale** relative to a 1.18.11 CLI. While a stale *dev* dependency won't break MCP runtime, it means plugin authoring against this repo would target an outdated API surface (the plugin gained `./v2/effect`, `./v2/promise`, `./v2/effect/plugin`, `./v2/effect/integration` export paths since 1.14.x).
+
+**Recommendation:** bump to `"@opencode-ai/plugin": "1.18.11"` (exact) or `"^1.18.11"`. Exact-match to the CLI version is the safest choice for a config-distributor repo. No breaking change is expected for the existing plugins in `opencode.json` (`opencode-superlocalmemory`, `opencode-dynamic-context-pruning`, etc.) — those are runtime plugins loaded by the CLI, not compiled against `@opencode-ai/plugin` here.
+
+> `[UNVERIFIED]` — whether any of the 11 runtime `plugin[]` entries in `opencode.json` have their own 1.18.11 incompatibilities was not individually checked (out of scope: each is a separate npm package). If a plugin fails to load on 1.18.11, the CLI logs it at startup without crashing other MCP servers.
+
+---
+
+## 6. `mcp-remote` bridge elimination plan (OPTIONAL — not required by 1.18.11)
+
+> **Reiterated:** this is an *optional modernization*, independent of the (non-existent) "stateless" premise. It is enabled by real native capabilities documented at `https://opencode.ai/docs/mcp-servers/` (native `type: "remote"` + native OAuth + `opencode mcp auth`). Do **not** treat it as a 1.18.11 prerequisite.
+
+### 6.1 Candidate classification
+
+| Bridge group | Count | Native-remote viable? | OAuth path | Verdict |
+|---|:---:|---|---|---|
+| **atlassian** | 1 | **Yes (high)** — endpoint is `/v1/mcp` (streamable-HTTP, the transport OpenCode natively serves best) | `opencode mcp auth atlassian` (auto DCR) | **Best candidate — MIGRATE after empirical test** |
+| **google-*** | 4 | Likely yes — OpenCode 1.18.8/1.18.11 fixed SSE reconnect; native remote now handles SSE | `opencode mcp auth google-*` | **INVESTIGATE** — SSE native + Google's OAuth client requirements need testing |
+| **microsoft-*** | 9 | Likely yes (SSE, same as Google) | `opencode mcp auth microsoft-*` | **INVESTIGATE** — SSE native + M365 OAuth needs testing |
+
+### 6.2 Before/after — Atlassian (strongest candidate)
+
+```jsonc
+// BEFORE (current) — opencode.json:151
+"atlassian": {
+  "type": "local",
+  "command": ["npx", "-y", "mcp-remote", "https://mcp.atlassian.com/v1/mcp"],
+  "enabled": true
+}
+
+// AFTER (proposed, OPTIONAL) — native remote + native OAuth
+"atlassian": {
+  "type": "remote",
+  "url": "https://mcp.atlassian.com/v1/mcp",
+  "enabled": true
+  // no headers; OpenCode handles OAuth via opencode mcp auth atlassian (auto DCR per docs)
+}
+```
+Then one-time: `opencode mcp auth atlassian` (opens browser; stores tokens in `~/.local/share/opencode/mcp-auth.json`).
+
+### 6.3 Before/after — Google BigQuery (representative SSE bridge)
+
+```jsonc
+// BEFORE (current) — opencode.json:194
+"google-bigquery": {
+  "type": "local",
+  "command": ["npx", "-y", "mcp-remote", "https://mcp.googleapis.com/bigquery/v1/sse"],
+  "environment": { "GOOGLE_APPLICATION_CREDENTIALS": "${env:GOOGLE_APPLICATION_CREDENTIALS}" },
+  "enabled": false
+}
+
+// AFTER (proposed, OPTIONAL) — native remote
+"google-bigquery": {
+  "type": "remote",
+  "url": "https://mcp.googleapis.com/bigquery/v1/sse",
+  "enabled": false
+}
+```
+> `[UNVERIFIED]` — whether OpenCode's native remote correctly auto-discovers/handles Google's OAuth on the `/v1/sse` (vs streamable-HTTP) transport. v1.18.8 ("improved compatibility with newer MCP servers and OAuth flows") + v1.18.11 (SSE reconnect fix) make it plausible, but this needs an empirical `opencode mcp debug google-bigquery` test before committing. The `GOOGLE_APPLICATION_CREDENTIALS` service-account env var may still be the cleaner path for headless use (see §8).
+
+### 6.4 Before/after — Microsoft Teams (representative SSE bridge)
+
+```jsonc
+// BEFORE (current) — opencode.json:283
+"microsoft-teams": {
+  "type": "local",
+  "command": ["npx", "-y", "mcp-remote", "https://mcp.cloud.microsoft/teams/v1/sse"],
+  "enabled": false
+}
+
+// AFTER (proposed, OPTIONAL) — native remote
+"microsoft-teams": {
+  "type": "remote",
+  "url": "https://mcp.cloud.microsoft/teams/v1/sse",
+  "enabled": false
+}
+```
+> Same `[UNVERIFIED]` caveat as Google. Test with `opencode mcp debug microsoft-teams`.
+
+### 6.5 Native remotes that should add `oauth: false`
+
+The 8 *existing* native remotes (Z.AI ×3, Autodesk ×4, web-search-prime) pass `Authorization: Bearer {env:...}` and do **not** want OpenCode's OAuth auto-detection to fire. The current docs recommend `oauth: false` for API-key remotes (`https://opencode.ai/docs/mcp-servers/#disabling-oauth`). Adding it is a robustness nicety, not a correctness fix (a 401 with a valid Bearer is unlikely to trigger DCR). Example:
+
+```jsonc
+// OPTIONAL hardening — zai-web-reader
+"zai-web-reader": {
+  "type": "remote",
+  "url": "https://api.z.ai/api/mcp/web_reader/mcp",
+  "headers": { "Authorization": "Bearer {env:ZAI_API_KEY}" },
+  "oauth": false,        // <-- optional: suppress OAuth auto-detection for API-key remotes
+  "enabled": true
+}
+```
+
+**Priority:** LOW. Purely defensive; no observed failure mode warrants it today.
+
+---
+
+## 7. `permission.read: { "mcp:*": "deny" }` workaround status
+
+**Current:** present at `opencode.json:20-22` (global) and repeated in `agent.explore` (L395-398) and `agent.general` (L403-407). Purpose (per `deploy/.AGENTS.md:47`): runtime-deny `read_mcp_resource` / `list_mcp_resources` because an **upstream opencode visibility bug** (`session/tools.ts`) leaves those tools in the model's tool list even when runtime-denied, causing wasted steps + `DeniedError`.
+
+**Status under 1.18.11:** **`[UNVERIFIED]` — keep the workaround.**
+
+- The 1.18.4–1.18.11 release notes contain **no** entry mentioning `session/tools.ts`, `read_mcp_resource`, MCP-resource visibility, or a fix for this specific bug.
+- I could not confirm from release notes alone whether the visibility bug is resolved. Verifying would require either (a) reading the 1.18.11 `session/tools.ts` source diff, or (b) an empirical test (load config without the workaround, observe whether `read_mcp_resource` still appears in the tool list).
+- **Cost of keeping it if fixed:** negligible — a harmless deny rule on tools the model shouldn't call anyway.
+- **Cost of removing it if unfixed:** the model regresses to calling dead MCP-resource tools, wasting context + steps.
+
+**Recommendation:** **KEEP** `permission.read: { "mcp:*": "deny" }` (all 3 locations) until the fix is empirically confirmed. Add a one-line TODO referencing this audit. Do not remove it speculatively.
+
+If/when verified fixed, the cleaner config is simply to delete the `permission.read` block (global + per-agent) — the model would then no longer *see* `read_mcp_resource`/`list_mcp_resources` at all. But that is a follow-up, not part of the 1.18.11 bump.
+
+---
+
+## 8. Docker / web-endpoint spawn semantics
+
+**Does the (non-existent) "stateless model" change MCP spawn semantics for Docker?** N/A — there is no stateless model.
+
+**Real Docker considerations (unchanged by 1.18.11):**
+
+1. **Local stdio servers** (`codegraph`, `zai-vision-mcp-server`, `mermaid`, `next-devtools`, `markitdown`) spawn as child processes per the `command`. No change. `markitdown` is pre-installed via `Dockerfile:86` (`pip install .../markitdown-local-mcp`); the console-script `markitdown-local-mcp` lands on PATH. Unaffected by the version bump.
+
+2. **`mcp-remote` bridges** spawn a Node child (`npx mcp-remote`) that proxies the remote SSE/HTTP server. `npx` needs network + npm cache; the compose file mounts `npm-cache:/home/opencode/.npm` for this. No change in 1.18.11.
+
+3. **Interactive OAuth is the headless-Docker constraint (unchanged):** `opencode mcp auth <server>` opens a browser — impossible in the containerized web endpoint (`docker-entrypoint.sh` only injects API keys into `auth.json` for `zai` + `gemini`). Therefore:
+   - **Bearer-header remotes** (Z.AI, Autodesk) work headless — they need only `ZAI_API_KEY`/`AUTODESK_API_KEY`, already handled.
+   - **OAuth-gated remotes** (Google, Microsoft, Atlassian) **cannot complete first-run OAuth inside Docker** regardless of bridge-vs-native. They are `enabled: false` by default precisely for this reason. A user enabling them must auth interactively on a desktop client first (tokens land in `~/.local/share/opencode/mcp-auth.json`, which is on the `opencode-data` volume), or use a service-account env-var path. **1.18.11 does not change this.**
+   - **Implication for §6 (optional bridge elimination):** migrating Atlassian/Google/Microsoft to native remote in the *Docker* config would not make them work headless — the OAuth constraint is identical. The bridge-elimination value is for the *desktop/user-space* deploy, not Docker.
+
+4. **`docker-entrypoint.sh`** (93 lines) contains **no MCP-specific assumptions** — it only writes `auth.json` (zai/gemini), sets up SSH/git, exports Ponytail env, and `exec opencode serve`. Nothing to change for 1.18.11.
+
+---
+
+## 9. Test impact (`tests/test_mcp_count_consistency.bats`)
+
+The recommended path (version-bump only, **no MCP add/remove**) breaks **zero** assertions. Verified against the three tests:
+
+| Test | Asserts | Breaks under recommended path? | When would it break? |
+|---|---|:---:|---|
+| `mcp_count_opencode_json_is_consistent_across_docs` | dynamic `len(mcp)` from JSON == README "ships N" == `setup.sh` "MCP SERVERS (N)" | **No** (stays 26) | Only if you add/remove an MCP key without updating README L295 + setup.sh L646 |
+| `mcp_count_markitdown_present` | `markitdown` key exists + `enabled is False` | **No** | Only if markitdown is removed or force-enabled |
+| `mcp_count_auto_start_is_six` | `sum(enabled) == 6` | **No** (stays 6) | Only if you flip an `enabled` flag without rebalancing |
+
+**If the OPTIONAL §6 bridge migrations were applied** (Atlassian native, Google/Microsoft native): these are *in-place rewrites* (`type`/fields change, key count unchanged), so the total stays **26** and enabled stays **6** → **still no test breakage.** The only test-risk scenario is an actual add/remove of server keys.
+
+**Conclusion: no bats edits required for 1.18.11.** The dynamic-count design of the suite correctly absorbs in-place schema rewrites.
+
+---
+
+## 10. Ordered implementation checklist
+
+### HIGH priority (required to target 1.18.11)
+- [ ] **B1** — `opencode_app/Dockerfile:7` — `ARG OPENCODE_VERSION=1.18.3` → `1.18.11`
+- [ ] **B2** — `docker-compose.yml:9` — default `1.18.3` → `1.18.11`
+- [ ] **B3** — `.env.example:12` (comment) + `:14` (value) — `1.18.3` → `1.18.11`
+- [ ] **B4** — `.opencode/package.json:3` — `"@opencode-ai/plugin": "1.14.20"` → `"1.18.11"`
+- [ ] **V1** — Rebuild image (`docker compose build`) and smoke-test `opencode serve` + `opencode mcp list`; confirm the 6 auto-start servers connect. (1.18.11 SSE-reconnect fix should make Atlassian/SSE-bridged servers more stable.)
+
+### MEDIUM priority (defensive / hygiene)
+- [ ] **P1** — Add a `TODO(1.18.11-audit)` comment near `opencode.json:20` noting the `permission.read.mcp:*` workaround is retained pending empirical confirmation of the `session/tools.ts` visibility-bug fix (§7).
+- [ ] **P2** — (Optional §6.5) Add `"oauth": false` to the 8 native API-key remotes (Z.AI ×3, Autodesk ×4) to suppress OAuth auto-detection. Low value; skip if time-boxed.
+
+### LOW priority (optional modernization — verify before merging)
+- [ ] **O1** — Empirically test Atlassian native remote (§6.2): temporarily swap to `type:"remote"` + `opencode mcp debug atlassian` + `opencode mcp auth atlassian`. If tools load, commit the migration.
+- [ ] **O2** — Empirically test one Google SSE native (§6.3) + one Microsoft SSE native (§6.4) via `opencode mcp debug`. Only roll out to all 4/9 if the representative test passes.
+- [ ] **O3** — Do **not** migrate anything in the Docker config expecting headless OAuth to work (§8.3) — keep bridges or `enabled:false` for OAuth-gated servers in Docker.
+
+> **Explicitly NOT recommended:** inventing a `stateless` config key, mass-migrating all bridges without testing, or removing the `permission.read.mcp:*` workaround without verifying the upstream fix.
+
+---
+
+## 11. Risks & rollback
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Version bump surfaces a 1.18.11 regression in a runtime `plugin[]` entry | Low | Plugins load independently; CLI logs failures without crashing MCP. Roll back the single pin if a plugin breaks. |
+| Optional §6 native-remote migration breaks OAuth for Google/Microsoft | Medium (if applied untested) | **Mitigation = don't apply §6 without §10 O1–O2 tests.** Each migration is reversible (restore the `mcp-remote` bridge JSON). Bridges still work on 1.18.11. |
+| Removing `permission.read.mcp:*` workaround prematurely | Medium (if applied) | Re-introduces dead `read_mcp_resource` calls. Roll back = restore the 3 deny rules. **Don't remove without verification (§7).** |
+| `@opencode-ai/plugin` 1.18.11 API drift breaks a locally-authored plugin | Low | None authored in-repo against it currently; it's a dev scaffold dep. |
+| npm `mcp-remote` package itself drifts/incompatibility | Out of scope | Independent of OpenCode version; bridges are third-party. |
+
+**Rollback path (simplest):** revert the four version-pin strings (§2). No MCP config is touched under the recommended path, so rollback is a 4-line diff.
+
+---
+
+## 12. Sources cited
+
+- OpenCode MCP servers doc: `https://opencode.ai/docs/mcp-servers/` (schema, OAuth, `mcp auth`/`list`/`logout`/`debug`, `oauth:false`)
+- OpenCode releases v1.18.4–v1.18.11: `https://github.com/anomalyco/opencode/releases`
+- npm `@opencode-ai/plugin`: `https://registry.npmjs.org/@opencode-ai/plugin` (latest `1.18.11`)
+- Repo files (read, not edited): `opencode_app/opencode.json`, `opencode_app/Dockerfile`, `docker-compose.yml`, `.env.example`, `.opencode/package.json`, `opencode_app/docker-entrypoint.sh`, `tests/test_mcp_count_consistency.bats`, `CHANGELOG.md`, `README.md`
+
+## 13. Unverified items (consolidated)
+
+- `[UNVERIFIED]` Whether the `session/tools.ts` MCP-resource visibility bug is fixed in 1.18.11 (§7) → workaround kept.
+- `[UNVERIFIED]` Whether OpenCode native `type:"remote"` auto-handles Google/Microsoft OAuth on `/v1/sse` transport (§6.3/6.4) → migrations gated on empirical `mcp debug`.
+- `[UNVERIFIED]` Per-plugin 1.18.11 compatibility for the 11 runtime `plugin[]` entries (§5) → out of scope; CLI isolates plugin load failures.

--- a/research/research-opencode-11811-stateless-mcp.md
+++ b/research/research-opencode-11811-stateless-mcp.md
@@ -1,0 +1,185 @@
+# OpenCode 1.18.11 "Stateless MCP" — Research Report
+
+> **Filename note:** The requested path was `research/opencode-11811-stateless-mcp-research.md`. This agent's write permission is restricted to `**/research*.md` (basename must begin with `research`), so the file is saved as `research/research-opencode-11811-stateless-mcp.md`. Content is identical to what was requested; only the filename was adjusted for tool-permission compliance.
+
+**Date:** 2026-08-03
+**Scope:** What the "stateless MCP server" change in OpenCode 1.18.x means for the `opencode-config-template` repo (currently pinned 1.18.3, user running 1.18.11), and what downstream config edits are needed.
+**Method:** Web-only literature review (no code execution, no repo file reads). All fetched content treated as untrusted data; claims sourced inline; unconfirmed claims marked `[UNVERIFIED]`.
+
+---
+
+## 1. Executive Summary
+
+- **The premise needs correction.** There is **no "stateless MCP server" feature in OpenCode 1.18.11.** The stateless Streamable-HTTP client (MCP SDK v2) shipped **transiently in v1.18.8** ([PR #39247](https://github.com/anomalyco/opencode/pull/39247)) and was **fully reverted in v1.18.9** ([PR #39373](https://github.com/anomalyco/opencode/pull/39373)) back to the legacy `@modelcontextprotocol/sdk@1.29.0`. The v1.18.11 release ([notes](https://github.com/anomalyco/opencode/releases/tag/v1.18.11)) contains only one MCP item: a fix stopping **SSE** (legacy transport) connections from getting stuck in reconnect loops.
+
+- **For the user's running version (1.18.11), the stateless/streamable-HTTP path is NOT active.** OpenCode 1.18.11 negotiates MCP servers using the **legacy v1 SDK** (stdio + HTTP+SSE transports). "Stateless" is a deferred, not-yet-shipped capability.
+
+- **This is therefore a LOW-risk upgrade for MCP config.** Going 1.18.3 → 1.18.11 does **not** introduce any breaking MCP config schema change. The user-facing MCP config keys are unchanged (`type: "local"|"remote"`, `command`, `enabled`, `environment`, `headers`; `oauth` and `timeout` are additive and already optional). No `transport`/`stateless` key exists in the public schema — negotiation is internal.
+
+- **Two concrete housekeeping actions are warranted:** (a) bump the **`@opencode-ai/plugin`** dependency from the stale `1.14.20` to `1.18.11` ([npm](https://www.npmjs.com/package/@opencode-ai/plugin) confirms 1.18.11 is current and tracks the opencode version); (b) bump the Docker version pins from `1.18.3` → `1.18.11` to match what is actually running.
+
+- **Do NOT prematurely migrate `mcp-remote` bridges to native `type: "remote"`.** The native remote-OAuth path that would make bridges redundant is the one that regressed (Atlassian issuer mismatch) and was reverted. The bridges remain a valid, SDK-version-decoupled approach in 1.18.11.
+
+---
+
+## 2. What "stateless MCP" means in the 1.18.x line (precise definition + transport diagram)
+
+### 2.1 Terminology
+
+In the MCP spec (version **2025-06-18**), "stateless" refers to the **Streamable HTTP** transport, which **replaced** the older **HTTP+SSE** transport (2024-11-05) ([spec: Transports](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports)):
+
+- **Streamable HTTP (modern):** A single MCP endpoint (e.g. `https://example.com/mcp`) accepts `POST` (JSON-RPC) and optionally `GET` (server→client SSE stream). Sessions are **optional** — a server *may* assign an `Mcp-Session-Id`; if it does not, operation is effectively **stateless** (each request is independent, no server-side session affinity). The client must send `MCP-Protocol-Version: 2025-06-18`.
+- **HTTP+SSE (legacy):** A separate `/sse` GET stream plus a `POST` endpoint discovered from the stream's first `endpoint` event.
+- **stdio (unchanged):** subprocess over stdin/stdout.
+
+"Stateless MCP" in the OpenCode context = **upgrading OpenCode's MCP client to SDK v2** (`@modelcontextprotocol/client@2.0.0-beta.5`, later `2.0.0`) so it can **"negotiate modern stateless and legacy MCP servers"** ([PR #39247 summary](https://github.com/anomalyco/opencode/pull/39247)). The phrase "modern stateless protocol support" appears verbatim in a downstream tracking issue referencing that PR.
+
+### 2.2 Transport diagram
+
+**Intended (shipped in 1.18.8, then REVERTED in 1.18.9 — NOT in 1.18.11):**
+
+```
+                          OpenCode MCP client (SDK v2)
+                          ┌──────────────────────────────────────┐
+   local stdio servers ──▶│  auto-negotiate on Initialize:       │
+   (codegraph, mermaid…)  │   POST InitializeRequest to URL      │
+                          │   ├─ if 2xx + streamable → MODERN    │──▶ Streamable-HTTP endpoint
+   remote servers ───────▶│   │   (stateless, Mcp-Session-Id     │    (https://…/mcp)
+   (type:"remote")        │   │    optional, MCP-Protocol-Version)│
+                          │   └─ if 4xx (405/404) → LEGACY SSE   │──▶ HTTP+SSE endpoint
+                          │       (GET /sse + POST)              │    (https://…/sse)
+                          └──────────────────────────────────────┘
+```
+
+**Actual behavior in 1.18.11 (SDK v1.29.0, post-revert):**
+
+```
+                          OpenCode MCP client (SDK v1.29.0 + compat patch)
+                          ┌──────────────────────────────────────┐
+   local stdio servers ──▶│  stdio transport (unchanged)         │──▶ subprocess stdin/stdout
+   (codegraph, mermaid…)  │                                      │
+                          │                                      │
+   remote servers ───────▶│  HTTP+SSE-style transport            │──▶ remote endpoint
+   (type:"remote")        │  (headers/oauth via v1 code path)    │    (SSE-back-compat expected)
+                          └──────────────────────────────────────┘
+   mcp-remote bridges ───▶  local stdio → npx mcp-remote → remote (bridge does its own transport
+   (type:"local")              negotiation: http-first, falls back to SSE on 404)
+```
+
+### 2.3 Version timeline (MCP-relevant only)
+
+| Version | Date | MCP change | Source |
+|---------|------|------------|--------|
+| 1.18.0 | Jul 14 | (none — Desktop v2) | [release](https://github.com/anomalyco/opencode/releases/tag/v1.18.0) |
+| 1.18.4 | Jul 20 | (none — Kimi/Anthropic thinking) | releases page |
+| 1.18.6 | Jul 27 | "Fixed legacy MCP state refreshing when opening a V1 workspace" | releases page |
+| **1.18.8** | **Jul 28 06:07** | **"Improved compatibility with newer MCP servers and OAuth flows" + expired-session reconnect + `mcp debug` callback ports — = MCP SDK v2 / stateless landed** | [PR #39247](https://github.com/anomalyco/opencode/pull/39247) |
+| **1.18.9** | **Jul 28 18:15** | **"Restored compatibility with legacy MCP SDK clients" — = REVERT of SDK v2 → v1.29.0. Stateless/streamable-HTTP REMOVED.** | [PR #39373](https://github.com/anomalyco/opencode/pull/39373) |
+| 1.18.10 | Jul 30 | (none — Modal models, Desktop) | releases page |
+| **1.18.11** | **Aug 1** | **"Stopped MCP SSE connections from getting stuck in reconnect loops after server error responses" — v1-era SSE stability fix only.** | [release](https://github.com/anomalyco/opencode/releases/tag/v1.18.11) |
+
+> Net: from 1.18.3 → 1.18.11 the MCP subsystem returns to the **same v1 SDK family** it started on. The stateless detour was a same-day add+revert (1.18.8 → 1.18.9).
+
+---
+
+## 3. Per-pattern impact table
+
+Rows = the repo's three MCP config patterns. "Action" reflects the 1.18.11 reality (legacy SDK).
+
+| # | Pattern | Current behavior (1.18.3) | 1.18.11 behavior | Action needed | Risk |
+|---|---------|---------------------------|------------------|---------------|------|
+| 1 | **`type:"remote"` + `headers.Authorization`** (Z.AI web-reader/zread, Autodesk, etc.) | Native remote via v1 SDK; sends headers on each request. | **Same** v1 SDK (reverted). The modern stateless auto-negotiation is NOT active. Works via established remote transport. | **None** (keep as-is). | **LOW**. *Caveat:* if any endpoint has dropped SSE back-compat and is streamable-HTTP-only, it could fail — verify per endpoint `[UNVERIFIED per-endpoint]`. |
+| 2 | **`type:"local"` + `npx -y mcp-remote <https URL>`** (Atlassian `/v1/mcp`, Google `*.sse`, Microsoft `mcp.cloud.microsoft/*/v1/sse`) | Local stdio subprocess; `mcp-remote` bridges to remote SSE/HTTP and owns the OAuth browser flow + token store (`~/.mcp-auth`). | **Same.** OpenCode still on v1 SDK; the bridge does its **own** transport negotiation (`http-first`, SSE fallback) independent of OpenCode's SDK. The bridge actually **shields** these servers from OpenCode SDK churn. | **None required.** Optional future modernization to native `type:"remote"` + `oauth:{}` is **not recommended now** (see §8) because the native OAuth path regressed under SDK v2 and was reverted. | **LOW** (keep). **MED** only if you migrate. |
+| 3 | **`type:"local"` + `npx -y <pkg>`** (codegraph, mermaid, next-devtools, `@z_ai/mcp-server`, markitdown-local-mcp) | Subprocess stdio transport. | **Identical** — stdio is unaffected by the SDK v2 detour. | **None.** | **LOW** (simplest, most stable). |
+
+---
+
+## 4. Breaking changes 1.18.3 → 1.18.11 affecting MCP / config / plugin
+
+Based on the [release list](https://github.com/anomalyco/opencode/releases), [MCP docs](https://opencode.ai/docs/mcp-servers/), and [config docs](https://opencode.ai/docs/config/):
+
+- **MCP transport / config schema:** **No breaking change.** The public MCP schema is unchanged in shape: `type` (`local`/`remote`), `command` (array), `enabled`, `environment`, `headers`. The docs additionally document `oauth` (object | `false`), `timeout` (ms, default 5000), and `cwd` (local) — these are **additive/optional**, not removals. Nothing the repo currently uses was renamed or removed.
+- **`mcp` CLI:** `opencode mcp auth <name>`, `mcp list`, `mcp logout <name>`, `mcp auth list`, `mcp debug <name>` are present and stable. v1.18.8 added "Honors configured MCP OAuth callback ports in `mcp debug`" — an enhancement, not a break.
+- **The only real "breakage" in the window was self-inflicted and self-healed:** SDK v2 (1.18.8) caused Atlassian OAuth issuer mismatch, Draft-07 schema rejection, ReUI OAuth failure, `server/discover` probe rejection with no `initialize` fallback, and Xcode MCP timeout ([PR #39373 rationale](https://github.com/anomalyco/opencode/pull/39373)). All were fixed by the 1.18.9 revert. If the user briefly ran 1.18.8 they may have hit these; 1.18.11 does not have them.
+- **`@opencode-ai/plugin` API:** see §5.
+- **Server/config:** no changes to `OPENCODE_SERVER_PORT` (still 4096 default) or `OPENCODE_SERVER_PASSWORD` ([server docs](https://opencode.ai/docs/server/)).
+
+> Bottom line: **1.18.3 → 1.18.11 is a non-breaking MCP upgrade.** The risk is in stale *dependencies* (the plugin), not in the MCP config.
+
+---
+
+## 5. `@opencode-ai/plugin` compatibility
+
+- **Current npm version: `1.18.11`** ([npm page](https://www.npmjs.com/package/@opencode-ai/plugin), published ~2 days ago, MIT, 4 deps / ~1486 dependents). The plugin package **version-tracks the opencode release** — i.e. the matching plugin for opencode 1.18.11 is `@opencode-ai/plugin@1.18.11`.
+- The repo pins **`1.14.20`** in `.opencode/package.json`. That is **stale by ~4 minor versions** and predates the 1.18 line. This is a real (if low-severity) drift: the plugin SDK is the contract local plugins and custom tools compile against (e.g. `import type { Plugin } from "@opencode-ai/plugin"` and the `tool()`/`tool.schema` helpers per [plugins docs](https://opencode.ai/docs/plugins/)).
+- **Recommended version for 1.18.11: `@opencode-ai/plugin@1.18.11`** (or `^1.18.11`).
+- **Caveat `[UNVERIFIED]`:** whether any hook/type name changed between 1.14.20 and 1.18.11 in a way that breaks the repo's *own* plugin code cannot be confirmed without reading the repo's plugins (out of scope per instructions). The current documented API surface (`Plugin` type, `tool`/`tool.schema`, event hooks incl. `experimental.session.compacting`, `tool.execute.before/after`) should be diffed against the repo's plugin sources after bumping. Treat as **MED** priority and verify with a `bun install` + typecheck.
+
+---
+
+## 6. `permission.read` / `mcp:*` deny + the `read_mcp_resource` visibility bug
+
+- The repo sets `permission.read: { "mcp:*": "deny" }` to runtime-deny `read_mcp_resource` / `list_mcp_resources`, citing an upstream opencode visibility bug that leaves those tools in the model's tool list even when denied.
+- **What the 1.18.11 docs say:** the [Tools page](https://opencode.ai/docs/tools/) lists the built-in tools — `bash, edit, write, read, grep, glob, lsp, apply_patch, skill, todowrite, webfetch, websearch, question` — and **does not list `read_mcp_resource` or `list_mcp_resources`.** The [MCP servers page](https://opencode.ai/docs/mcp-servers/) documents MCP servers as surfacing **only as tools** (prefixed `<servername>_*`); it does not document MCP `resources` or `prompts` primitives at all. This *suggests* the resources-prompts tool surface is de-emphasized/undocumented in the current model.
+- **Bug-fix status in 1.18.11: `[UNVERIFIED]`.** I found **no release note, PR, or commit** in 1.18.4–1.18.11 that explicitly fixes the "denied MCP resource tools still appear in the tool list" visibility bug. Its presence/absence in 1.18.11 is not confirmed by documentation.
+- **Recommendation:** **keep** `permission.read: { "mcp:*": "deny" }`. It is harmless (defense-in-depth) whether or not the bug persists, and removing it has no upside until the bug is confirmed fixed. Re-test empirically after bumping (see §9).
+
+---
+
+## 7. Docker / web-endpoint implications
+
+- `opencode serve` / `opencode web` expose the HTTP server; default **port 4096**, hostname `127.0.0.1`, optional `OPENCODE_SERVER_PASSWORD` (basic auth) and `OPENCODE_SERVER_USERNAME` ([server docs](https://opencode.ai/docs/server/)). These match the repo's `OPENCODE_SERVER_PORT=4096`. **No stateless-related env-var changes** exist.
+- **Spawn model unchanged:** local MCP servers are subprocesses (stdio) of the opencode server process; remote MCP servers are in-process HTTP clients. The SDK version (v1 in 1.18.11) does **not** change this spawn/connect model, and the SDK v2 detour (which also did not change the spawn model) is reverted anyway.
+- **Net Docker impact: none beyond the version bump.** The only required Docker edits are the version pins in `opencode_app/Dockerfile` (`ARG OPENCODE_VERSION=1.18.3` → `1.18.11`) and `docker-compose.yml` (`OPENCODE_VERSION: ${OPENCODE_VERSION:-1.18.3}` → `1.18.11`) so the image matches the user's actual runtime.
+- `[UNVERIFIED]` whether the bundled base image / Node-Bun runtime in the 1.18.11 release artifacts differs from 1.18.3 in a way that affects the Dockerfile's install step — re-check the build after bumping.
+
+---
+
+## 8. Recommended actions (ordered, with file paths + priority)
+
+> These are advisory; the repo's own files were not read per instructions. Paths are taken from the task's repo summary.
+
+| # | Priority | Action | File(s) | Rationale |
+|---|----------|--------|---------|-----------|
+| 1 | **HIGH** | Bump OpenCode version pin `1.18.3` → `1.18.11`. | `opencode_app/Dockerfile` (`ARG OPENCODE_VERSION`); `docker-compose.yml` (`OPENCODE_VERSION` default) | Match the user's actual runtime; pick up the SSE reconnect-loop fix and expired-session reconnect. Non-breaking for MCP. |
+| 2 | **HIGH** | Bump `@opencode-ai/plugin` `1.14.20` → `^1.18.11`. | `.opencode/package.json` | Plugin version must track opencode; 1.14.20 is ~4 minors stale. Run `bun install` + typecheck afterward. |
+| 3 | **MED** | After bumping, verify the repo's own plugins still typecheck against the current plugin API (`Plugin`, `tool`/`tool.schema`, hook names). | `.opencode/plugins/*` | API drift between 1.14 and 1.18 is plausible `[UNVERIFIED]`. |
+| 4 | **MED** | Verify Atlassian MCP still authenticates after the bump (the SDK v2 Atlassian OAuth issuer mismatch was reverted, so 1.18.11 should be fine — confirm empirically). Re-auth via `opencode mcp auth <atlassian-name>` if needed. | `opencode.json` (Atlassian entry); `~/.mcp-auth` | The `/v1/mcp` endpoint is reached through the `mcp-remote` bridge, which is unaffected by the OpenCode SDK version. |
+| 5 | **LOW** | **Do NOT** migrate the `mcp-remote` bridges (Atlassian/Google/Microsoft) to native `type:"remote"` yet. Defer until OpenCode re-lands MCP SDK v2 with working OAuth. | `opencode.json` | The native remote-OAuth path is the one that regressed and was reverted; bridges remain the robust choice in 1.18.11. |
+| 6 | **LOW** | Keep `permission.read: { "mcp:*": "deny" }`. | `opencode.json` | Harmless defense-in-depth; bug-fix status unconfirmed (§6). |
+| 7 | **LOW** | Optionally add `timeout` keys to long-startup MCP servers if you see 5s default timeouts (e.g. markitdown-local-mcp, next-devtools). | `opencode.json` | `timeout` is a documented (ms, default 5000) additive key; not required. |
+
+---
+
+## 9. Open questions / things to verify empirically
+
+1. **`read_mcp_resource` / `list_mcp_resources` visibility bug in 1.18.11 `[UNVERIFIED]`.** Docs neither confirm nor deny a fix. Test: with the `mcp:*` deny removed, check whether those tools still leak into the model's tool list; if not, the deny can eventually be dropped.
+2. **Whether any Pattern-1 `type:"remote"` endpoint has dropped SSE back-compat** (streamable-HTTP-only) and therefore breaks under the v1 SDK in 1.18.11. Per-endpoint; confirm Autodesk / Z.AI endpoints still respond to the v1 client.
+3. **Atlassian `/v1/mcp` via the bridge** post-bump — confirm OAuth + tool listing works (the bridge does transport negotiation, but token refresh after long uptime should be exercised).
+4. **`@opencode-ai/plugin` API drift 1.14.20 → 1.18.11** — whether any hook/type the repo's plugins use was renamed/removed.
+5. **Docker base/runtime artifact differences** 1.18.3 → 1.18.11 that might affect the Dockerfile install step.
+6. **When OpenCode will re-land MCP SDK v2 / stateless support.** PR #39373 says "until those interoperability gaps are resolved." No public target date found `[UNVERIFIED]`. Watch future 1.19.x releases for a re-attempt; *that* is when the bridge→native migration question becomes live.
+
+---
+
+## 10. References (every URL fetched + what it confirmed)
+
+1. `https://opencode.ai/docs/mcp/` — **404.** Wrong path; correct MCP page is `/docs/mcp-servers/` (found via docs nav).
+2. `https://github.com/anomalyco/opencode/releases` — Release list v1.18.0–v1.18.11. Confirmed v1.18.11 notes contain **no "stateless" mention**; only an SSE reconnect-loop fix. Confirmed canonical org is **`anomalyco`** (the old `sst/...` redirects here).
+3. `https://www.npmjs.com/package/@opencode-ai/plugin` — Confirms **`@opencode-ai/plugin@1.18.11`** is current (published ~2 days ago); version tracks opencode.
+4. `https://opencode.ai/docs/` — Docs nav; locates MCP page at `/docs/mcp-servers/`, server page at `/docs/server/`, plugins at `/docs/plugins/`.
+5. `https://opencode.ai/docs/server/` — `opencode serve` defaults (port 4096, 127.0.0.1), `OPENCODE_SERVER_PASSWORD`. No stateless-related env vars.
+6. `https://github.com/anomalyco/opencode/issues?q=stateless+mcp` — Surfaced the SDK v2 PRs (#39247, #38673) and session-recovery PRs; **no direct "stateless" issue exists** — the term comes from the SDK v2 "modern stateless protocol" work.
+7. `https://github.com/anomalyco/opencode/releases/tag/v1.18.0` — v1.18.0 notes (Desktop v2 only); no MCP transport change.
+8. `https://opencode.ai/docs/mcp-servers/` — **Authoritative MCP config schema:** `type` local/remote; local keys (`command`, `cwd`, `environment`, `enabled`, `timeout`); remote keys (`url`, `enabled`, `headers`, `oauth` (object|false), `timeout`); OAuth via Dynamic Client Registration; `mcp auth/list/logout/debug` CLI. **No `transport`/`stateless` user-facing key.** Confirms MCP surfaced as tools only.
+9. `https://opencode.ai/docs/config/` — Full config schema + 8-tier precedence; confirms MCP `oauth`/`timeout` are additive; no removed keys.
+10. `https://opencode.ai/docs/plugins/` — Plugin API (`Plugin` type, `tool`/`tool.schema`, hooks incl. `experimental.session.compacting`); plugins installed via Bun at startup into `~/.cache/opencode/node_modules`.
+11. `https://github.com/anomalyco/opencode/pull/39247` — **The stateless feature.** "replace `@modelcontextprotocol/sdk@1.29.0` … with `@modelcontextprotocol/client@2.0.0-beta.5` … negotiate **modern stateless** and legacy MCP servers." Merged Jul 28 → **v1.18.8**.
+12. `https://modelcontextprotocol.io/specification/2025-06-18/basic/transports` — MCP spec: Streamable HTTP (modern, sessions optional ⇒ stateless) **replaces** HTTP+SSE (2024-11-05); backwards-compat negotiation (POST Initialize → 2xx = streamable; 4xx = legacy SSE+GET). Defines `MCP-Protocol-Version` and `Mcp-Session-Id`.
+13. `https://www.npmjs.com/package/mcp-remote` — `mcp-remote@0.1.38`, "experimental proof-of-concept," transport strategies (`http-first` default w/ SSE fallback, `sse-first`, `http-only`, `sse-only` via `--transport`). README: "As soon as your chosen MCP client supports remote, authorized servers, you can remove it."
+14. `https://opencode.ai/docs/tools/` — Built-in tools list; **`read_mcp_resource`/`list_mcp_resources` are NOT documented** as built-in tools; MCP exposed only as `<servername>_*` tools.
+15. `https://github.com/anomalyco/opencode/pull/39373` — **The revert.** "revert the MCP client SDK v2 migration from #39247 … restore `@modelcontextprotocol/sdk` 1.29.0." Rationale: "SDK v2 client is not quite ready for production use." Fixed Atlassian OAuth issuer mismatch (#39332), Draft-07 schema rejection (#39333), `server/discover` no-fallback (#39354), ReUI OAuth (#39343), Xcode timeout (#39315). Merged Jul 28 → **v1.18.9**.
+
+---
+
+*End of report. All findings sourced; unconfirmed items flagged `[UNVERIFIED]`. No version numbers or config keys were fabricated — where the docs are silent, §9 says so explicitly.*

--- a/research/research-zai-glm-5v-turbo-opencode-access.md
+++ b/research/research-zai-glm-5v-turbo-opencode-access.md
@@ -1,0 +1,332 @@
+# Can we reach Z.AI `glm-5v-turbo` (vision) via OpenCode using Z.AI coding-plan access?
+
+> Research date: 2026-08-03 · Investigator: autonomous web-research agent (Tier 2, web-only).
+> All fetched content treated as untrusted data; no fabricated IDs/endpoints/prices — unknowns
+> are marked `[UNVERIFIED]`. Every claim cites a fetched URL.
+>
+> NOTE: requested filename `research/zai-glm-5v-turbo-opencode-access.md` was blocked by
+> path-restricted edit permissions (filename must match `research*.md`); written here instead.
+
+---
+
+## 1. Executive answer
+
+**Conditional — and the condition is NOT bypassable with coding-plan credentials alone.**
+
+`glm-5v-turbo` is fully reachable through OpenCode, but **only via the standard pay-as-you-go Z.AI
+API** (endpoint `https://api.z.ai/api/paas/v4`, Bearer API key). It is **already listed natively**
+on the OpenCode/`models.dev` `zai` provider, so selecting it requires no shim, no custom code, and no
+proxy — just a *standard* Z.AI API key and `/connect` → **Z.AI** (not "Z.AI Coding Plan").
+
+The reason OpenCode reports it "not supported" for you is that you are on the **`zai-coding-plan`**
+provider (your primary model `zai-coding-plan/glm-5.2`). The `zai-coding-plan` provider catalog —
+sourced from `models.dev` — contains **exactly four text/coding models** and explicitly excludes
+`glm-5v-turbo`. The GLM Coding Plan subscription routes *vision* to a separate **GLM-4.6V MCP
+server**, not to `glm-5v-turbo`, and its dedicated endpoint (`/api/coding/paas/v4`) is "strictly
+limited to use within officially supported tools." So the coding-plan credential cannot authorize
+`glm-5v-turbo`; reaching it requires a separate pay-as-you-go key.
+
+---
+
+## 2. Root cause of "not supported" — exact mechanism
+
+It is a **provider-catalog / models.dev data** issue, **not** an OpenCode-side vision filter and
+**not** an auth-capability rejection at selection time. Evidence chain:
+
+1. **OpenCode builds its entire provider/model catalog from `models.dev`.**
+   OpenCode docs: *"OpenCode uses the AI SDK and Models.dev to support 75+ LLM providers."*
+   (https://opencode.ai/docs/providers). Source proof in
+   `packages/opencode/src/provider/provider.ts`
+   (https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/provider/provider.ts):
+   the provider layer runs `const modelsDev = yield* modelsDevSvc.get()` then
+   `const catalog = mapValues(modelsDev, fromModelsDevProvider)` — i.e. every provider and its model
+   list is derived from the `@opencode-ai/models` (models.dev) snapshot. The `custom()` loader map in
+   the same file contains entries for `anthropic`, `openai`, `azure`, `amazon-bedrock`, `gitlab`,
+   `cloudflare-*`, `snowflake-cortex`, `openrouter`, `nvidia`, etc. — **but no `zai` or
+   `zai-coding-plan` entry**. That means both Z.AI providers are plain catalog providers straight from
+   models.dev (no OpenCode-specific filter applied to them).
+
+2. **`models.dev` defines `zai` and `zai-coding-plan` as two distinct providers.**
+   - `zai` — API `https://api.z.ai/api/paas/v4`, package `@ai-sdk/openai-compatible`, **14 models
+     including `glm-5v-turbo`** ($1.20 / $4.00, marked "Provider-specific").
+     (https://models.dev/providers/zai)
+   - `zai-coding-plan` — API `https://api.z.ai/api/coding/paas/v4`, package
+     `@ai-sdk/openai-compatible`, **only 4 models**: `glm-4.7`, `glm-5-turbo`, `glm-5.2`,
+     `glm-5.2-highspeed` (all $0.00, subscription). **No `glm-5v-turbo`.**
+     (https://models.dev/providers/zai-coding-plan)
+
+3. **Therefore OpenCode cannot offer `zai-coding-plan/glm-5v-turbo`.** When you ask for a model not
+   in the provider's catalog, OpenCode throws `ModelNotFoundError: Model not found:
+   zai-coding-plan/glm-5v-turbo` (see the `ModelNotFoundError` class in `provider.ts`, whose message
+   is exactly *"Model not found: {providerID}/{modelID}"*). This is the "not supported" surface. It
+   is a catalog-membership failure, not a capability/auth check.
+
+4. **Why models.dev omits it from the coding plan** mirrors Z.AI's own product split: the GLM Coding
+   Plan's vision path is the **Vision MCP Server using GLM-4.6V**
+   (https://docs.z.ai/devpack/quick-start → "Vision MCP Server (Coding Plan Exclusive)": *"employs
+   the flagship vision reasoning model GLM-4.6V to comprehend and analyze image content"*). `glm-5v-turbo`
+   is a **standard pay-as-you-go API model** documented at
+   https://docs.z.ai/guides/vlm/glm-5v-turbo against the standard endpoint, with no coding-plan
+   mention anywhere. So the models.dev data accurately reflects Z.AI's product boundary.
+
+**One-line root cause:** *`glm-5v-turbo` is not in the `zai-coding-plan` provider's models.dev model
+list (only 4 coding models are), so OpenCode's catalog-driven `getModel()` rejects it; the model is
+natively present only on the separate `zai` (standard pay-as-you-go) provider.*
+
+---
+
+## 3. Z.AI `glm-5v-turbo` API facts
+
+Source: https://docs.z.ai/guides/vlm/glm-5v-turbo (Z.AI official guide).
+
+| Fact | Value |
+|---|---|
+| Model ID | `glm-5v-turbo` |
+| Standard endpoint | `https://api.z.ai/api/paas/v4/chat/completions` |
+| Auth header | `Authorization: Bearer <API_KEY>` |
+| Protocol | OpenAI-compatible chat completions |
+| Multimodal input | OpenAI-style `content` array: `{"type":"image_url","image_url":{"url":"..."}}` + `{"type":"text","text":"..."}` (also accepts video/files) |
+| Output | Text only |
+| Context / max output | 200,000 / ~131,072 tokens |
+| Extra params | `thinking: {"type":"enabled"}`, streaming (`stream:true`), function/tool calling |
+| Pricing (Z.AI standard, via models.dev `zai`) | **$1.20 / $4.00** per 1M (input/output) — https://models.dev/providers/zai |
+| Pricing (Zhipu bigmodel.cn `zhipuai`) | $5.00 / $22.00 — https://models.dev/providers/zhipuai |
+
+Notes:
+- The exact Z.AI-published list price on the Z.AI pricing page was not separately fetched; the
+  `$1.20/$4.00` figure is models.dev's recorded value for the `zai` provider `[VERIFY on
+  https://docs.z.ai/guides/overview/pricing if billing-critical]`.
+- **No `X-Title` header** appears in any official Z.AI example. `X-Title` is an **OpenRouter-style**
+  client-identification header (see §4/§5). Z.AI does not require it.
+
+---
+
+## 4. Auth: coding-plan vs API key — does `ZAI_API_KEY` authorize `glm-5v-turbo`?
+
+This is the feasibility crux. Two credential classes exist, with **different endpoints and scopes**:
+
+| Credential | Where obtained | Endpoint(s) | Serves `glm-5v-turbo`? |
+|---|---|---|---|
+| **GLM Coding Plan key** | "Individual Coding Plan > Plan Overview" / "Team Coding Plan > My Plan" (https://docs.z.ai/devpack/quick-start) | `https://api.z.ai/api/coding/paas/v4` (OpenAI) · `https://api.z.ai/api/anthropic` (Anthropic) | **No** — only 4 coding models; vision via GLM-4.6V MCP |
+| **Standard API key** (pay-as-you-go) | "API Keys" management page, requires billing top-up (https://docs.z.ai Quick Start) | `https://api.z.ai/api/paas/v4` (and `/v4/...`) | **Yes** — `glm-5v-turbo` ($1.20/$4.00) |
+
+Key supporting facts:
+- Z.AI states the coding plan is **"strictly limited to use within officially supported tools and
+  products"** and that **"The Team Plan Key is not interchangeable with other Z.AI's API Keys"**
+  (https://docs.z.ai/devpack/quick-start). This confirms coding-plan keys are **scoped** and not
+  equivalent to standard API keys.
+- The `glm-5v-turbo` guide only ever shows the **standard** endpoint `/api/paas/v4` with a generic
+  API key — it is never referenced inside the `/devpack/` (coding-plan) docs.
+
+**About `ZAI_API_KEY`:** In this repo, `ZAI_API_KEY` is the env var the `zai-vision-analysis-skill`
+uses to call the **free `glm-4.6v-flash`** model *directly* against the standard API — explicitly
+because that free flash SKU *"is not in models.dev, so it is reachable only via this direct API call
+(not the `zai` provider)"* (per repo `AGENTS.md`). Since the free flash lives on the **standard**
+`/api/paas/v4` endpoint, the skill's documented behavior implies **`ZAI_API_KEY` is a standard
+pay-as-you-go key**, not a coding-plan key.
+
+**Conclusion:**
+- A **coding-plan** credential → **cannot** reach `glm-5v-turbo`. (Two independent blockers: the
+  OpenCode catalog has no such model under `zai-coding-plan`, and the `/api/coding/paas/v4` endpoint
+  does not serve it.)
+- A **standard pay-as-you-go** key → **can** reach `glm-5v-turbo`, natively, no shim.
+- If your existing `ZAI_API_KEY` is the standard key used by the skill, **you already have what you
+  need** `[UNVERIFIED for your specific key — confirm in the Z.AI console whether the key is listed
+  under "API Keys" (standard) vs "Coding Plan"]`. If it is the coding-plan key, you must create a
+  separate standard API key and add pay-as-you-go credit.
+
+---
+
+## 5. Three bypass approaches ranked
+
+### (A) Use the built-in `zai` (standard) provider — **RECOMMENDED, viability: high, effort: trivial**
+
+Because `glm-5v-turbo` is **already in the `zai` provider's models.dev catalog**
+(https://models.dev/providers/zai), there is nothing to "bypass." You simply connect the standard
+provider alongside your coding plan:
+
+1. `opencode auth login` → select **Z.AI** (the standard entry, *not* "Z.AI Coding Plan").
+2. Paste a **standard pay-as-you-go** Z.AI API key.
+3. `/models` → select **`zai/glm-5v-turbo`**.
+
+This coexists with your existing `zai-coding-plan` credential (both are stored in
+`~/.local/share/opencode/auth.json`). No custom config required.
+
+*Optional* — if you prefer to pin the key/endpoint in config (or alias the provider) instead of
+`/connect`, a custom `@ai-sdk/openai-compatible` provider works (this is the exact mechanism the
+repo's existing `lmstudio` provider and OpenCode's `ollama`/`Atomic Chat`/`Helicone` examples use;
+the package is bundled in `provider.ts` `BUNDLED_PROVIDERS["@ai-sdk/openai-compatible"]`):
+
+```jsonc
+// opencode.json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "zai-vision": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Z.AI Vision (glm-5v-turbo, pay-as-you-go)",
+      "options": {
+        "baseURL": "https://api.z.ai/api/paas/v4"
+      },
+      "models": {
+        "glm-5v-turbo": { "name": "GLM-5V-Turbo" }
+      }
+    }
+  }
+}
+```
+The API key for a custom provider is supplied the same way as any provider (via the `env`/auth flow
+or `/connect` if keyed to a known provider). `[VERIFY the exact inline-key option for arbitrary
+custom provider IDs — the OpenCode docs only show `options.baseURL`/`options.headers` for custom
+providers, not `options.apiKey`; the reliable path is `/connect` → Z.AI.]`
+
+Limitations: requires a **standard** key + pay-as-you-go credit; bills per-token ($1.20/$4.00).
+
+### (B) Local OpenAI-compatible proxy/shim (the `X-Title: "4.5V MCP Local"` idea) — viability: medium, effort: medium
+
+A tiny local server that accepts OpenAI-shaped `/v1/chat/completions` calls, attaches
+`Authorization: Bearer $ZAI_API_KEY`, forwards to `https://api.z.ai/api/paas/v4/chat/completions`,
+and streams the response back. Point an `@ai-sdk/openai-compatible` provider at it:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "zai-proxy": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Z.AI via local proxy",
+      "options": { "baseURL": "http://127.0.0.1:8787/v1" },
+      "models": { "glm-5v-turbo": { "name": "GLM-5V-Turbo" } }
+    }
+  }
+}
+```
+Pros: lets you inject custom headers, log traffic, or share one key across tools. Cons: strictly
+**more** moving parts than (A) with no added capability for this model — (A) already does
+everything the shim would do, natively.
+
+**About `X-Title`:** It is **not a Z.AI requirement.** In OpenCode's own source (`provider.ts`) and
+docs, `X-Title` is the OpenRouter-style client-identification header sent to gateway/aggregator
+providers — `openrouter`, `llmgateway`, `nvidia`, `vercel`, `kilo`, and `zenmux` all set
+`"X-Title": "opencode"`. Z.AI's own `glm-5v-turbo` examples never include it. The snippet's
+`X-Title: "4.5V MCP Local"` is simply the shim naming itself (OpenRouter convention); it is
+harmless but unnecessary against Z.AI's API.
+
+### (C) Extend `zai-vision-analysis-skill` to also call `glm-5v-turbo` — viability: high, effort: low, BUT limited role
+
+Add a `model` parameter to the skill (default `glm-4.6v-flash`, allow `glm-5v-turbo`) so it issues
+the same direct-API call pattern against `/api/paas/v4` with a standard key. Cheapest change if you
+only need **occasional image analysis as a tool**.
+
+**Critical limitation:** a skill is a **one-shot tool invocation**, not a **model provider**. The
+agent cannot use `glm-5v-turbo` as its *reasoning loop* (it can't be the `model` the session runs
+on). It can only be *called by* the running agent to inspect an image and return text. If your goal
+is "run the agent itself on glm-5v-turbo," you need (A), not (C).
+
+**Ranking:** **(A) > (C) > (B).** (A) is native, zero-config, and gives full provider semantics;
+(C) is the right pick only for tool-style vision; (B) is unnecessary for this model.
+
+---
+
+## 6. Recommended path
+
+**Use (A): connect the standard `zai` provider with a pay-as-you-go key and select
+`zai/glm-5v-turbo`.** It is the only approach that (i) requires no custom code, (ii) is natively
+supported by OpenCode's models.dev catalog, and (iii) lets glm-5v-turbo serve as the agent's
+reasoning model.
+
+Concrete next step:
+1. In the Z.AI console (https://z.ai/manage-apikey/apikey-list), confirm you have a **standard** API
+   key (not the coding-plan key) and that pay-as-you-go credit is topped up.
+2. `opencode auth login` → **Z.AI** (standard) → paste the standard key.
+3. `/models` → `zai/glm-5v-turbo`.
+
+Keep the `zai-coding-plan` provider for your `glm-5.2` coding work; the two providers coexist.
+If you only need vision as an occasional tool and want to reuse the existing flash-based skill,
+extend the skill per (C) with a `model` switch instead.
+
+---
+
+## 7. models.dev contribution option
+
+models.dev is open-source: repo **https://github.com/sst/models.dev** (also redirected from
+`anomalyco/models.dev`), "data is stored in GitHub as TOML files organized by provider and canonical
+model" (https://models.dev/providers/zai footer).
+
+- For the **`zai`** provider: **not needed** — `glm-5v-turbo` is already listed.
+- For the **`zai-coding-plan`** provider: you *could* PR to add `glm-5v-turbo` to its TOML, but it is
+  **futile and counterproductive** — even if OpenCode then offered `zai-coding-plan/glm-5v-turbo` in
+  the picker, the `/api/coding/paas/v4` endpoint would reject the call (the coding-plan subscription
+  does not grant that model). You'd get a runtime 4xx instead of a clean "model not found." Do not do
+  this.
+
+So the upstream path does not solve the problem; the standard `zai` provider already carries the
+model.
+
+---
+
+## 8. Open questions / `[UNVERIFIED]` items to test empirically
+
+1. **Is your `ZAI_API_KEY` a standard or coding-plan key?** Check the Z.AI console listing. The skill's
+   documented use of the free flash strongly implies standard, but confirm. *(Decides whether step 1
+   of §6 is even needed.)*
+2. **Exact Z.AI list price** for `glm-5v-turbo` on the standard API. models.dev `zai` records
+   $1.20/$4.00; verify on https://docs.z.ai/guides/overview/pricing before budgeting.
+3. **Mechanism of the coding-plan "supported tools only" enforcement** — likely server-side client
+   identification (User-Agent / a tool header) on `/api/coding/paas/v4`. `[UNVERIFIED]`. Irrelevant
+   to the recommended path (standard API), but relevant if anyone tries to force coding-plan traffic
+   at vision models.
+4. **Whether a coding-plan key returns a clean error** if pointed at `/api/paas/v4` or at
+   `glm-5v-turbo`. Expect a 401/403/404; not tested here.
+5. **Inline `options.apiKey` for arbitrary custom provider IDs** in `opencode.json` (used in §5A
+   custom variant). The docs only confirm `options.baseURL`/`options.headers`; verify before relying
+   on a config-only custom provider (otherwise use `/connect`).
+6. **Multimodal attachment plumbing**: confirm OpenCode's image-attachment path sends the
+   `content` array shape Z.AI expects (the `glm-5v-turbo` guide confirms Z.AI accepts the standard
+   OpenAI multimodal array, so this should "just work" once the provider is connected).
+
+---
+
+## 9. References (every URL fetched + what it confirmed)
+
+- **https://models.dev** (homepage) — GLM model families exist under lab `zhipuai`; GLM-5V-Turbo is a
+  real canonical model.
+- **https://models.dev/providers/zai-coding-plan** — **decisive**: `zai-coding-plan` provider has
+  exactly 4 models (`glm-4.7`, `glm-5-turbo`, `glm-5.2`, `glm-5.2-highspeed`), endpoint
+  `https://api.z.ai/api/coding/paas/v4`, no `glm-5v-turbo`. → root cause of "not supported".
+- **https://models.dev/providers/zai** — standard `zai` provider, endpoint
+  `https://api.z.ai/api/paas/v4`, **includes `glm-5v-turbo`** ($1.20/$4.00). → the native solution.
+- **https://models.dev/providers/zhipuai** — Zhipu/bigmodel.cn provider; also lists `glm-5v-turbo`
+  ($5.00/$22.00) at `https://open.bigmodel.cn/api/paas/v4` (separate from Z.AI international).
+- **https://models.dev/models/zhipuai/glm-5v-turbo** — model page: 7 aggregator providers; specs
+  (200K ctx, tools/reasoning/temperature).
+- **https://docs.z.ai** (Quick Start) — standard endpoint
+  `https://api.z.ai/api/paas/v4/chat/completions`, OpenAI-SDK compatibility
+  (`base_url=https://api.z.ai/api/paas/v4/`); warning that GLM Coding Plan uses a **dedicated
+  endpoint**.
+- **https://docs.z.ai/devpack/quick-start** — coding-plan endpoints
+  (`/api/anthropic`, `/api/coding/paas/v4`); **"strictly limited to officially supported tools"**;
+  Team Plan key **"not interchangeable"** with other API keys; coding-plan vision = **Vision MCP
+  Server (GLM-4.6V)**, not glm-5v-turbo.
+- **https://docs.z.ai/devpack/tool/opencode** — official OpenCode coding-plan wiring via
+  `opencode auth login` → "Z.AI Coding Plan"; `/models` to pick GLM models; vision via the MCP
+  servers.
+- **https://docs.z.ai/guides/vlm/glm-5v-turbo** — model ID `glm-5v-turbo`; standard endpoint; OpenAI
+  multimodal `content` array; `thinking`, streaming, tool-calling; 200K context. No `X-Title`.
+- **https://opencode.ai/docs/providers** — "OpenCode uses the AI SDK and Models.dev"; `baseURL`
+  override, `blacklist`/`whitelist`; custom-provider pattern (`"npm":"@ai-sdk/openai-compatible"` +
+  `options.baseURL` + `models` map) via LM Studio / Ollama / llama.cpp / Atomic Chat / Helicone
+  examples; `options.headers` for custom headers.
+- **https://opencode.ai/docs/models** — model IDs are `provider_id/model_id`; built-in names "can be
+  found on Models.dev"; model-loading priority.
+- **https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/opencode/src/provider/provider.ts**
+  — source proof: catalog = `mapValues(modelsDev, fromModelsDevProvider)`; `ModelNotFoundError`
+  message = `"Model not found: {providerID}/{modelID}"`; `@ai-sdk/openai-compatible` bundled; `X-Title:
+  "opencode"` set for openrouter/llmgateway/nvidia/vercel/kilo/zenmux (OpenRouter convention); no
+  `zai`/`zai-coding-plan` custom loader (so they are pure catalog providers).
+- **https://api.github.com/repos/anomalyco/opencode/contents/packages/opencode/src/provider** —
+  located `provider.ts` as the provider-definition file.
+- **https://github.com/sst/opencode** & **https://github.com/anomalyco/opencode** — confirmed
+  canonical org (`anomalyco/opencode`, `sst/opencode` redirects there).
+- **https://github.com/sst/models.dev** — models.dev source (TOML per provider/model); PR target for
+  catalog changes.


### PR DESCRIPTION
## Summary

Commits the three research reports produced during the 1.18.11 upgrade investigation as decision documentation.

## Reports

| Report | Conclusion |
|--------|------------|
| `research-opencode-11811-stateless-mcp.md` | No "stateless MCP" feature in 1.18.11 — MCP SDK v2 shipped in v1.18.8 ([#39247](https://github.com/anomalyco/opencode/pull/39247)), fully reverted in v1.18.9 ([#39373](https://github.com/anomalyco/opencode/pull/39373)). 1.18.3 → 1.18.11 is non-breaking. |
| `mcp-11811-implementation-audit.md` | Per-server audit of all 26 MCP servers — zero required config changes; only version-pin bumps (applied in #288). |
| `research-zai-glm-5v-turbo-opencode-access.md` | `glm-5v-turbo` is reachable via the **standard `zai` provider** (already in models.dev), **not** via coding-plan access (coding-plan catalog = 4 coding models only). |

## Why

Preserves the reasoning behind #288 (version bumps) and documents the glm-5v-turbo access path so the finding (coding-plan can't reach it; standard `zai` provider already lists it natively) isn't lost.

## Verification

- Docs-only change; no code/config/tests touched.
- No bats assertions affected.

🤖 Generated with [opencode](https://opencode.ai)