### PR TITLE
chore(release): promote dev to main — config-drift remediation + cleanup

### DIFF
--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -1682,11 +1682,22 @@ function Set-Configuration {
 
     if (Test-Path $agentsSrc) {
         if (Test-Path $agentsDest) {
-            Write-LogWarn "AGENTS.md already exists at $agentsDest"
-            if (Read-YesNo "Do you want to overwrite it?" $false) {
-                New-FileBackup $agentsDest
-                if (-not $DryRun) { Copy-Item $agentsSrc $agentsDest -Force }
-                Write-LogSuccess "AGENTS.md copied successfully (renamed from .AGENTS.md)"
+            $stale = $true
+            if (-not $DryRun) {
+                $stale = ((Get-FileHash $agentsSrc).Hash -ne (Get-FileHash $agentsDest).Hash)
+            }
+            if ($stale) {
+                Write-LogWarn "AGENTS.md at $agentsDest is STALE - it differs from the source $agentsSrc"
+                Write-LogWarn "Stale shipped instructions can cause incorrect agent behavior. Recommend overwriting."
+                if (Read-YesNo "Overwrite with the current source version?" $true) {
+                    New-FileBackup $agentsDest
+                    if (-not $DryRun) { Copy-Item $agentsSrc $agentsDest -Force }
+                    Write-LogSuccess "AGENTS.md updated successfully (renamed from .AGENTS.md)"
+                } else {
+                    Write-LogWarn "Kept stale AGENTS.md - shipped agent instructions may be out of date."
+                }
+            } else {
+                Write-LogInfo "AGENTS.md already up to date at $agentsDest"
             }
         } else {
             if (-not $DryRun) { Copy-Item $agentsSrc $agentsDest -Force }

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -2424,11 +2424,18 @@ setup_config() {
     # Copy AGENTS.md from project to global config
     if [ -f "${SCRIPT_DIR}/.AGENTS.md" ]; then
         if [ -f "${CONFIG_DIR}/AGENTS.md" ]; then
-            log_warn "AGENTS.md already exists at ${CONFIG_DIR}/AGENTS.md"
-            if prompt_yes_no "Do you want to overwrite it?" "n"; then
-                create_backup "${CONFIG_DIR}/AGENTS.md"
-                run_cmd cp "${SCRIPT_DIR}/.AGENTS.md" "${CONFIG_DIR}/AGENTS.md"
-                log_success "AGENTS.md copied successfully (renamed from .AGENTS.md)"
+            if diff -q "${SCRIPT_DIR}/.AGENTS.md" "${CONFIG_DIR}/AGENTS.md" >/dev/null 2>&1; then
+                log_info "AGENTS.md already up to date at ${CONFIG_DIR}/AGENTS.md"
+            else
+                log_warn "AGENTS.md at ${CONFIG_DIR}/AGENTS.md is STALE — it differs from the source ${SCRIPT_DIR}/.AGENTS.md"
+                log_warn "Stale shipped instructions can cause incorrect agent behavior. Recommend overwriting."
+                if prompt_yes_no "Overwrite with the current source version?" "y"; then
+                    create_backup "${CONFIG_DIR}/AGENTS.md"
+                    run_cmd cp "${SCRIPT_DIR}/.AGENTS.md" "${CONFIG_DIR}/AGENTS.md"
+                    log_success "AGENTS.md updated successfully (renamed from .AGENTS.md)"
+                else
+                    log_warn "Kept stale AGENTS.md — shipped agent instructions may be out of date."
+                fi
             fi
         else
             run_cmd cp "${SCRIPT_DIR}/.AGENTS.md" "${CONFIG_DIR}/AGENTS.md"

--- a/opencode_app/.opencode/skills/autoresearch-core-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/autoresearch-core-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: opencode
 metadata:
   audience: developers
   workflow: autonomous-iteration
-  protocol-source: true
+  protocol-source: "true"
 category: Autoresearch
 ---
 

--- a/opencode_app/opencode.json
+++ b/opencode_app/opencode.json
@@ -114,6 +114,33 @@
       "frontend-design-skill": "allow",
       "accessibility-a11y-skill": "allow",
       "changelog-python-cliff-skill": "allow"
+    },
+    "tool": {
+      "codegraph*": "allow",
+      "atlassian*": "allow",
+      "mermaid*": "allow",
+      "markitdown*": "deny",
+      "zai-web-reader*": "allow",
+      "zai-vision-mcp-server*": "deny",
+      "zai-zread*": "deny",
+      "google-bigquery*": "deny",
+      "google-maps*": "deny",
+      "google-gce*": "deny",
+      "google-gke*": "deny",
+      "autodesk-revit*": "deny",
+      "autodesk-model-data*": "deny",
+      "autodesk-fusion*": "deny",
+      "autodesk-help*": "deny",
+      "next-devtools*": "deny",
+      "microsoft-teams*": "deny",
+      "microsoft-mail*": "deny",
+      "microsoft-calendar*": "deny",
+      "microsoft-sharepoint*": "deny",
+      "microsoft-onedrive*": "deny",
+      "microsoft-user*": "deny",
+      "microsoft-word*": "deny",
+      "microsoft-copilot*": "deny",
+      "microsoft-dataverse*": "deny"
     }
   },
   "command": {
@@ -350,33 +377,6 @@
       },
       "enabled": false
     }
-  },
-  "tools": {
-    "codegraph*": true,
-    "atlassian*": true,
-    "mermaid*": true,
-    "markitdown*": false,
-    "zai-web-reader*": true,
-    "zai-vision-mcp-server*": false,
-    "zai-zread*": false,
-    "google-bigquery*": false,
-    "google-maps*": false,
-    "google-gce*": false,
-    "google-gke*": false,
-    "autodesk-revit*": false,
-    "autodesk-model-data*": false,
-    "autodesk-fusion*": false,
-    "autodesk-help*": false,
-    "next-devtools*": false,
-    "microsoft-teams*": false,
-    "microsoft-mail*": false,
-    "microsoft-calendar*": false,
-    "microsoft-sharepoint*": false,
-    "microsoft-onedrive*": false,
-    "microsoft-user*": false,
-    "microsoft-word*": false,
-    "microsoft-copilot*": false,
-    "microsoft-dataverse*": false
   },
   "agent": {
     "build": {


### PR DESCRIPTION
## Summary

Release promotion: `dev` → `main`. Includes the **#297 config-drift remediation** (PR #298) plus substantial prior history — large-scale test/asset cleanup (~43k lines removed), new skills, agent tier fixes, plugin improvements, and documentation sync.

## Commit Summary (14 commits, grouped by type)

### `feat` — New features
- `feat(deploy): detect stale AGENTS.md and warn loudly + default to overwrite`
- `feat(deploy): auto-register zai provider auth from ZAI_API_KEY (#296)`

### `refactor` — Restructuring
- `refactor(config): migrate deprecated tools: block to permission`
- `refactor(config): prune redundant permission entries to 2 active denies`

### `fix` — Bug fixes
- `fix(skills): convert array metadata values to string-to-string per opencode.ai spec`
- `fix(skills): escape description colons via folded block scalars (ScannerError fix)`
- `fix(setup): correct stale Agents count in Quick Start banner`

### `docs` — Documentation & planning
- `docs(plan): add PLAN-GIT-297 for verified config-drift remediation`
- `docs(plan): trace PLAN-GIT-297 completion`
- `docs(plan): add Phase 6 post-review findings to PLAN-GIT-297`
- `docs(plan): trace Phase 6 completion; tech-debt split to #299`
- `docs(plan): add Phase 7 (metadata conformance + stale-deploy detection)`
- `docs(agents): Phase 6 — tier-table completeness + sync-rules note`
- `docs(counts): fix skill-count drift 113->115 + reconcile category tables`
- `docs(agents): add responsive-audit to glm-5.1 tier table row`

### Merge
- `Merge pull request #298 from darellchua2/fix/297-audit-remediation`

## #297 Config-Drift Remediation Highlights

PR #298 (closing #297) addressed verified config drift across the repo:

- **Skill-count fix:** reconciled documented count (113→115) with actual deployed skills
- **`tools:` → `permission` migration:** removed deprecated `tools:` block, migrated to `permission` denies (opencode.ai v1.18+ conformance)
- **Skill metadata string-to-string conformance:** array-valued frontmatter fields converted to single strings per opencode.ai spec
- **Stale AGENTS.md deploy detection:** setup scripts now detect and warn about outdated deployed AGENTS.md files, defaulting to overwrite
- **ScannerError fixes:** YAML description colons escaped via folded block scalars

Tech-debt follow-ups tracked in #299 (remains open).

## Quality Gates

| Gate | Result |
|------|--------|
| Shell syntax (`bash -n deploy/setup.sh`) | ✅ PASS |
| YAML frontmatter (all SKILL.md) | ✅ PASS (0 parse errors) |
| JSON validity (`opencode.json`) | ✅ PASS |
| Bats tests (`bats tests/`) | ✅ PASS (218/218) |
| Makefile / package.json scripts | N/A (no additional gates) |

## Changes

```
361 files changed, 4,872 insertions(+), 43,507 deletions(-)
```

Dominant change: large-scale deletion of deprecated test files, old assets, and redundant config entries from prior development cycles.

## Semantic Versioning Label

Applied **`minor`**: the migration from `tools:` → `permission` and metadata conformance fixes are significant structural changes, but this is a configuration template repo (not a runtime library) — the changes are additive/conforming rather than API-breaking. The large line deletions are cleanup of deprecated files, not removal of user-facing functionality. A `major` label would be appropriate if this repo shipped a consumed library with removed APIs.

## Related Issues

- Closes #297 (config-drift remediation — already merged via #298)
- #299 (tech-debt follow-ups — remains open)