### PR TITLE
feat(agents): bake role-tuned Ponytail lenses into 8 coding agents

### DIFF
--- a/opencode_app/.opencode/agents/architecture-review-subagent.md
+++ b/opencode_app/.opencode/agents/architecture-review-subagent.md
@@ -149,6 +149,17 @@ If `.codegraph/` does not exist, fall back to grep/glob/read for the Mandatory C
 
 - Code changes: Request from parent agent (read-only review)
 
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail architecture lens (baked-in, role-tuned)
+
+Apply YAGNI at the architecture layer, not just the code layer:
+- Challenge speculative extensibility: a layer/seam added for a future consumer that does not yet exist is an architecture smell even when the code is clean.
+- Prefer the design that makes the *next* change cheap over the design that tries to pre-build every change now. A seam nobody needs is coupling nobody asked for.
+- When two architectures hold, the boring, fewer-component one wins unless you can name the concrete future need the richer one would block.
+
+This complements `clean-architecture-skill`'s dependency rule. It does **not** weaken boundary discipline or the Mandatory Consumer Traversal Gate.
+
 ## Return Contract
 
 When your task is complete, return ONLY this structure:

--- a/opencode_app/.opencode/agents/autoresearch-code-subagent.md
+++ b/opencode_app/.opencode/agents/autoresearch-code-subagent.md
@@ -173,6 +173,16 @@ When `.codegraph/` exists in the project:
 
 If `.codegraph/` does not exist, use `grep -r`/`glob` per the Consumer Coverage Gate above — the gate still applies, only the tooling changes.
 
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail iteration lens (baked-in, role-tuned)
+
+Each iteration proposes ONE atomic change, and the laziest one that moves the metric wins:
+- Prefer deleting dead code or reusing an existing helper over writing new code in the same iteration — deletion cannot regress the guard suite.
+- The shortest working diff per iteration keeps revert cheap and the `*-results.tsv` signal clean; a large rewrite muddies whether the metric moved for the reason you think.
+
+Never trade the Consumer Coverage Gate for a smaller diff: a rename that breaks an uninspected consumer reverts, no matter how lazy it looked. This aligns with the modify→verify loop; it makes "minimum code that moves the metric" the iteration default.
+
 ## Return Contract
 
 When your task is complete, return ONLY this structure:

--- a/opencode_app/.opencode/agents/code-review-subagent.md
+++ b/opencode_app/.opencode/agents/code-review-subagent.md
@@ -263,6 +263,17 @@ When the codebase is primarily a single language, delegate to the language-speci
 
 Always balance critique with positive feedback. Provide actionable recommendations.
 
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail review lens (baked-in, role-tuned)
+
+Challenge over-engineering as a first-class finding, not just a style note:
+- Flag speculative generality: interfaces with one implementation, factories for one product, config flags that never vary, base classes with a single subclass.
+- When an addition and a deletion both fix the issue, recommend the deletion — the smaller, more boring fix is the better review outcome.
+- A dependency added for what a few lines or the stdlib could do is a Major finding, named by package.
+
+This sharpens the design-patterns checklist ("patterns forced unnecessarily") into an active deletion bias. It does **not** relax the security/correctness gates, the Mandatory Impact & Consumer Coverage gate, or the severity rubric above.
+
 ## Return Contract
 
 When your task is complete, return ONLY this structure:

--- a/opencode_app/.opencode/agents/error-resolver-subagent.md
+++ b/opencode_app/.opencode/agents/error-resolver-subagent.md
@@ -74,6 +74,16 @@ Delegation:
 
 Always provide complete, actionable solutions. For complex issues, suggest debugging strategies.
 
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail bug-fix lens (baked-in, role-tuned)
+
+A report names a symptom; the lazy fix IS the root-cause fix. Before recommending a change:
+- Grep every caller of the function the fix touches. One guard in the shared path is a smaller diff (and fewer sibling bugs) than a guard per caller.
+- The smallest fix in the wrong place is a second bug, not laziness — confirm the real flow first, then fix once where all callers route through.
+
+Never trade correctness for diff size: validation at trust boundaries, error handling that prevents data loss, and the actual root cause are not laziness targets. This aligns with the existing root-cause workflow; it makes "fix once, in the shared function" the default recommendation.
+
 ## Return Contract
 
 When your task is complete, return ONLY this structure:

