### PR TITLE
fix(setup): auto-register zai provider auth from ZAI_API_KEY

### DIFF
--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -2413,6 +2413,35 @@ function ar-disable { Remove-Item Env:\AUTORESEARCH_PROTOCOL -ErrorAction Silent
             }
         }
     }
+
+    # Register the PAYG `zai` provider in opencode's native auth store
+    # (~/.local/share/opencode/auth.json) so `opencode auth list` shows it and
+    # the built-in `zai` provider resolves. Mirrors the Docker entrypoint + the
+    # bash register_zai_auth helper. MERGES — never clobbers existing entries.
+    if (-not [string]::IsNullOrWhiteSpace($ZaiApiKey)) {
+        $authDir = Join-Path $HOME ".local\share\opencode"
+        $authFile = Join-Path $authDir "auth.json"
+        if ($DryRun) {
+            Write-Host "[DRY-RUN] Would register zai credential in $authFile"
+        } else {
+            if (-not (Test-Path $authDir)) {
+                New-Item -ItemType Directory -Path $authDir -Force | Out-Null
+            }
+            $auth = @{}
+            if (Test-Path $authFile) {
+                try {
+                    $obj = Get-Content $authFile -Raw | ConvertFrom-Json
+                    $obj.PSObject.Properties | ForEach-Object { $auth[$_.Name] = $_.Value }
+                } catch {
+                    $auth = @{}
+                }
+            }
+            $auth["zai"] = [PSCustomObject]@{ type = "api"; key = $ZaiApiKey }
+            ($auth | ConvertTo-Json -Depth 10) | Set-Content -Path $authFile -Encoding UTF8
+            Write-Host "  auth.json providers: $(($auth.Keys) -join ', ')"
+            Write-LogSuccess "Registered zai credential in $authFile (native opencode auth store)"
+        }
+    }
 }
 
 ################################################################################

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -3010,6 +3010,46 @@ setx_env() {
     fi
 }
 
+# Register the PAYG `zai` provider credential in opencode's native auth store
+# (~/.local/share/opencode/auth.json) so `opencode auth list` shows it and the
+# built-in `zai` provider resolves (e.g. zai/glm-5v-turbo). Mirrors the Docker
+# entrypoint's auth["zai"] write. MERGES — never clobbers existing entries
+# (zai-coding-plan, gemini, ...). Idempotent. MCP servers still read
+# {env:ZAI_API_KEY} independently — this only authenticates the model provider.
+register_zai_auth() {
+    [ -z "$ZAI_API_KEY" ] && return 0
+    if [ "$DRY_RUN" = true ]; then
+        echo "[DRY-RUN] Would register zai credential in ~/.local/share/opencode/auth.json"
+        return 0
+    fi
+    if ! command_exists python3; then
+        log_warn "python3 not found — skipping auth.json registration for zai (model provider stays unauthenticated)"
+        return 0
+    fi
+    local auth_dir="${XDG_DATA_HOME:-$HOME/.local/share}/opencode"
+    local auth_file="${auth_dir}/auth.json"
+    ZAI_API_KEY="$ZAI_API_KEY" python3 - "$auth_file" "$auth_dir" <<'PYEOF'
+import json, os, sys
+auth_file, auth_dir = sys.argv[1], sys.argv[2]
+key = os.environ.get("ZAI_API_KEY", "").strip()
+if not key:
+    sys.exit(0)
+auth = {}
+try:
+    with open(auth_file) as f:
+        loaded = json.load(f)
+        auth = loaded if isinstance(loaded, dict) else {}
+except (FileNotFoundError, ValueError):
+    pass
+auth["zai"] = {"type": "api", "key": key}
+os.makedirs(auth_dir, exist_ok=True)
+with open(auth_file, "w") as f:
+    json.dump(auth, f, indent=2)
+print("  auth.json providers: " + ", ".join(auth.keys()))
+PYEOF
+    log_success "Registered zai credential in ${auth_file} (native opencode auth store)"
+}
+
 # Setup environment variables in shell config (bashrc, zshrc, etc.)
 setup_shell_vars() {
     echo ""
@@ -3049,6 +3089,10 @@ setup_shell_vars() {
             fi
         fi
     fi
+
+    # Register the PAYG `zai` provider in opencode's native auth store so it
+    # resolves identically to the Docker path (single credential mechanism).
+    register_zai_auth
 
     # Offer to install autoresearch protocol helpers (ar-enable / ar-disable)
     # into existing bashrc / zshrc. Prompted — never silent.


### PR DESCRIPTION
## What
- `deploy/setup.sh`: new `register_zai_auth()` helper — writes `auth["zai"]={type:api,key}` into `~/.local/share/opencode/auth.json` during the `ZAI_API_KEY` env-persistence step, **mirroring `docker-entrypoint.sh`**. Merges (never clobbers `zai-coding-plan`), idempotent, gated on `ZAI_API_KEY`+python3+`!DRY_RUN`.
- `deploy/setup.ps1`: mirrored the same merge (PS 5.1-compatible).

## Why
Reconciles the `zai` auth mechanism to **ONE path (auth.json)** across both deploy modes (setup.sh user-space + Docker). Fixes `Model not found: zai/glm-5v-turbo` for the vision-tier agents (`image-analyzer-subagent`, `error-resolver-subagent`) after a `setup.sh` deploy — they now resolve via the built-in `zai` provider reading auth.json, no provider block needed.

## Mechanism decision
Chose `opencode auth login`/auth.json (opencode's native credential store, visible in `opencode auth list`) over a `provider` block env-key override. The provider block was reverted (it duplicated docker-entrypoint's auth write and could shadow it). `--provider`/`--enable-pack` in setup.sh are unchanged (tier-map / MCP-toggle respectively — unrelated to credentials).

## Verification
- [x] local `bats tests/*.bats` → 276/276 pass
- [x] `bash -n deploy/setup.sh` OK
- [x] `opencode auth list` → 2 credentials (Z.AI Coding Plan + Z.AI); `zai-coding-plan` intact
- [x] `opencode models` → `zai/glm-5v-turbo` resolves via auth.json alone
- [x] JSON valid; `opencode.json` net-zero (provider block added then reverted)