### PR TITLE
fix(plugin): expand ponytail off-set to 11 non-coding agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,11 @@ GIT_USER_EMAIL=
 # off   — disable injection globally (per-session /ponytail still works)
 PONYTAIL_DEFAULT_MODE=full
 
-# Regex of agent names that SKIP ponytail injection (read-only/research agents).
-# Default (when empty): explore, general, autoresearch-research-subagent,
-# explorer-subagent, requirements-specialist-subagent, discovery-specialist-subagent,
-# technical-design-specialist-subagent. Set to override, e.g. ^(explore|general|code-review)$
+# Regex of agent names that SKIP ponytail injection.
+# Default (when empty): 7 read-only/research agents + 11 non-coding agents
+# (docs, business, integrations, vision) where the lazy-code ruleset is N/A.
+# See ponytail-scoped.ts DEFAULT_OFF_PATTERN for the full list.
+# Set to override, e.g. ^(explore|general|code-review)$
 PONYTAIL_SUBAGENT_OFF=
 
 # Optional per-agent mode overrides as JSON. Unset = PONYTAIL_DEFAULT_MODE governs.

--- a/opencode_app/.opencode/plugins/ponytail-scoped.ts
+++ b/opencode_app/.opencode/plugins/ponytail-scoped.ts
@@ -54,11 +54,19 @@ const {
 
 const PONYTAIL_DEFAULT_MODE = normalizeMode(process.env.PONYTAIL_DEFAULT_MODE) || DEFAULT_MODE;
 
-// Default off-set: read-only / research agents that should NOT be pushed toward minimal code.
+// Default off-set: agents that should NOT receive Ponytail injection —
+// read-only/research agents (Ponytail N/A) + non-coding agents (docs,
+// business, integrations, vision) where the lazy-code ruleset is irrelevant
+// and only adds context weight. Coding agents stay in the injection set.
 const DEFAULT_OFF_PATTERN =
   '^(explore|general|autoresearch-research-subagent|explorer-subagent|' +
   'requirements-specialist-subagent|discovery-specialist-subagent|' +
-  'technical-design-specialist-subagent)$';
+  'technical-design-specialist-subagent|' +
+  'coverage-subagent|documentation-subagent|docx-creation-subagent|' +
+  'pptx-specialist-subagent|xlsx-specialist-subagent|office-document-primary-agent|' +
+  'startup-ceo-subagent|startup-founder-primary-agent|' +
+  'google-mcp-specialist-subagent|microsoft-m365-specialist-subagent|' +
+  'image-analyzer-subagent)$';
 
 function compileOffRegex() {
   const pattern = process.env.PONYTAIL_SUBAGENT_OFF || DEFAULT_OFF_PATTERN;


### PR DESCRIPTION
## Summary

The default Ponytail off-set listed only 7 read-only/research agents, so **11 non-coding agents** (docs, business, integrations, vision) still received the full "lazy senior dev" injection every turn — irrelevant to their job and pure context weight (~1.5k tokens/turn aggregate). Ponytail governs **code**; it's N/A for document creators, business agents, MCP specialists, and the text-based image-analyzer.

## Change

Adds 11 agents to `DEFAULT_OFF_PATTERN` in `ponytail-scoped.ts`:

```
coverage-subagent, documentation-subagent, docx-creation-subagent,
pptx-specialist-subagent, xlsx-specialist-subagent, office-document-primary-agent,
startup-ceo-subagent, startup-founder-primary-agent,
google-mcp-specialist-subagent, microsoft-m365-specialist-subagent,
image-analyzer-subagent
```

All 18 coding/meta agents (incl. the primary `build` session) **remain in the injection set**.

## Verification

- Regex validated: **12/12 assertions pass** (6 should-skip incl. new agents + existing read-only; 6 should-inject incl. `build`, `code-review`, `tdd`, `error-resolver`, `nextjs-specialist`, `typescript-reviewer`).
- Deployed copy (`~/.config/opencode/plugins/ponytail-scoped.ts`) updated in lockstep; diff confirms identical.
- Zero bats tests affected (off-set is runtime config, not counted).

## Scope

This is the **safe, independent half** of audit item H1 (`research/ponytail-agent-integration-audit.md`). The coupled half — baking role-tuned Ponytail lenses into 8 high-value coding agents (M1–M8) **and then** adding those 8 to the off-set — is deferred to a separate change (those 8 must be baked *before* joining the off-set, else they'd lose Ponytail entirely).

Activates on next opencode restart (plugin discovery is startup-only).

🤖 Generated with [opencode](https://opencode.ai)