--- a/opencode_app/.opencode/agents/loop-operator-subagent.md
+++ b/opencode_app/.opencode/agents/loop-operator-subagent.md
@@ -135,6 +135,16 @@ When `.codegraph/` exists in the project:
 
 If `.codegraph/` does not exist, fall back to grep/glob/read normally.
 
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail loop lens (baked-in, role-tuned)
+
+Inside the self-correction protocol, the minimal fix that clears the gate is the right fix:
+- Diagnose root cause, then apply the shortest working diff — a smaller change is easier to verify and easier to revert if the next iteration fails.
+- Reuse an existing helper or stdlib over a new function; deletion of the offending code over a guard wrapping it, when both pass verification.
+
+Never trade the completion criteria for brevity: a lazy fix that leaves a blocking error is unfinished, not done. This does not change the iteration limits or abort conditions; it makes each retry leaner.
+
 ## Return Contract
 
 When your task is complete, return ONLY this structure:

--- a/opencode_app/.opencode/agents/nextjs-specialist-subagent.md
+++ b/opencode_app/.opencode/agents/nextjs-specialist-subagent.md
@@ -109,6 +109,17 @@ When `.codegraph/` exists in the project, use CodeGraph selectively by mode:
 
 If `.codegraph/` does not exist, fall back to grep/glob/read. Do NOT call `read_mcp_resource` — codegraph is tools-only (no resources); use the `codegraph_*` tools directly.
 
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail scaffolding lens (baked-in, role-tuned)
+
+Scaffold only what the task names — "for later" is the most common bloat source in greenfield Next.js:
+- Reach for the platform feature before a dependency: native form controls, CSS, route handlers, DB constraints over a library.
+- One already-installed dependency (e.g. shadcn/ui) beats a new one. If a current dep covers it, do not add a package.
+- Ship the minimal scaffold, then name the one thing you skipped and when to add it — never stall the scaffold waiting for a decision you can default.
+
+This does **not** override Server/Client Component boundary discipline, React Compiler, or the security/accessibility best practices above.
+
 ## Return Contract
 
 **Status:** [success | partial | failed]

--- a/opencode_app/.opencode/agents/tdd-subagent.md
+++ b/opencode_app/.opencode/agents/tdd-subagent.md
@@ -126,3 +126,14 @@ When `.codegraph/` exists in the project, prioritize CodeGraph tools for test ta
 | `codegraph_impact` | Assess what tests to update when source changes |
 
 If `.codegraph/` does not exist, fall back to grep/glob/read. Do NOT call `read_mcp_resource` — codegraph is tools-only (no resources); use the `codegraph_*` tools directly.
+
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail × TDD reconciliation (baked-in, role-tuned)
+
+TDD's "minimal code to pass" *is* Ponytail rung 7 — they agree on the implementation step. Reconcile the two on tests themselves:
+- Write the smallest test that captures the behavior, not the most exhaustive suite for a single behavior. One focused test per red-green cycle is the cycle, not a constraint to fight.
+- "Test behavior, not implementation" (already your rule) is also the lazy choice: a test pinned to implementation details is a test you rewrite on every refactor.
+- Where the user asks for a full framework suite, build it fully (Ponytail yields to explicit request). Where they ask for a quick check, one runnable test is the honest TDD answer.
+
+Ponytail does **not** mean "skip the test" — TDD red IS the runnable check Ponytail demands non-trivial logic leave behind.

--- a/opencode_app/.opencode/agents/testing-subagent.md
+++ b/opencode_app/.opencode/agents/testing-subagent.md
@@ -74,6 +74,17 @@ Workflow:
 
 For TDD adoption, guide developers through red-green-refactor cycle before generating tests. For complex systems, suggest integration and end-to-end testing strategies. Always prioritize test coverage of critical functionality.
 
+<!-- Ponytail lens derived from plugins/ponytail/SKILL.md (vendored v4.8.4); re-sync when the ladder or "when NOT to be lazy" semantics change -->
+
+## Ponytail test-generation lens (baked-in, role-tuned)
+
+Apply the ladder to the tests themselves, not just the code under test:
+- Reuse the project's existing test utilities, fixtures, and factories before writing new ones — duplicated test setup is the most common slop.
+- One focused test per behavior beats a sprawling test that asserts everything; expand edge cases only where the risk tier (critical paths → 90%) demands it.
+- Trivial one-liners need no dedicated test (YAGNI applies to tests too), but never skip the test for logic on a money/security/auth path — those always get one.
+
+This does not undercut the coverage targets; it makes the tests that exist count rather than padding the count.
+
 ## Return Contract
 
 When your task is complete, return ONLY this structure:

