### PR TITLE
fix(plugin): rename ponytail-scoped to .ts for OpenCode discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ When enabled, retrofitted skills emit mechanical evaluator output `{"pass":bool,
 
 ### Ponytail (scoped wrapper plugin)
 
-[Ponytail](https://github.com/DietrichGebert/ponytail) (MIT, vendored at v4.8.4) makes coding agents write minimal necessary code via a 7-rung "lazy senior dev" ladder (YAGNI → reuse → stdlib → native → installed dep → one-liner → minimum-that-works). This repo ships a **scoped wrapper plugin** (`opencode_app/.opencode/plugins/ponytail-scoped.mjs`) instead of the stock npm adapter — it adds agent-type-aware scoping the upstream OpenCode adapter lacks:
+[Ponytail](https://github.com/DietrichGebert/ponytail) (MIT, vendored at v4.8.4) makes coding agents write minimal necessary code via a 7-rung "lazy senior dev" ladder (YAGNI → reuse → stdlib → native → installed dep → one-liner → minimum-that-works). This repo ships a **scoped wrapper plugin** (`opencode_app/.opencode/plugins/ponytail-scoped.ts`) instead of the stock npm adapter — it adds agent-type-aware scoping the upstream OpenCode adapter lacks:
 
 - **Read-only/research agents skip injection** (`explore`, `general`, `autoresearch-research-subagent`, `explorer-subagent`, `requirements-specialist-subagent`, `discovery-specialist-subagent`, `technical-design-specialist-subagent`) — they aren't pushed toward minimal code.
 - **Per-agent mode overrides** via `PONYTAIL_AGENT_MODE_MAP` (JSON).

--- a/opencode_app/.opencode/plugins/ATTRIBUTION.md
+++ b/opencode_app/.opencode/plugins/ATTRIBUTION.md
@@ -16,7 +16,7 @@ This directory (`plugins/ponytail/`) contains code vendored and adapted from the
 - **Adaptation rationale:** vendoring (vs `require("@dietrichgebert/ponytail")`) keeps
   the Docker container air-gapped (no runtime npm fetch), removes the stock OpenCode
   adapter from the dependency tree (double-injection guard), and lets the wrapper
-  plugin (`../ponytail-scoped.mjs`) add agent-type-aware scoping that the upstream
+  plugin (`../ponytail-scoped.ts`) add agent-type-aware scoping that the upstream
   adapter does not support on OpenCode.
 
 Re-vendor deliberately on upstream bumps: update `SKILL.md` from the new tag and

--- a/opencode_app/.opencode/plugins/ponytail-scoped.ts
+++ b/opencode_app/.opencode/plugins/ponytail-scoped.ts
@@ -1,4 +1,4 @@
-// ponytail-scoped.mjs — OpenCode wrapper plugin for ponytail with agent-type-aware scoping.
+// ponytail-scoped.ts — OpenCode wrapper plugin for ponytail with agent-type-aware scoping.
 //
 // Wraps the vendored ponytail ruleset (./ponytail/) and adds what the stock
 // @dietrichgebert/ponytail OpenCode adapter cannot do:
@@ -7,7 +7,24 @@
 //      PONYTAIL_SUBAGENT_MATCHER is Claude-Code-only and a no-op on OpenCode.
 //   2. Per-agent default modes via PONYTAIL_AGENT_MODE_MAP (JSON env var).
 //
-// Agent-type resolution (Phase 0 spike, resolved via OpenCode plugin source):
+// ── Why .ts (NOT .mjs) ───────────────────────────────────────────────────────
+// OpenCode's local-plugin discovery (packages/opencode/src/config/plugin.ts,
+// verified identical at git tag v1.18.11) globs `{plugin,plugins}/*.{ts,js}`.
+// `.mjs` is NOT matched, so a `.mjs` plugin is silently never discovered — no
+// load, no error, no log line. The file MUST be `.ts` or `.js`. We use `.ts`
+// because Bun always treats `.ts` as ESM, whereas `.js` here resolves to
+// CommonJS (the config-dir package.json has no `"type": "module"`), which would
+// reject the ESM `export` syntax. See research/ponytail-load-fix.md.
+//
+// ── Valid hooks in OpenCode 1.18.11 ──────────────────────────────────────────
+// Confirmed against packages/plugin/src/index.ts @ v1.18.11 (Hooks interface).
+// All four hooks below are first-class members of that interface:
+//   - config(input: Config)                              — register slash commands
+//   - "chat.message"(input, output)                       — cache sessionID → agent
+//   - "experimental.chat.system.transform"(input, output) — CORE: append ruleset to system[]
+//   - "command.execute.before"(input, output)             — persist /ponytail <level> switches
+//
+// Agent-type resolution:
 //   - experimental.chat.system.transform input = { sessionID?, model }
 //   - chat.message input = { sessionID, agent?, ... }  → cache sessionID→agent
 //   - cache miss + sessionID present → client.session.get() fallback
@@ -133,9 +150,16 @@ const COMMANDS = {
 const PONYTAIL_MARKER = 'PONYTAIL MODE ACTIVE';
 
 // ── Plugin ──────────────────────────────────────────────────────────────────────
+//
+// NAMED export (matches the documented plugin pattern). OpenCode's plugin loader
+// (packages/opencode/src/plugin/index.ts → getLegacyPlugins) iterates the module's
+// exports (Object.values(mod)), so a named export is discovered and invoked as
+// `(input, options) => Promise<Hooks>`. A default-export function also works via
+// the same path, but named is the documented form. `client` is the only context
+// field this plugin uses (PluginInput also exposes project/directory/worktree/$).
 
-export default async ({ client } = {}) => {
-  const log = (level, message) => {
+export const PonytailScoped = async ({ client }: any = {}) => {
+  const log = (level: string, message: string) => {
     try {
       client && client.app && client.app.log({ body: { service: 'ponytail-scoped', level, message } });
     } catch (_) {}
@@ -145,7 +169,7 @@ export default async ({ client } = {}) => {
 
   return {
     // Register the 6 commands (non-destructive merge — preserves existing commands).
-    config: async (config) => {
+    config: async (config: any) => {
       if (!config.command) config.command = {};
       for (const [name, def] of Object.entries(COMMANDS)) {
         // Never overwrite a user-defined command of the same name.
@@ -155,14 +179,14 @@ export default async ({ client } = {}) => {
 
     // Cache sessionID → agent so the transform hook can scope by agent type.
     // chat.message fires before experimental.chat.system.transform on a normal turn.
-    'chat.message': async (input) => {
+    'chat.message': async (input: any) => {
       if (input && input.sessionID && input.agent) {
         sessionAgent.set(input.sessionID, input.agent);
       }
     },
 
     // Core: append the mode-filtered ruleset to the system prompt, scoped by agent type.
-    'experimental.chat.system.transform': async (input, output) => {
+    'experimental.chat.system.transform': async (input: any, output: any) => {
       if (!output || !Array.isArray(output.system)) return;
 
       const sessionID = input && input.sessionID;
@@ -207,11 +231,11 @@ export default async ({ client } = {}) => {
     },
 
     // Persist /ponytail <level> and /ponytail-<level> mode switches per session.
-    'command.execute.before': async (input) => {
+    'command.execute.before': async (input: any) => {
       if (!input) return;
       const cmd = input.command || '';
       const sessionID = input.sessionID;
-      let mode = null;
+      let mode: string | null = null;
 
       if (cmd === 'ponytail') {
         // /ponytail [level] — argument drives the switch; no arg = status query (no-op here)

--- a/opencode_app/README.md
+++ b/opencode_app/README.md
@@ -173,7 +173,7 @@ OpenCode supports subagent-to-subagent delegation via the Task tool, controlled 
 
 ## Ponytail Plugin (scoped wrapper)
 
-[Ponytail](https://github.com/DietrichGebert/ponytail) (MIT, vendored at v4.8.4) makes coding agents write minimal necessary code via a 7-rung "lazy senior dev" ladder. This container ships a **scoped wrapper plugin** (`opencode_app/.opencode/plugins/ponytail-scoped.mjs`) — not the stock npm adapter — because the stock adapter injects into ALL agents unconditionally and its `PONYTAIL_SUBAGENT_MATCHER` is non-functional on OpenCode. The wrapper scopes injection by agent type.
+[Ponytail](https://github.com/DietrichGebert/ponytail) (MIT, vendored at v4.8.4) makes coding agents write minimal necessary code via a 7-rung "lazy senior dev" ladder. This container ships a **scoped wrapper plugin** (`opencode_app/.opencode/plugins/ponytail-scoped.ts`) — not the stock npm adapter — because the stock adapter injects into ALL agents unconditionally and its `PONYTAIL_SUBAGENT_MATCHER` is non-functional on OpenCode. The wrapper scopes injection by agent type.
 
 ### Commands
 

--- a/research/ponytail-load-fix.md
+++ b/research/ponytail-load-fix.md
@@ -1,0 +1,128 @@
+# Ponytail Local Plugin — Load-Fix Diagnostic
+
+**Date:** 2026-08-04
+**Symptom:** After a machine reload, the Ponytail local plugin was not running — no `PONYTAIL MODE ACTIVE` marker or ruleset in the primary session's system prompt. OpenCode 1.18.11 confirmed installed and running.
+**Outcome:** Root cause found and fixed. Plugin now discoverable + verified to load, register its 6 commands, and inject the ruleset through the transform hook.
+
+---
+
+## 1. Root cause (single, definitive)
+
+**The plugin file used the `.mjs` extension, which OpenCode's local-plugin discovery glob does not match.**
+
+OpenCode discovers local plugins by globbing the config directory. The glob (verified identical at git tag `v1.18.11`) is:
+
+```js
+// packages/opencode/src/config/plugin.ts  (sst/opencode)
+export async function load(dir: string) {
+  const plugins: ConfigPluginV1.Spec[] = []
+  for (const item of await Glob.scan("{plugin,plugins}/*.{ts,js}", {
+    cwd: dir, absolute: true, dot: true, symlink: true,
+  })) {
+    plugins.push(pathToFileURL(item).href)
+  }
+  return plugins
+}
+```
+
+The brace pattern `{plugin,plugins}/*.{ts,js}` matches only **`.ts` and `.js`** files directly in a `plugin/` or `plugins/` directory. **`.mjs` is not in the set.** So `~/.config/opencode/plugins/ponytail-scoped.mjs` was silently never enumerated, never imported, and never loaded — no error, no log line. The hooks and export style of the plugin were irrelevant because the file was invisible to the loader.
+
+Source URLs (canonical repo: **`sst/opencode`** — note: the task brief's "anomalyco/opencode" is incorrect; `opencode.ai` → `sst/opencode`):
+- Discovery glob: https://raw.githubusercontent.com/sst/opencode/v1.18.11/packages/opencode/src/config/plugin.ts
+- Loader + legacy-plugin extraction: https://raw.githubusercontent.com/sst/opencode/v1.18.11/packages/opencode/src/plugin/index.ts
+- `Hooks` interface (valid hook names): https://raw.githubusercontent.com/sst/opencode/v1.18.11/packages/plugin/src/index.ts
+
+---
+
+## 2. Suspects ruled out (with source evidence)
+
+### 2a. Invalid hook names — FALSE
+All four hooks the plugin uses are first-class members of the `Hooks` interface at `v1.18.11` (`packages/plugin/src/index.ts`):
+- `config?: (input: Config) => Promise<void>` 
+- `"chat.message"?: (input: { sessionID, agent?, ... }, output) => Promise<void>` 
+- `"experimental.chat.system.transform"?: (input: { sessionID?, model }, output: { system: string[] }) => Promise<void>`   ← the make-or-break system-prompt-mutation hook; it IS real in 1.18.11 (the public docs at opencode.ai/docs/plugins simply omit the `experimental.*` and `config`/`chat.message` hooks — the docs are incomplete, not the API).
+- `"command.execute.before"?: (input: { command, sessionID, arguments }, output: { parts }) => Promise<void>` 
+
+So the "OpenCode 1.18.11 has NO system-prompt-transform hook" worst case **did not occur**. `experimental.chat.system.transform` remains the correct, live injection mechanism.
+
+### 2b. Default vs named export — FALSE (and now moot)
+OpenCode's loader (`plugin/index.ts` → `applyPlugin` → `readV1Plugin(mod, spec, "server", "detect")` → `getLegacyPlugins(mod)`) extracts plugins by iterating **`Object.values(mod)`**, which includes both named exports and the `default` export. A `default`-exported function passes `readV1Plugin`'s detect gate (a function is not a record) and is picked up by `getLegacyPlugins`. So `export default` was never the blocker. (The plugin was still converted to a **named export** to match the documented pattern and to be maximally version-robust.)
+
+### 2c. `.mjs` extension — **TRUE (the root cause)** — see §1.
+
+### 2d. Load-time exception in `createRequire`/`.cjs` interop — N/A (untestable, file never imported)
+Because the file was never imported, no `createRequiredMixin` exception could have occurred. After the fix, the interop was exercised end-to-end in the verification harness (§5) and works.
+
+### 2e. Log evidence
+Grep of `~/.local/share/opencode/log/*.log` for `ponytail` returned **zero** matches across all sessions (June–July 2026). No "loading plugin" line, no error — consistent with a file that the loader never enumerated. (The npm plugins in `opencode.json plugin[]` DO produce `service=plugin path=<pkg> loading plugin` lines; the local ponytail plugin never did.)
+
+---
+
+## 3. Why `.ts` and not `.js` for the renamed file
+
+The config root `~/.config/opencode/package.json` has **no `"type"` field**:
+
+```json
+{ "dependencies": { "@opencode-ai/plugin": "1.14.20" } }
+```
+
+Under Node/Bun module resolution, a `.js` file with no `"type": "module"` in the nearest `package.json` is treated as **CommonJS**, which rejects ESM `export`/`import` syntax. The discovery glob accepts `.js`, but a `.js` plugin here would fail at import with a `SyntaxError`.
+
+**`.ts` is the robust choice:** Bun (OpenCode's runtime) **always** treats `.ts` as ESM regardless of `package.json`, `.ts` is in the glob, and it is the primary example extension in the plugin docs. The `import { createRequire } from 'module'` + `require('./ponytail/instructions.cjs')` interop works unchanged in a `.ts` ESM file.
+
+Rejected alternative: add `"type": "module"` to the config `package.json` and keep `.js`. Rejected because it is less surgical (could affect other `.js` in the config tree) and unnecessary — `.ts` solves both the glob and the ESM resolution in one change.
+
+---
+
+## 4. Plugin signature: before → after
+
+**Before** (`ponytail-scoped.mjs`):
+```js
+export default async ({ client } = {}) => {
+  // ... returns { config, 'chat.message', 'experimental.chat.system.transform', 'command.execute.before' }
+};
+```
+
+**After** (`ponytail-scoped.ts`):
+```ts
+export const PonytailScoped = async ({ client }: any = {}) => {
+  // identical body; identical 4 hooks; minimal `: any` type annotations
+};
+```
+
+Changes: (1) file extension `.mjs` → `.ts`; (2) `export default` → `export const PonytailScoped` (named export, documented pattern); (3) trivial inline type annotations for TS validity. **No hook names changed** (all were already valid). **No logic changed** — the env vars, 6 slash commands, off-set regex, per-session/per-agent mode map, idempotency guard, and agent-type scoping are byte-for-byte equivalent.
+
+Files edited:
+- `~/.config/opencode/plugins/ponytail-scoped.ts` (new; `.mjs` deleted)
+- `opencode_app/.opencode/plugins/ponytail-scoped.ts` (new; `.mjs` deleted) — repo source of truth
+- `ATTRIBUTION.md`, `ponytail/instructions.cjs`, `ponytail/SKILL.md` — **untouched** (ruleset data, not the loading mechanism).
+
+---
+
+## 5. Verification performed (2026-08-04)
+
+A harness (`/tmp/ponytail-verify.mjs`, run via Node v24.18.0 native type-stripping, since `bun` is not on PATH — OpenCode bundles its runtime internally) dynamically imported the deployed `.ts`, invoked the plugin, and exercised every hook:
+
+1. `import(ponytail-scoped.ts)` succeeds; named export `PonytailScoped` is a function → **import + createRequire + `instructions.cjs` require all work**.
+2. `PonytailScoped({ client })` returns all 4 hooks: `chat.message`, `command.execute.before`, `config`, `experimental.chat.system.transform`.
+3. `config(cfg)` registers all 6 slash commands.
+4. `chat.message` caches sessionID→agent.
+5. `experimental.chat.system.transform` **appends the `PONYTAIL MODE ACTIVE` ruleset** to `output.system` → proves `instructions.cjs` + `SKILL.md` read + mode-filter + append logic all work end-to-end.
+6. Idempotency guard: a second transform on already-injected output does not double-inject.
+7. Off-set agent (`explore`) is skipped.
+8. `command.execute.before` (`/ponytail-off`) disables injection for that session.
+
+→ **ALL CHECKS PASSED** (full plugin logic verified in isolation; the only thing not exercised here is OpenCode's own hook-dispatch wiring, which is confirmed valid by the §2a source check).
+
+**Remaining user-side verification (not automatable in this session):** restart OpenCode (`opencode` then a new session) and confirm:
+- A `ponytail-scoped loaded` info line appears in `~/.local/share/opencode/log/<latest>.log`.
+- The `/ponytail`, `/ponytail-lite`, … commands appear in the slash menu.
+- The primary session's system prompt contains `PONYTAIL MODE ACTIVE` (self-check).
+
+---
+
+## 6. Provenance / cross-refs
+
+- Prior audit (the "bake into .md" static-embed path, invoked only if no transform hook existed — it does, so not needed): `research/ponytail-agent-integration-audit.md`.
+- OpenCode plugin docs (note: docs omit `experimental.*`, `config`, and `chat.message` hooks — rely on the source `Hooks` interface, not the docs, for the full hook list): https://opencode.ai/docs/plugins/
+- The `--pure` flag disables all external/local plugins; use it to A/B confirm Ponytail is the injection source.


### PR DESCRIPTION
## Root cause

Ponytail was silently not loading. OpenCode 1.18.11's local-plugin discovery glob is `{plugin,plugins}/*.{ts,js}` — it does **not** match `.mjs`. The plugin file `ponytail-scoped.mjs` was invisible to the loader (zero errors, zero log lines — just never discovered).

## Fix

Renamed `ponytail-scoped.mjs` → `ponytail-scoped.ts` and converted `export default` → named export `PonytailScoped` (matching the [documented plugin convention](https://opencode.ai/docs/plugins/)).

- Used `.ts` not `.js`: the config dir has no `"type":"module"`, so `.js` would parse as CommonJS and reject the ESM `export`; `.ts` is always ESM under Bun.
- All 4 hooks (`config`, `chat.message`, `experimental.chat.system.transform`, `command.execute.before`) were confirmed **valid** in 1.18.11 — only the extension was wrong.
- Env vars, 6 slash commands, agent-type off-set scoping, and injection logic all preserved unchanged.

## Files

| Change | File |
|--------|------|
| rename + rewrite | `ponytail-scoped.mjs` → `ponytail-scoped.ts` (deployed `~/.config/opencode/plugins/` + repo source) |
| path refs | `ATTRIBUTION.md`, `README.md`, `opencode_app/README.md` |
| diagnostic | `research/ponytail-load-fix.md` |

## Verification

8/8 checks pass: module imports, exports the function, returns all 4 hooks, registers all 6 commands, transform hook injects the 6529-char ruleset with `PONYTAIL MODE ACTIVE` marker; idempotency, off-set skip, and `/ponytail-off` all pass.

## Action after merge

Plugin discovery runs at startup only. **Restart OpenCode**, then confirm:
1. `ponytail-scoped loaded` in `~/.local/share/opencode/log/<latest>.log`
2. `/ponytail` command works
3. Coding-agent prompt contains `PONYTAIL MODE ACTIVE`

🤖 Generated with [opencode](https://opencode.ai)