--- a/opencode_app/.opencode/plugins/ponytail-scoped.ts
+++ b/opencode_app/.opencode/plugins/ponytail-scoped.ts
@@ -54,10 +54,12 @@ const {
 
 const PONYTAIL_DEFAULT_MODE = normalizeMode(process.env.PONYTAIL_DEFAULT_MODE) || DEFAULT_MODE;
 
-// Default off-set: agents that should NOT receive Ponytail injection —
-// read-only/research agents (Ponytail N/A) + non-coding agents (docs,
-// business, integrations, vision) where the lazy-code ruleset is irrelevant
-// and only adds context weight. Coding agents stay in the injection set.
+// Default off-set: agents that should NOT receive runtime Ponytail injection —
+// read-only/research agents (Ponytail N/A), non-coding agents (docs, business,
+// integrations, vision), and the 8 high-value coding agents that carry a baked-in
+// role-tuned lens (see each agent's "Ponytail <X> lens" section + provenance tag).
+// All other coding/meta agents get runtime injection. Grep 'Ponytail lens derived'
+// to find the 8 baked agents on re-vendor.
 const DEFAULT_OFF_PATTERN =
   '^(explore|general|autoresearch-research-subagent|explorer-subagent|' +
   'requirements-specialist-subagent|discovery-specialist-subagent|' +
@@ -66,7 +68,10 @@ const DEFAULT_OFF_PATTERN =
   'pptx-specialist-subagent|xlsx-specialist-subagent|office-document-primary-agent|' +
   'startup-ceo-subagent|startup-founder-primary-agent|' +
   'google-mcp-specialist-subagent|microsoft-m365-specialist-subagent|' +
-  'image-analyzer-subagent)$';
+  'image-analyzer-subagent|' +
+  'code-review-subagent|architecture-review-subagent|error-resolver-subagent|' +
+  'nextjs-specialist-subagent|autoresearch-code-subagent|loop-operator-subagent|' +
+  'tdd-subagent|testing-subagent)$';
 
 function compileOffRegex() {
   const pattern = process.env.PONYTAIL_SUBAGENT_OFF || DEFAULT_OFF_PATTERN;


### PR DESCRIPTION
## Summary

Completes the hybrid plan (**M1–M8**) from the agent-integration audit (#291): each of the 8 highest-value coding agents now carries a **role-tuned Ponytail lens** in its  body, and all 8 are added to the runtime off-set so the generic ruleset is **not** also injected (structural double-injection guard via the off-set — no marker hack).

This is the companion to #292 (which expanded the off-set for the 11 non-coding agents). Together they finish audit items **H1 + M1–M8**.

## Agents + lenses

| Agent | Lens focus |
|-------|-----------|
| `code-review-subagent` | Challenge over-engineering as a first-class finding; prefer deletion suggestions |
| `architecture-review-subagent` | YAGNI at the architecture layer; boring/fewer-component wins |
| `error-resolver-subagent` | Root-cause-not-symptom; fix once in the shared path, grep every caller |
| `nextjs-specialist-subagent` | Scaffold only what's named; platform feature before dependency |
| `autoresearch-code-subagent` | Laziest atomic change that moves the metric; deletion cannot regress guards |
| `loop-operator-subagent` | Minimal fix that clears the gate; leaner self-correction |
| `tdd-subagent` | Reconcile minimal-to-pass with the leave-one-check rule |
| `testing-subagent` | YAGNI applies to test code; reuse fixtures, one focused test per behavior |

Each lens is a **derivative paraphrase** (not verbatim), carries a provenance tag (`<!-- Ponytail lens derived ... -->`) for drift review on re-vendor, and ends with a guard clause asserting it does **not** weaken the agent's existing correctness/security/gate rules.

## Off-set change

`ponytail-scoped.ts` `DEFAULT_OFF_PATTERN` now skips **26 agents** (7 read-only + 11 non-coding from #292 + 8 baked here). **12 coding/meta agents + the primary `build` session** keep runtime injection.

## Verification

- **Regex: 23/23 assertions pass** (12 should-skip incl. the 8 baked + 4 prior; 11 should-inject incl. `build`, language reviewers, linting, opentofu, responsive-audit, pr-workflow, uiux-reviewer).
- **bats suite: 276/276 pass** — body edits don't affect frontmatter-based counts (`init.bats` agent count stays 38, category counts unchanged, no `permission.skill` entries added).
- Deployed copy (`~/.config/opencode/plugins/ponytail-scoped.ts`) updated in lockstep; diff confirms identical.

## Design notes

- **No double injection**: the off-set is the single structural guard. Baked lenses intentionally do **not** contain the `PONYTAIL MODE ACTIVE` marker (per audit §4) — instead the off-set prevents the runtime plugin from firing for these 8.
- **Drift prevention**: grep `Ponytail lens derived` to find all 8 files on re-vendor.
- **Revert**: each lens is a self-contained `## Ponytail … lens` section; reverting M1–M8 + restoring the off-set (or just the 8 entries) is a clean diff.

Activates on next opencode restart (plugin discovery is startup-only).

🤖 Generated with [opencode](https://opencode.ai)