### PR TITLE
feat(deploy): dynamic skill-counts + auto-derived categories (BT-157)

### DIFF
--- a/PLANS/PLAN-BT-157.md
+++ b/PLANS/PLAN-BT-157.md
@@ -4,105 +4,151 @@
 **JIRA:** [BT-157](https://betekk.atlassian.net/browse/BT-157) (BETEKK / Task)
 **Branch:** `BT-157` (off `main` @ v4.11.0)
 **Origin:** Split from #297 / PR #298 (Phase 6.4 + 6.5)
+**Revision:** v2 — corrected after opencode-tooling-subagent review (see "Review corrections" below)
+
+## Review corrections (v1 → v2)
+
+The review caught 3 critical defects + major gaps in v1. Corrected here:
+1. **v1 said "reality = 132" — WRONG.** Naive `find` counts 6 **archived** skills in `_archived/`. Active count (what the deploy ships, `rsync --exclude='_archived'` at `setup.sh:2533`) = **126**. So the `126` literals are coincidentally *correct*; only `123` is stale. All dynamic computations must use `-not -path "*/_archived/*"`.
+2. **v1 Phase 1.1 "lift to function scope" — unworkable.** The 3 consumers live in 3 *different* functions (`show_help`:465, `print_summary`:3341, `print_next_steps`:3599). A `local` in one is invisible to the others. **Fix:** a `count_skills <dir>` helper called by each.
+3. **v1 Phase 3.3 "categories are editorial, not disk-derivable" — FALSE.** 126/126 active skills carry a `category:` frontmatter field (21 categories). Per-category counts ARE auto-derivable via one `grep | sort | uniq -c` pipeline. **Reversed:** auto-derive (drift-proof) instead of hand-maintain.
+4. **v1 missed:** `README.md` (2 stale `126` literals), a **second** category listing at `setup.sh:3632-3637` (`print_next_steps`), the **source-vs-deployed** semantic (banner needs SOURCE count, shown on `--help` before deploy; `--status` needs DEPLOYED count), and the `init.bats`/`registry.json` code path (`126` is correct there but pinned to a literal).
 
 ## Context — verified current state (main v4.11.0)
 
-The deploy scripts hardcode the skill total in **multiple** locations with **three different stale values** — triple drift:
+| Location | Literal | Correct active count | Verdict |
+|----------|---------|----------------------|---------|
+| `setup.sh:685` `SKILLS (126):` banner (`show_help`) | 126 | 126 | coincidentally right, but **hardcoded → will drift** |
+| `setup.sh:3629` `📦 123 Skills Available` (`print_next_steps`) | 123 | 126 | **stale (−3)** |
+| `setup.sh:3632-3637` category breakdown (`print_next_steps`) | sums 109 | 126 | **stale + incomplete** |
+| `setup.sh:3447` `--status` compute (`print_summary`) | dynamic | deployed | ✓ correct (deployed dir excludes `_archived`) |
+| `setup.sh:3449+` `--status` category listing | sums 102 | 126 | **stale + incomplete (omits 6 cats)** |
+| `setup.ps1:924` `SKILLS (126):` banner | 126 | 126 | hardcoded → will drift |
+| `setup.ps1:2707` `123 Skills Available` | 123 | 126 | **stale (−3)** |
+| `README.md:175` "126 skills" | 126 | 126 | hardcoded → will drift |
+| `README.md:459` "126 skills ... 21 categories" | 126 | 126 | hardcoded → will drift |
+| `deploy/registry.json` skills array | 126 | 126 | ✓ correct (opencode-init source) |
+| `tests/init.bats:28,43` `[ "$skills" = "126" ]` | 126 | 126 | ✓ value correct, but **pinned literal** → will drift |
 
-| Location | Hardcoded value | Reality |
-|----------|-----------------|---------|
-| `setup.sh:685` `SKILLS (126):` banner | 126 | disk = **132** |
-| `setup.sh:3629` `📦 123 Skills Available` summary | 123 | disk = **132** |
-| `setup.ps1:924` `SKILLS (126):` banner | 126 | disk = **132** |
-| `setup.ps1:2707` `123 Skills Available` summary | 123 | disk = **132** |
+**Root cause:** every count is a hardcoded literal that must be hand-updated on each skill add (3rd drift cycle: PLAN-GIT-237 → #297 → now). Fix: derive from disk once, interpolate everywhere, exclude `_archived`.
 
-Meanwhile `setup.sh:3447` **already computes** `skill_count=$(find ${SKILLS_DIR} -name "SKILL.md" | wc -l)` — but only the `--status` debug headline uses it. `setup.ps1` has **no** dynamic computation at all.
-
-Additionally, the `--status` category listing (`setup.sh:3449+`) is internally contradictory: its headline reports the dynamic count, but the per-category breakdown omits ~6 categories (Agent Optimization, Startup/Business, Configuration, Security, DevOps + Autoresearch) so the listing sums to far less than the headline.
+**Key paths (setup.sh):** `REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"` (`:70`); source skills `${REPO_DIR}/opencode_app/.opencode/skills`; deployed `${SKILLS_DIR}` = `${CONFIG_DIR}/skills`.
 
 ## Dependency & Consumer Map
 
-| Node (file/section) | Depends on (must precede) | Consumers (who depends on this) | Change risk |
-|---------------------|---------------------------|---------------------------------|-------------|
-| `setup.sh` banner @ `:685` (`SKILLS (N):`) | dynamic `skill_count` var in scope | every user running `setup.sh` (first-impression banner) | low |
-| `setup.sh` summary @ `:3629` (`📦 N Skills Available`) | dynamic `skill_count` var in scope | user-visible summary on completion | low |
-| `setup.sh` dynamic compute @ `:3447` | `${SKILLS_DIR}` populated | `--status` headline (already) + banners (after this work) | low — already exists, just lift scope |
-| `setup.sh` `--status` category listing `:3449+` | none | `--status` diagnostic output (operators/debug) | low — editorial mapping |
-| `setup.ps1` banner @ `:924` | new `$skillCount` compute | every Windows user running `setup.ps1` | low |
-| `setup.ps1` summary @ `:2707` | new `$skillCount` compute | Windows user-visible summary | low |
-| `tests/test_*.bats` count assertions | depends on which assert a hardcoded total | CI (Release workflow) | med — may need updating if a test pins a literal |
+| Node | Depends on | Consumers | Risk |
+|------|-----------|-----------|------|
+| `count_skills <dir>` helper (new) | `${REPO_DIR}` set (`:70`) | show_help, print_next_steps, print_summary | low |
+| `print_skill_categories <dir>` helper (new) | source skills dir exists | print_next_steps (`:3632`), print_summary (`:3449`) | low |
+| `show_help` banner `:685` | `count_skills` + SOURCE path | every `--help` / `-h` invocation | low |
+| `print_next_steps` total `:3629` | `count_skills` + SOURCE path | post-deploy summary | low |
+| `print_next_steps` cats `:3632` | `print_skill_categories` | post-deploy summary | low |
+| `print_summary` `:3447` total | `count_skills` + DEPLOYED dir | `--status` | low — refactor existing find to helper |
+| `print_summary` cats `:3449` | `print_skill_categories` | `--status` | low |
+| `setup.ps1` parity helpers | `$RepoDir` set | ps1 banner/summary/--status | low |
+| `README.md` literals `:175,:459` | manual edit (markdown, no interp) | readers | low |
+| `init.bats:28,43` | registry.json length | CI | low — make dynamic |
 
 ## Implementation Phases
 
-### Phase 1: `setup.sh` — interpolate dynamic total into banners
-- [ ] **1.1** Compute `skill_count` once at function scope (top of the deploy/banner function) from disk: `local skill_count=$(find "${SKILLS_DIR}" -type f -name "SKILL.md" 2>/dev/null | wc -l)`, so it is in scope for both banner locations.
-    — **Why:** the computation already exists at `:3447` but only inside the `--status` block; lifting it to function scope makes it available to the main banner (`:685`) and summary (`:3629`) without duplicating the `find`.
-    — **Done when:** a single `skill_count` assignment is reachable by all three consumers; no second `find ... | wc -l` is added.
-    — **Consumers affected:** `:685` banner, `:3629` summary, `:3447` `--status` headline (reuse same var).
-- [ ] **1.2** Replace the hardcoded `SKILLS (126):` literal at `:685` with interpolation `SKILLS (${skill_count}):`.
-    — **Why:** removes the primary drift surface (first-impression banner); the heredoc/echo context is interpolation-capable.
-    — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.sh` returns no literal-number matches.
-    — **Consumers affected:** user banner output.
-- [ ] **1.3** Replace the hardcoded `📦 123 Skills Available` at `:3629` with `📦 ${skill_count} Skills Available`.
-    — **Why:** second drift surface; same var, different (wrong) literal today.
-    — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.sh` returns no literal-number matches.
-    — **Consumers affected:** completion summary output.
+### Phase 1: `setup.sh` — `count_skills` helper + wire 3 consumers (source vs deployed)
+- [ ] **1.1** Add a `count_skills()` helper near the other utility functions (after `REPO_DIR` is defined, ~`:85`): `count_skills() { find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" 2>/dev/null | wc -l; }`.
+    — **Why:** the 3 consumers are in 3 different functions (`show_help`, `print_summary`, `print_next_steps`); a `local` can't span them. A helper is the DRY, scope-safe way to share one computation. `-not -path "*/_archived/*"` matches the deploy's `rsync --exclude='_archived'` so the count reflects **active** skills only.
+    — **Done when:** `grep -nE "^count_skills\(\)" deploy/setup.sh` finds the helper; calling `count_skills "${REPO_DIR}/opencode_app/.opencode/skills"` returns 126.
+    — **Consumers affected:** 1.2, 1.3, 1.4, Phase 3.
+- [ ] **1.2** In `show_help()` replace `SKILLS (126):` at `:685` with `SKILLS ($(count_skills "${REPO_DIR}/opencode_app/.opencode/skills")):` — **SOURCE** count (banner shown on `--help` before any deploy, must advertise what's shipped, not what's deployed).
+    — **Why:** `show_help` runs pre-deploy; using the DEPLOYED dir would show `0` on a fresh machine. Source count is the advertising number.
+    — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.sh` returns no literal; `--help` shows the active source count.
+    — **Consumers affected:** every `setup.sh --help` user.
+- [ ] **1.3** In `print_next_steps()` replace `📦 123 Skills Available` at `:3629` with `📦 $(count_skills "${REPO_DIR}/opencode_app/.opencode/skills") Skills Available` — SOURCE count.
+    — **Why:** post-deploy summary advertises what's available; source count is stable regardless of deploy success. Fixes the stale `123` (−3).
+    — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.sh` returns no literal.
+    — **Consumers affected:** post-deploy summary output.
+- [ ] **1.4** Refactor `print_summary()` `:3447` to use the helper: replace `local skill_count=$(find "${SKILLS_DIR}" -type f -name "SKILL.md" ...)` with `local skill_count=$(count_skills "${SKILLS_DIR}")` — **DEPLOYED** count.
+    — **Why:** dedupe the computation into the helper; `--status` legitimately reports the DEPLOYED state (what the user actually has), which differs from source if a deploy is partial. Deployed dir already excludes `_archived` (rsync), so the helper's `-not -path` is harmless here.
+    — **Done when:** `:3447` calls `count_skills`; no standalone `find ... SKILL.md | wc -l` remains outside the helper.
+    — **Consumers affected:** `--status` headline (unchanged value, cleaner source).
 
-### Phase 2: `setup.ps1` — add dynamic compute + interpolate
-- [ ] **2.1** Add a `$skillCount` computation near the top of the deploy function: `$skillCount = (Get-ChildItem -Path $SkillsDir -Recurse -Filter "SKILL.md" -ErrorAction SilentlyContinue | Measure-Object).Count` (guard for missing dir).
-    — **Why:** `setup.ps1` has no dynamic count today — both banner literals are pure guesses; this is the Windows-parity fix.
-    — **Done when:** a single `$skillCount` variable is assigned and reachable by both banner locations; missing-dir case yields 0 without error.
-    — **Consumers affected:** `:924` banner, `:2707` summary.
-- [ ] **2.2** Replace `SKILLS (126):` at `:924` with `SKILLS ($skillCount):`.
-    — **Why:** Windows parity with 1.2; removes the same drift on PowerShell.
-    — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.ps1` returns no literal-number matches.
-    — **Consumers affected:** Windows user banner output.
-- [ ] **2.3** Replace `123 Skills Available` at `:2707` with `$skillCount Skills Available`.
+### Phase 2: `setup.ps1` — parity helpers + wire consumers
+- [ ] **2.1** Add a `Get-SkillCount` function near the other utilities: `function Get-SkillCount { param([string]$Path) if (-not (Test-Path $Path)) { return 0 }; return @(Get-ChildItem -Path $Path -Recurse -Filter "SKILL.md" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -notmatch "[\\/​]_archived[\\/​]" }).Count }`.
+    — **Why:** Windows parity with 1.1; `setup.ps1` currently has NO correct SKILL.md-file count (its `:1811`/`:2649` count *directories* including non-skill subdirs — a different, wrong metric). Excludes `_archived` to match deploy (`:1802`).
+    — **Done when:** `grep -nE "function Get-SkillCount" deploy/setup.ps1` finds it; `Get-SkillCount (Join-Path $RepoDir "opencode_app\.opencode\skills")` returns 126.
+    — **Consumers affected:** 2.2, 2.3, 2.4.
+- [ ] **2.2** Replace `SKILLS (126):` at `:924` with `SKILLS ($(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills'))):` — SOURCE count.
+    — **Why:** Windows parity with 1.2.
+    — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.ps1` returns no literal.
+    — **Consumers affected:** Windows `--help` users.
+- [ ] **2.3** Replace `123 Skills Available` at `:2707` with `$(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills')) Skills Available` — SOURCE count.
     — **Why:** Windows parity with 1.3.
-    — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.ps1` returns no literal-number matches.
-    — **Consumers affected:** Windows completion summary output.
+    — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.ps1` returns no literal.
+    — **Consumers affected:** Windows post-deploy summary.
+- [ ] **2.4** Wire `Get-SkillCount` into the ps1 `--status` total (find the ps1 equivalent of `:3447`'s dir-count) — DEPLOYED count.
+    — **Why:** parity with 1.4; replace the directory-count metric with the correct SKILL.md-file count.
+    — **Done when:** ps1 `--status` headline uses `Get-SkillCount $SkillsDir` (deployed).
+    — **Consumers affected:** Windows `--status`.
 
-### Phase 3: `--status` category listing reconciliation (item 6.4)
-- [ ] **3.1** Rebuild the `setup.sh` `--status` per-category breakdown (`:3449+`) to include all current categories (add the ~6 missing: Agent Optimization, Startup/Business, Configuration, Security, DevOps, Autoresearch) so the listing's sum matches the dynamic headline.
-    — **Why:** the diagnostic is internally contradictory today (headline says 132, listing sums to ~90); a wrong diagnostic is worse than none.
-    — **Done when:** the sum of all category counts in the listing equals the dynamic `skill_count` headline above it.
-    — **Consumers affected:** operators running `setup.sh --status` (debug only).
-- [ ] **3.2** Mirror the rebuilt category listing in `setup.ps1` `--status` equivalent.
-    — **Why:** Windows parity; keep both scripts' diagnostics consistent.
-    — **Done when:** `setup.ps1` `--status` listing sums to the same total as `setup.sh`.
+### Phase 3: Auto-derive category breakdown (REVERSES v1's "hand-maintain" — categories ARE disk-derivable)
+- [ ] **3.1** Add a `print_skill_categories()` helper (bash) that auto-derives per-category counts from frontmatter and prints them: `find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" -exec grep -hE '^[[:space:]]*category:' {} + 2>/dev/null | sed -E 's/^[[:space:]]*category:[[:space:]]*//' | sort | uniq -c | sort -rn | while read n c; do echo "    - $c ($n)"; done`.
+    — **Why:** v1 Phase 3.3 claimed categories aren't disk-derivable — **FALSE**: 126/126 active skills carry a `category:` field (21 categories). Auto-derive is drift-proof; hand-maintenance is the bug we're fixing. One pipeline replaces two stale hardcoded listings.
+    — **Done when:** `grep -nE "^print_skill_categories\(\)" deploy/setup.sh` finds the helper; running it on the source dir prints 21 categories summing to 126.
+    — **Consumers affected:** 3.2, 3.3.
+- [ ] **3.2** Replace the hardcoded `--status` category listing at `setup.sh:3449+` with a call `print_skill_categories "${SKILLS_DIR}"` (DEPLOYED) — removes ~115 lines of stale echo.
+    — **Why:** the listing omits 6 categories and sums to 102 vs the 126 headline — internally contradictory. Auto-derive fixes both the omissions and the sum.
+    — **Done when:** the `--status` listing sums to the `--status` headline total; `grep -cE "Framework \(19\)|Language-Specific \(8\)" setup.sh` drops (those literals removed).
+    — **Consumers affected:** operators running `--status`.
+- [ ] **3.3** Replace the hardcoded `print_next_steps` category listing at `setup.sh:3632-3637` with `print_skill_categories "${REPO_DIR}/opencode_app/.opencode/skills"` (SOURCE).
+    — **Why:** this second listing (sums 109) was missed by v1; it re-drifts immediately after 1.3 fixes the total. SOURCE dir because it advertises what's shipped.
+    — **Done when:** `print_next_steps` category section is a single helper call; no hardcoded `Framework (N)` literals remain.
+    — **Consumers affected:** post-deploy summary.
+- [ ] **3.4** Mirror `Get-SkillCategories` + the two call sites in `setup.ps1` (Windows parity for 3.1-3.3).
+    — **Why:** keep both scripts' diagnostics consistent.
+    — **Done when:** ps1 `--status` and post-deploy listings auto-derive and sum to 126.
     — **Consumers affected:** Windows operators.
-- [ ] **3.3** (per-category counts stay human-maintained) — explicitly do NOT auto-derive categories; only the **total** is dynamic. Add a one-line comment at the listing stating categorization is an editorial mapping.
-    — **Why:** categorization is editorial (a skill's category is a human judgement), not disk-derivable; auto-deriving would introduce a different drift. Documenting this prevents the next cycle from "fixing" it the wrong way.
-    — **Done when:** a comment explains per-category numbers are hand-maintained and only the total is computed.
-    — **Consumers affected:** future maintainers (next remediation cycle).
 
-### Phase 4: Tests + verification gate
-- [ ] **4.1** Audit `tests/*.bats` for any assertion that pins a hardcoded skill total; update to compute from disk (or assert `>=` a floor) instead of a literal.
-    — **Why:** a test that pins `123` would now fail (disk=132) and re-introduce the drift as a "fix the test to 132" cycle; make the test count-agnostic.
-    — **Done when:** `grep -rnE "123|126" tests/ | grep -i skill` returns no count-pinning assertions (or they are dynamic).
+### Phase 4: README.md + registry.json + init.bats (sync-rule targets v1 missed)
+- [ ] **4.1** Update `README.md:175` ("126 skills") and `:459` ("126 skills organized across 21 categories") — README is markdown (no interpolation), so update the literal to the current active count **and add a `<!-- count: hand-maintained, see BT-157 -->` comment** flagging it as a known sync target.
+    — **Why:** the repo's own sync rule (AGENTS.md "Sync Rules") lists README.md as mandatory; v1 omitted it entirely. Markdown can't interpolate, so a flag comment is the laziest way to surface it for the next sync.
+    — **Done when:** both literals match the active count; a comment marks them.
+    — **Consumers affected:** README readers, documentation-sync-workflow.
+- [ ] **4.2** Regenerate `deploy/registry.json` skill list from disk (excluding `_archived`) so it stays at 126/active; verify `jq '.skills | length' deploy/registry.json` = 126 and each entry resolves to a real skill dir.
+    — **Why:** registry.json is the opencode-init source-of-truth; it's currently correct (126) but was hand-built. A regeneration guarantees no orphans/stale entries. If a generator script exists, run it; else diff-current and only fix discrepancies.
+    — **Done when:** `jq '.skills|length' deploy/registry.json` = active count; no entry points to a missing/nonexistent skill.
+    — **Consumers affected:** opencode-init CLI.
+- [ ] **4.3** Make `tests/init.bats:28,43` count-agnostic: assert against the registry's own length (`[ "$skills" = "$(jq '.skills|length' "$REG")" ]`) instead of the literal `"126"`.
+    — **Why:** the current `126` is correct, but pinning a literal means the test silently rots on the next skill add (the exact drift cycle this ticket kills). Asserting against the registry's own length makes the test self-healing. Note `:43`'s line has no "skill" word, so v1's grep missed it.
+    — **Done when:** `grep -nE '"126"|"123"' tests/init.bats` returns no literal count assertions (both :28 and :43 dynamic).
     — **Consumers affected:** CI Release workflow.
-- [ ] **4.2** Run the full gate: `bash -n deploy/setup.sh`; `python3 -m json.tool opencode_app/opencode.json >/dev/null`; all skill frontmatter parses; `bats tests/` green (if bats installed).
-    — **Why:** every prior change in this repo ships through this gate; a green gate is the completion signal.
-    — **Done when:** all commands exit 0.
+
+### Phase 5: Verification gate
+- [ ] **5.1** Run the full gate: `bash -n deploy/setup.sh`; `pwsh -nop -c '…parse setup.ps1…'` or manual brace check; `python3 -m json.tool deploy/registry.json >/dev/null`; `python3 -m json.tool opencode_app/opencode.json >/dev/null`; all skill frontmatter parses; `bats tests/` green (if installed).
+    — **Why:** every prior change ships through this gate; green = done.
+    — **Done when:** all commands exit 0; `bats tests/` shows 0 failures.
     — **Consumers affected:** PR merge / Release workflow.
+- [ ] **5.2** Confirm the drift surface is eliminated: `grep -rnE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero** matches; `grep -rnE "Framework \(19\)|Language-Specific \(8\)|CAD & Hardware Design \(14\)" deploy/setup.sh deploy/setup.ps1` → **zero** (no hardcoded category literals).
+    — **Why:** this is the acceptance signal — no hardcoded count literals remain in either deploy script.
+    — **Done when:** both greps return zero.
+    — **Consumers affected:** future skill-add cycles (the drift can't recur).
 
 ## Acceptance Criteria (summary)
 
-- [ ] No hardcoded total skill-count literals in `setup.sh` or `setup.ps1` — all interpolated from a single disk-derived computation.
-- [ ] `grep -nE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero** matches.
-- [ ] `--status` category listing sums to the dynamic total in both scripts.
-- [ ] Per-category counts remain human-maintained (documented), not auto-derived.
-- [ ] `bash -n` clean; bats tests green; count-assertion tests made dynamic.
+- [ ] No hardcoded total skill-count literals in `setup.sh`/`setup.ps1` — all via `count_skills`/`Get-SkillCount` (excluding `_archived`).
+- [ ] `grep -rnE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero**.
+- [ ] No hardcoded category literals — both listings auto-derive from frontmatter; sums match totals.
+- [ ] Source-vs-deployed semantics correct: `show_help`/`print_next_steps` = SOURCE; `--status` = DEPLOYED.
+- [ ] `README.md` literals current + flagged; `registry.json` regenerated; `init.bats` count-agnostic.
+- [ ] `bash -n` clean; bats green; JSON valid.
 
 ## Risks & Mitigation
 
-- **Risk:** a category count in the listing is itself wrong (stale). **Mitigation:** Phase 3 reconciles the listing to the total; any residual per-category inaccuracy is editorial and out of scope (documented).
-- **Risk:** a bats test pins a literal and breaks. **Mitigation:** Phase 4.1 makes count-assertions dynamic before running the gate.
+- **Risk:** auto-derive grep is slow on `--help` (132-file scan). **Mitigation:** `show_help` uses only `count_skills` (find|wc -l, ~10ms); the heavier category grep runs only in `print_summary`/`print_next_steps` (once per deploy/status, acceptable).
+- **Risk:** a skill lacks `category:` → auto-derive sum < total. **Mitigation:** verified 126/126 active skills have `category:`; if a future skill omits it, the listing sum will visibly fall short of the total (a self-announcing discrepancy, not a silent drift).
+- **Risk:** PowerShell regex for `_archived` path matching varies by separator. **Mitigation:** match `[\\/]_archived[\\/]` (both separators).
+- **Risk:** registry.json regeneration drops/renames an entry. **Mitigation:** 4.2 diffs against current; only fix discrepancies, don't rebuild blindly.
 
 ## Out of scope
 
-- Auto-deriving categories from disk (categorization is editorial).
-- The devmain divergence that caused the original stale counts (resolved separately via the v4.11.0 rebase).
+- The `38 agents` count (`setup.sh:2484`, `README.md:175`) — same drift class but agents, not skills; separate ticket.
+- The devmain divergence that caused the original stale `123` (resolved via the v4.11.0 rebase).
 
 ---
-*Generated by ticket-plan-workflow-skill for BT-157. Update checkboxes as phases complete.*
+*PLAN-BT-157 v2 — revised after opencode-tooling-subagent review. Update checkboxes as phases complete.*

--- a/PLANS/PLAN-BT-157.md
+++ b/PLANS/PLAN-BT-157.md
@@ -1,0 +1,108 @@
+# PLAN-BT-157 — Dynamic skill-counts in deploy scripts + rebuild stale debug-echo category listing
+
+**Issue:** darellchua2/opencode-config-template#299
+**JIRA:** [BT-157](https://betekk.atlassian.net/browse/BT-157) (BETEKK / Task)
+**Branch:** `BT-157` (off `main` @ v4.11.0)
+**Origin:** Split from #297 / PR #298 (Phase 6.4 + 6.5)
+
+## Context — verified current state (main v4.11.0)
+
+The deploy scripts hardcode the skill total in **multiple** locations with **three different stale values** — triple drift:
+
+| Location | Hardcoded value | Reality |
+|----------|-----------------|---------|
+| `setup.sh:685` `SKILLS (126):` banner | 126 | disk = **132** |
+| `setup.sh:3629` `📦 123 Skills Available` summary | 123 | disk = **132** |
+| `setup.ps1:924` `SKILLS (126):` banner | 126 | disk = **132** |
+| `setup.ps1:2707` `123 Skills Available` summary | 123 | disk = **132** |
+
+Meanwhile `setup.sh:3447` **already computes** `skill_count=$(find ${SKILLS_DIR} -name "SKILL.md" | wc -l)` — but only the `--status` debug headline uses it. `setup.ps1` has **no** dynamic computation at all.
+
+Additionally, the `--status` category listing (`setup.sh:3449+`) is internally contradictory: its headline reports the dynamic count, but the per-category breakdown omits ~6 categories (Agent Optimization, Startup/Business, Configuration, Security, DevOps + Autoresearch) so the listing sums to far less than the headline.
+
+## Dependency & Consumer Map
+
+| Node (file/section) | Depends on (must precede) | Consumers (who depends on this) | Change risk |
+|---------------------|---------------------------|---------------------------------|-------------|
+| `setup.sh` banner @ `:685` (`SKILLS (N):`) | dynamic `skill_count` var in scope | every user running `setup.sh` (first-impression banner) | low |
+| `setup.sh` summary @ `:3629` (`📦 N Skills Available`) | dynamic `skill_count` var in scope | user-visible summary on completion | low |
+| `setup.sh` dynamic compute @ `:3447` | `${SKILLS_DIR}` populated | `--status` headline (already) + banners (after this work) | low — already exists, just lift scope |
+| `setup.sh` `--status` category listing `:3449+` | none | `--status` diagnostic output (operators/debug) | low — editorial mapping |
+| `setup.ps1` banner @ `:924` | new `$skillCount` compute | every Windows user running `setup.ps1` | low |
+| `setup.ps1` summary @ `:2707` | new `$skillCount` compute | Windows user-visible summary | low |
+| `tests/test_*.bats` count assertions | depends on which assert a hardcoded total | CI (Release workflow) | med — may need updating if a test pins a literal |
+
+## Implementation Phases
+
+### Phase 1: `setup.sh` — interpolate dynamic total into banners
+- [ ] **1.1** Compute `skill_count` once at function scope (top of the deploy/banner function) from disk: `local skill_count=$(find "${SKILLS_DIR}" -type f -name "SKILL.md" 2>/dev/null | wc -l)`, so it is in scope for both banner locations.
+    — **Why:** the computation already exists at `:3447` but only inside the `--status` block; lifting it to function scope makes it available to the main banner (`:685`) and summary (`:3629`) without duplicating the `find`.
+    — **Done when:** a single `skill_count` assignment is reachable by all three consumers; no second `find ... | wc -l` is added.
+    — **Consumers affected:** `:685` banner, `:3629` summary, `:3447` `--status` headline (reuse same var).
+- [ ] **1.2** Replace the hardcoded `SKILLS (126):` literal at `:685` with interpolation `SKILLS (${skill_count}):`.
+    — **Why:** removes the primary drift surface (first-impression banner); the heredoc/echo context is interpolation-capable.
+    — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.sh` returns no literal-number matches.
+    — **Consumers affected:** user banner output.
+- [ ] **1.3** Replace the hardcoded `📦 123 Skills Available` at `:3629` with `📦 ${skill_count} Skills Available`.
+    — **Why:** second drift surface; same var, different (wrong) literal today.
+    — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.sh` returns no literal-number matches.
+    — **Consumers affected:** completion summary output.
+
+### Phase 2: `setup.ps1` — add dynamic compute + interpolate
+- [ ] **2.1** Add a `$skillCount` computation near the top of the deploy function: `$skillCount = (Get-ChildItem -Path $SkillsDir -Recurse -Filter "SKILL.md" -ErrorAction SilentlyContinue | Measure-Object).Count` (guard for missing dir).
+    — **Why:** `setup.ps1` has no dynamic count today — both banner literals are pure guesses; this is the Windows-parity fix.
+    — **Done when:** a single `$skillCount` variable is assigned and reachable by both banner locations; missing-dir case yields 0 without error.
+    — **Consumers affected:** `:924` banner, `:2707` summary.
+- [ ] **2.2** Replace `SKILLS (126):` at `:924` with `SKILLS ($skillCount):`.
+    — **Why:** Windows parity with 1.2; removes the same drift on PowerShell.
+    — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.ps1` returns no literal-number matches.
+    — **Consumers affected:** Windows user banner output.
+- [ ] **2.3** Replace `123 Skills Available` at `:2707` with `$skillCount Skills Available`.
+    — **Why:** Windows parity with 1.3.
+    — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.ps1` returns no literal-number matches.
+    — **Consumers affected:** Windows completion summary output.
+
+### Phase 3: `--status` category listing reconciliation (item 6.4)
+- [ ] **3.1** Rebuild the `setup.sh` `--status` per-category breakdown (`:3449+`) to include all current categories (add the ~6 missing: Agent Optimization, Startup/Business, Configuration, Security, DevOps, Autoresearch) so the listing's sum matches the dynamic headline.
+    — **Why:** the diagnostic is internally contradictory today (headline says 132, listing sums to ~90); a wrong diagnostic is worse than none.
+    — **Done when:** the sum of all category counts in the listing equals the dynamic `skill_count` headline above it.
+    — **Consumers affected:** operators running `setup.sh --status` (debug only).
+- [ ] **3.2** Mirror the rebuilt category listing in `setup.ps1` `--status` equivalent.
+    — **Why:** Windows parity; keep both scripts' diagnostics consistent.
+    — **Done when:** `setup.ps1` `--status` listing sums to the same total as `setup.sh`.
+    — **Consumers affected:** Windows operators.
+- [ ] **3.3** (per-category counts stay human-maintained) — explicitly do NOT auto-derive categories; only the **total** is dynamic. Add a one-line comment at the listing stating categorization is an editorial mapping.
+    — **Why:** categorization is editorial (a skill's category is a human judgement), not disk-derivable; auto-deriving would introduce a different drift. Documenting this prevents the next cycle from "fixing" it the wrong way.
+    — **Done when:** a comment explains per-category numbers are hand-maintained and only the total is computed.
+    — **Consumers affected:** future maintainers (next remediation cycle).
+
+### Phase 4: Tests + verification gate
+- [ ] **4.1** Audit `tests/*.bats` for any assertion that pins a hardcoded skill total; update to compute from disk (or assert `>=` a floor) instead of a literal.
+    — **Why:** a test that pins `123` would now fail (disk=132) and re-introduce the drift as a "fix the test to 132" cycle; make the test count-agnostic.
+    — **Done when:** `grep -rnE "123|126" tests/ | grep -i skill` returns no count-pinning assertions (or they are dynamic).
+    — **Consumers affected:** CI Release workflow.
+- [ ] **4.2** Run the full gate: `bash -n deploy/setup.sh`; `python3 -m json.tool opencode_app/opencode.json >/dev/null`; all skill frontmatter parses; `bats tests/` green (if bats installed).
+    — **Why:** every prior change in this repo ships through this gate; a green gate is the completion signal.
+    — **Done when:** all commands exit 0.
+    — **Consumers affected:** PR merge / Release workflow.
+
+## Acceptance Criteria (summary)
+
+- [ ] No hardcoded total skill-count literals in `setup.sh` or `setup.ps1` — all interpolated from a single disk-derived computation.
+- [ ] `grep -nE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero** matches.
+- [ ] `--status` category listing sums to the dynamic total in both scripts.
+- [ ] Per-category counts remain human-maintained (documented), not auto-derived.
+- [ ] `bash -n` clean; bats tests green; count-assertion tests made dynamic.
+
+## Risks & Mitigation
+
+- **Risk:** a category count in the listing is itself wrong (stale). **Mitigation:** Phase 3 reconciles the listing to the total; any residual per-category inaccuracy is editorial and out of scope (documented).
+- **Risk:** a bats test pins a literal and breaks. **Mitigation:** Phase 4.1 makes count-assertions dynamic before running the gate.
+
+## Out of scope
+
+- Auto-deriving categories from disk (categorization is editorial).
+- The devmain divergence that caused the original stale counts (resolved separately via the v4.11.0 rebase).
+
+---
+*Generated by ticket-plan-workflow-skill for BT-157. Update checkboxes as phases complete.*

--- a/PLANS/PLAN-BT-157.md
+++ b/PLANS/PLAN-BT-157.md
@@ -52,91 +52,91 @@ The review caught 3 critical defects + major gaps in v1. Corrected here:
 ## Implementation Phases
 
 ### Phase 1: `setup.sh` — `count_skills` helper + wire 3 consumers (source vs deployed)
-- [ ] **1.1** Add a `count_skills()` helper near the other utility functions (after `REPO_DIR` is defined, ~`:85`): `count_skills() { find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" 2>/dev/null | wc -l; }`.
+- [x] **1.1** Add a `count_skills()` helper near the other utility functions (after `REPO_DIR` is defined, ~`:85`): `count_skills() { find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" 2>/dev/null | wc -l; }`.
     — **Why:** the 3 consumers are in 3 different functions (`show_help`, `print_summary`, `print_next_steps`); a `local` can't span them. A helper is the DRY, scope-safe way to share one computation. `-not -path "*/_archived/*"` matches the deploy's `rsync --exclude='_archived'` so the count reflects **active** skills only.
     — **Done when:** `grep -nE "^count_skills\(\)" deploy/setup.sh` finds the helper; calling `count_skills "${REPO_DIR}/opencode_app/.opencode/skills"` returns 126.
     — **Consumers affected:** 1.2, 1.3, 1.4, Phase 3.
-- [ ] **1.2** In `show_help()` replace `SKILLS (126):` at `:685` with `SKILLS ($(count_skills "${REPO_DIR}/opencode_app/.opencode/skills")):` — **SOURCE** count (banner shown on `--help` before any deploy, must advertise what's shipped, not what's deployed).
+- [x] **1.2** In `show_help()` replace `SKILLS (126):` at `:685` with `SKILLS ($(count_skills "${REPO_DIR}/opencode_app/.opencode/skills")):` — **SOURCE** count (banner shown on `--help` before any deploy, must advertise what's shipped, not what's deployed).
     — **Why:** `show_help` runs pre-deploy; using the DEPLOYED dir would show `0` on a fresh machine. Source count is the advertising number.
     — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.sh` returns no literal; `--help` shows the active source count.
     — **Consumers affected:** every `setup.sh --help` user.
-- [ ] **1.3** In `print_next_steps()` replace `📦 123 Skills Available` at `:3629` with `📦 $(count_skills "${REPO_DIR}/opencode_app/.opencode/skills") Skills Available` — SOURCE count.
+- [x] **1.3** In `print_next_steps()` replace `📦 123 Skills Available` at `:3629` with `📦 $(count_skills "${REPO_DIR}/opencode_app/.opencode/skills") Skills Available` — SOURCE count.
     — **Why:** post-deploy summary advertises what's available; source count is stable regardless of deploy success. Fixes the stale `123` (−3).
     — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.sh` returns no literal.
     — **Consumers affected:** post-deploy summary output.
-- [ ] **1.4** Refactor `print_summary()` `:3447` to use the helper: replace `local skill_count=$(find "${SKILLS_DIR}" -type f -name "SKILL.md" ...)` with `local skill_count=$(count_skills "${SKILLS_DIR}")` — **DEPLOYED** count.
+- [x] **1.4** Refactor `print_summary()` `:3447` to use the helper: replace `local skill_count=$(find "${SKILLS_DIR}" -type f -name "SKILL.md" ...)` with `local skill_count=$(count_skills "${SKILLS_DIR}")` — **DEPLOYED** count.
     — **Why:** dedupe the computation into the helper; `--status` legitimately reports the DEPLOYED state (what the user actually has), which differs from source if a deploy is partial. Deployed dir already excludes `_archived` (rsync), so the helper's `-not -path` is harmless here.
     — **Done when:** `:3447` calls `count_skills`; no standalone `find ... SKILL.md | wc -l` remains outside the helper.
     — **Consumers affected:** `--status` headline (unchanged value, cleaner source).
 
 ### Phase 2: `setup.ps1` — parity helpers + wire consumers
-- [ ] **2.1** Add a `Get-SkillCount` function near the other utilities: `function Get-SkillCount { param([string]$Path) if (-not (Test-Path $Path)) { return 0 }; return @(Get-ChildItem -Path $Path -Recurse -Filter "SKILL.md" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -notmatch "[\\/​]_archived[\\/​]" }).Count }`.
+- [x] **2.1** Add a `Get-SkillCount` function near the other utilities: `function Get-SkillCount { param([string]$Path) if (-not (Test-Path $Path)) { return 0 }; return @(Get-ChildItem -Path $Path -Recurse -Filter "SKILL.md" -ErrorAction SilentlyContinue | Where-Object { $_.FullName -notmatch "[\\/​]_archived[\\/​]" }).Count }`.
     — **Why:** Windows parity with 1.1; `setup.ps1` currently has NO correct SKILL.md-file count (its `:1811`/`:2649` count *directories* including non-skill subdirs — a different, wrong metric). Excludes `_archived` to match deploy (`:1802`).
     — **Done when:** `grep -nE "function Get-SkillCount" deploy/setup.ps1` finds it; `Get-SkillCount (Join-Path $RepoDir "opencode_app\.opencode\skills")` returns 126.
     — **Consumers affected:** 2.2, 2.3, 2.4.
-- [ ] **2.2** Replace `SKILLS (126):` at `:924` with `SKILLS ($(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills'))):` — SOURCE count.
+- [x] **2.2** Replace `SKILLS (126):` at `:924` with `SKILLS ($(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills'))):` — SOURCE count.
     — **Why:** Windows parity with 1.2.
     — **Done when:** `grep -nE "SKILLS \([0-9]+\)" deploy/setup.ps1` returns no literal.
     — **Consumers affected:** Windows `--help` users.
-- [ ] **2.3** Replace `123 Skills Available` at `:2707` with `$(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills')) Skills Available` — SOURCE count.
+- [x] **2.3** Replace `123 Skills Available` at `:2707` with `$(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills')) Skills Available` — SOURCE count.
     — **Why:** Windows parity with 1.3.
     — **Done when:** `grep -nE "[0-9]+ Skills Available" deploy/setup.ps1` returns no literal.
     — **Consumers affected:** Windows post-deploy summary.
-- [ ] **2.4** Wire `Get-SkillCount` into the ps1 `--status` total (find the ps1 equivalent of `:3447`'s dir-count) — DEPLOYED count.
+- [x] **2.4** Wire `Get-SkillCount` into the ps1 `--status` total (find the ps1 equivalent of `:3447`'s dir-count) — DEPLOYED count.
     — **Why:** parity with 1.4; replace the directory-count metric with the correct SKILL.md-file count.
     — **Done when:** ps1 `--status` headline uses `Get-SkillCount $SkillsDir` (deployed).
     — **Consumers affected:** Windows `--status`.
 
 ### Phase 3: Auto-derive category breakdown (REVERSES v1's "hand-maintain" — categories ARE disk-derivable)
-- [ ] **3.1** Add a `print_skill_categories()` helper (bash) that auto-derives per-category counts from frontmatter and prints them: `find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" -exec grep -hE '^[[:space:]]*category:' {} + 2>/dev/null | sed -E 's/^[[:space:]]*category:[[:space:]]*//' | sort | uniq -c | sort -rn | while read n c; do echo "    - $c ($n)"; done`.
+- [x] **3.1** Add a `print_skill_categories()` helper (bash) that auto-derives per-category counts from frontmatter and prints them: `find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" -exec grep -hE '^[[:space:]]*category:' {} + 2>/dev/null | sed -E 's/^[[:space:]]*category:[[:space:]]*//' | sort | uniq -c | sort -rn | while read n c; do echo "    - $c ($n)"; done`.
     — **Why:** v1 Phase 3.3 claimed categories aren't disk-derivable — **FALSE**: 126/126 active skills carry a `category:` field (21 categories). Auto-derive is drift-proof; hand-maintenance is the bug we're fixing. One pipeline replaces two stale hardcoded listings.
     — **Done when:** `grep -nE "^print_skill_categories\(\)" deploy/setup.sh` finds the helper; running it on the source dir prints 21 categories summing to 126.
     — **Consumers affected:** 3.2, 3.3.
-- [ ] **3.2** Replace the hardcoded `--status` category listing at `setup.sh:3449+` with a call `print_skill_categories "${SKILLS_DIR}"` (DEPLOYED) — removes ~115 lines of stale echo.
+- [x] **3.2** Replace the hardcoded `--status` category listing at `setup.sh:3449+` with a call `print_skill_categories "${SKILLS_DIR}"` (DEPLOYED) — removes ~115 lines of stale echo.
     — **Why:** the listing omits 6 categories and sums to 102 vs the 126 headline — internally contradictory. Auto-derive fixes both the omissions and the sum.
     — **Done when:** the `--status` listing sums to the `--status` headline total; `grep -cE "Framework \(19\)|Language-Specific \(8\)" setup.sh` drops (those literals removed).
     — **Consumers affected:** operators running `--status`.
-- [ ] **3.3** Replace the hardcoded `print_next_steps` category listing at `setup.sh:3632-3637` with `print_skill_categories "${REPO_DIR}/opencode_app/.opencode/skills"` (SOURCE).
+- [x] **3.3** Replace the hardcoded `print_next_steps` category listing at `setup.sh:3632-3637` with `print_skill_categories "${REPO_DIR}/opencode_app/.opencode/skills"` (SOURCE).
     — **Why:** this second listing (sums 109) was missed by v1; it re-drifts immediately after 1.3 fixes the total. SOURCE dir because it advertises what's shipped.
     — **Done when:** `print_next_steps` category section is a single helper call; no hardcoded `Framework (N)` literals remain.
     — **Consumers affected:** post-deploy summary.
-- [ ] **3.4** Mirror `Get-SkillCategories` + the two call sites in `setup.ps1` (Windows parity for 3.1-3.3).
+- [x] **3.4** Mirror `Get-SkillCategories` + the two call sites in `setup.ps1` (Windows parity for 3.1-3.3).
     — **Why:** keep both scripts' diagnostics consistent.
     — **Done when:** ps1 `--status` and post-deploy listings auto-derive and sum to 126.
     — **Consumers affected:** Windows operators.
 
 ### Phase 4: README.md + registry.json + init.bats (sync-rule targets v1 missed)
-- [ ] **4.1** Update `README.md:175` ("126 skills") and `:459` ("126 skills organized across 21 categories") — README is markdown (no interpolation), so update the literal to the current active count **and add a `<!-- count: hand-maintained, see BT-157 -->` comment** flagging it as a known sync target.
+- [x] **4.1** Update `README.md:175` ("126 skills") and `:459` ("126 skills organized across 21 categories") — README is markdown (no interpolation), so update the literal to the current active count **and add a `<!-- count: hand-maintained, see BT-157 -->` comment** flagging it as a known sync target.
     — **Why:** the repo's own sync rule (AGENTS.md "Sync Rules") lists README.md as mandatory; v1 omitted it entirely. Markdown can't interpolate, so a flag comment is the laziest way to surface it for the next sync.
     — **Done when:** both literals match the active count; a comment marks them.
     — **Consumers affected:** README readers, documentation-sync-workflow.
-- [ ] **4.2** Regenerate `deploy/registry.json` skill list from disk (excluding `_archived`) so it stays at 126/active; verify `jq '.skills | length' deploy/registry.json` = 126 and each entry resolves to a real skill dir.
+- [x] **4.2** Regenerate `deploy/registry.json` skill list from disk (excluding `_archived`) so it stays at 126/active; verify `jq '.skills | length' deploy/registry.json` = 126 and each entry resolves to a real skill dir.
     — **Why:** registry.json is the opencode-init source-of-truth; it's currently correct (126) but was hand-built. A regeneration guarantees no orphans/stale entries. If a generator script exists, run it; else diff-current and only fix discrepancies.
     — **Done when:** `jq '.skills|length' deploy/registry.json` = active count; no entry points to a missing/nonexistent skill.
     — **Consumers affected:** opencode-init CLI.
-- [ ] **4.3** Make `tests/init.bats:28,43` count-agnostic: assert against the registry's own length (`[ "$skills" = "$(jq '.skills|length' "$REG")" ]`) instead of the literal `"126"`.
+- [x] **4.3** Make `tests/init.bats:28,43` count-agnostic: assert against the registry's own length (`[ "$skills" = "$(jq '.skills|length' "$REG")" ]`) instead of the literal `"126"`.
     — **Why:** the current `126` is correct, but pinning a literal means the test silently rots on the next skill add (the exact drift cycle this ticket kills). Asserting against the registry's own length makes the test self-healing. Note `:43`'s line has no "skill" word, so v1's grep missed it.
     — **Done when:** `grep -nE '"126"|"123"' tests/init.bats` returns no literal count assertions (both :28 and :43 dynamic).
     — **Consumers affected:** CI Release workflow.
 
 ### Phase 5: Verification gate
-- [ ] **5.1** Run the full gate: `bash -n deploy/setup.sh`; `pwsh -nop -c '…parse setup.ps1…'` or manual brace check; `python3 -m json.tool deploy/registry.json >/dev/null`; `python3 -m json.tool opencode_app/opencode.json >/dev/null`; all skill frontmatter parses; `bats tests/` green (if installed).
+- [x] **5.1** Run the full gate: `bash -n deploy/setup.sh`; `pwsh -nop -c '…parse setup.ps1…'` or manual brace check; `python3 -m json.tool deploy/registry.json >/dev/null`; `python3 -m json.tool opencode_app/opencode.json >/dev/null`; all skill frontmatter parses; `bats tests/` green (if installed).
     — **Why:** every prior change ships through this gate; green = done.
     — **Done when:** all commands exit 0; `bats tests/` shows 0 failures.
     — **Consumers affected:** PR merge / Release workflow.
-- [ ] **5.2** Confirm the drift surface is eliminated: `grep -rnE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero** matches; `grep -rnE "Framework \(19\)|Language-Specific \(8\)|CAD & Hardware Design \(14\)" deploy/setup.sh deploy/setup.ps1` → **zero** (no hardcoded category literals).
+- [x] **5.2** Confirm the drift surface is eliminated: `grep -rnE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero** matches; `grep -rnE "Framework \(19\)|Language-Specific \(8\)|CAD & Hardware Design \(14\)" deploy/setup.sh deploy/setup.ps1` → **zero** (no hardcoded category literals).
     — **Why:** this is the acceptance signal — no hardcoded count literals remain in either deploy script.
     — **Done when:** both greps return zero.
     — **Consumers affected:** future skill-add cycles (the drift can't recur).
 
 ## Acceptance Criteria (summary)
 
-- [ ] No hardcoded total skill-count literals in `setup.sh`/`setup.ps1` — all via `count_skills`/`Get-SkillCount` (excluding `_archived`).
-- [ ] `grep -rnE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero**.
-- [ ] No hardcoded category literals — both listings auto-derive from frontmatter; sums match totals.
-- [ ] Source-vs-deployed semantics correct: `show_help`/`print_next_steps` = SOURCE; `--status` = DEPLOYED.
-- [ ] `README.md` literals current + flagged; `registry.json` regenerated; `init.bats` count-agnostic.
-- [ ] `bash -n` clean; bats green; JSON valid.
+- [x] No hardcoded total skill-count literals in `setup.sh`/`setup.ps1` — all via `count_skills`/`Get-SkillCount` (excluding `_archived`).
+- [x] `grep -rnE "SKILLS \([0-9]+\)|[0-9]+ Skills Available" deploy/setup.sh deploy/setup.ps1` → **zero**.
+- [x] No hardcoded category literals — both listings auto-derive from frontmatter; sums match totals.
+- [x] Source-vs-deployed semantics correct: `show_help`/`print_next_steps` = SOURCE; `--status` = DEPLOYED.
+- [x] `README.md` literals current + flagged; `registry.json` regenerated; `init.bats` count-agnostic.
+- [x] `bash -n` clean; bats green; JSON valid.
 
 ## Risks & Mitigation
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ docker compose build --no-cache
 
 ## Project-Scoped Install (`opencode-init`)
 
-Not every project needs all 38 agents + 126 skills. `opencode-init` installs a **curated subset** into a target project's `.opencode/` and writes a project `opencode.json` configuring just that subset — chosen interactively (TUI) or via flags (LLM/CI). It is the project-scoped companion to the global `setup.sh` deploy, and is symlinked onto PATH as `opencode-init` by `setup.sh`.
+Not every project needs all 38 agents + 126 skills. <!-- count: hand-maintained — sync on skill/agent add (BT-157) --> `opencode-init` installs a **curated subset** into a target project's `.opencode/` and writes a project `opencode.json` configuring just that subset — chosen interactively (TUI) or via flags (LLM/CI). It is the project-scoped companion to the global `setup.sh` deploy, and is symlinked onto PATH as `opencode-init` by `setup.sh`.
 
 > **Mutually exclusive with global deploy for isolation.** OpenCode **merges** config and **unions** agents/skills across `~/.config/opencode` and `<project>/.opencode`. A project subset only yields an *isolated* curated experience on a **clean slate** (no global deploy). If `~/.config/opencode/agents/` is non-empty, the project install is **additive** — `opencode-init` detects this and warns. `permission.task` (scoped subagent-spawn allowlist) still restricts auto-spawning even with a global deploy; `@`-mention still bypasses it. See [issue #286](https://github.com/darellchua2/opencode-config-template/issues/286) and `PLANS/PLAN-GIT-286.md`.
 
@@ -456,7 +456,7 @@ TypeScript, JavaScript, Python, Go, Rust, Java, C#, PHP, Ruby, C, C++, Swift, Ko
 
 ## Skill Modularization
 
-This repository implements **skill modularization** with 126 skills organized across 21 categories. Skills are designed with clear separation of concerns and explicit dependencies.
+This repository implements **skill modularization** with 126 skills organized across 21 categories. <!-- count: hand-maintained — sync on skill add (BT-157) --> Skills are designed with clear separation of concerns and explicit dependencies.
 
 > **Registry-derived (PLAN-GIT-286):** every skill + agent now carries a `category:` frontmatter field, which `deploy/build-registry.mjs` reads to emit `deploy/registry.json` — the single source of truth consumed by the `opencode-init` project-scoped installer and (regenerable into) this category table. To refresh after editing frontmatter: `node deploy/build-registry.mjs` (CI fails on drift via `--check`).
 

--- a/deploy/setup.ps1
+++ b/deploy/setup.ps1
@@ -171,6 +171,34 @@ function Write-LogError   { param([string]$Msg) Write-Log "ERROR"   $Msg }
 function Write-LogSuccess { param([string]$Msg) Write-Log "SUCCESS" $Msg }
 function Write-LogDebug   { param([string]$Msg) Write-Log "DEBUG"   $Msg }
 
+# Count active SKILL.md files in a directory, excluding _archived (matches the
+# deploy's _archived skip). Drift-proof skill count for banners/status. BT-157.
+function Get-SkillCount {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return 0 }
+    return @(Get-ChildItem -Path $Path -Recurse -Filter "SKILL.md" -File -ErrorAction SilentlyContinue |
+             Where-Object { $_.FullName -notmatch "[\\/]_archived[\\/]" }).Count
+}
+
+# Auto-derive per-category counts from skill frontmatter (category: field),
+# excluding _archived. Prints "Category (N)" lines sorted by count desc. BT-157.
+function Get-SkillCategories {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return }
+    Get-ChildItem -Path $Path -Recurse -Filter "SKILL.md" -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch "[\\/]_archived[\\/]" } |
+        ForEach-Object {
+            $cat = (Get-Content $_.FullName -ErrorAction SilentlyContinue |
+                    Where-Object { $_ -match '^\s*category:\s*(.+)$' } |
+                    Select-Object -First 1) -replace '^\s*category:\s*',''
+            [pscustomobject]@{ Category = $cat.Trim() }
+        } |
+        Where-Object { $_.Category } |
+        Group-Object Category |
+        Sort-Object Count -Descending |
+        ForEach-Object { "    - {0} ({1})" -f $_.Name, $_.Count }
+}
+
 ################################################################################
 # UTILITY FUNCTIONS
 ################################################################################
@@ -921,89 +949,9 @@ USAGE:
     Usage: opencode --agent build 'implement auth feature'
             opencode --agent explore 'find all API routes'
  
-            SKILLS (126):
-              Framework (19):       test-generator-framework, linting-workflow,
-                                      pr-creation-workflow, pr-merge-workflow,
-                                      error-resolver-workflow, tdd-workflow,
-                                      docx-creation,
-                                      xlsx-specialist, pdf-specialist, frontend-design,
-                                      uiux-review-skill,
-                                      api-design-skill, openapi-contract-adherence-skill,
-                                      performance-optimization-skill, srs-creation-skill,
-                                      brd-creation-skill, technical-design-creation-skill,
-                                      vision-creation-skill, interactive-document-rendering-skill
+            SKILLS ($(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills'))):
 
-            Presentation (3):       pptx-generate-slide-skill, pptx-generate-template-skill,
-                                      pptx-template-modifier-skill
-
-            Office Utilities (2):   ooxml-editing-skill, office-thumbnail-skill
-
-            Language-Specific (8): python-pytest-creator, python-ruff-linter,
-                                  javascript-eslint-linter, changelog-python-cliff,
-                                  python-backend-skill, python-packaging-skill,
-                                  csharp-linter-skill, java-linter-skill
-
-           Framework-Specific (10): nextjs-pr-workflow, nextjs-unit-test-creator,
-                                  nextjs-standard-setup, nextjs-image-usage,
-                                  nextjs-devtools-mcp, amplify-nextjs-deployment,
-                                  typescript-dry-principle, accessibility-a11y-skill,
-                                  react-nextjs-antipatterns-skill,
-                                  threejs-nextjs-skill
-           OpenCode Meta (4):    opencode-agent-creation, opencode-skill-creation,
-                                 opencode-skills-maintainer,
-                                 documentation-consistency-skill
-           OpenTofu (7):         opentofu-aws-explorer, opentofu-keycloak-explorer,
-                                 opentofu-kubernetes-explorer, opentofu-neon-explorer,
-                                 opentofu-provider-setup, opentofu-provisioning-workflow,
-                                 opentofu-ecr-provision
-            Git/Workflow (13):    ascii-diagram-creator, mermaid-diagram-creator,
-                                   ticket-plan-workflow-skill, plan-execution-skill,
-                                   plan-automation-loop-skill,
-                                   git-issue-labeler, git-issue-updater,
-                                   git-semantic-commits, semantic-release-convention,
-                                   git-compact-commits, plan-updater, version-bump-standard,
-                                   git-branch-workflow-setup-skill
-          Documentation (3):    coverage-readme-workflow, docstring-generator,
-                                 documentation-sync-workflow
-
-          JIRA (3):             jira-status-updater, jira-git-integration, jira-ticket-labeler
-          Code Quality (8):     solid-principles, clean-code, clean-architecture,
-                                design-patterns, object-design, code-smells,
-                                complexity-management, deprecated-code-cleanup-skill
-
-       Agent Optimization (7):  continuous-learning, eval-harness,
-                                 strategic-compact, verification-loop,
-                                 search-first, context-budget,
-                                 agent-introspection-debugging
-
-            Autoresearch (4):  autoresearch-core-skill, autoresearch-ml-skill,
-                                autoresearch-code-skill, autoresearch-research-skill
-
-            Startup/Business (3): startup-pitch-deck-skill, startup-business-docs-skill,
-                                  construction-bd-skill
-
-            Configuration (3):    microsoft-m365-config-skill, codegraph-setup-skill,
-                                  markitdown-mcp-skill
-
-              Security (2):     security-audit-skill, authentication-authorization-skill
-
-                 DevOps (4):     docker-containerization-skill, monorepo-management-skill,
-                                 database-migration-skill, logging-observability-skill
-
-      Planning & Alignment (4): grilling-skill, domain-modeling-skill,
-                                grill-with-docs-skill, grill-me-skill
-
- Responsive & Visual Testing (2): wireframer-skill,
-                                   playwright-responsive-audit-skill
-
-    CAD & Hardware Design (14): cad-generation, cad-viewer, cad-step-parts,
-                                 cad-dxf, cad-urdf, cad-srdf, cad-sdf,
-                                 cad-sendcutsend, cad-gcode, cad-bambu-labs,
-                                 cad-implicit, autodesk-aps-skill,
-civil-3d-skill, open3d-skill
-
-  Academic & Research Writing (2): horseshoe-paper-writing-skill,
-                                    research-paper-generation-skill
+$(Get-SkillCategories (Join-Path $RepoDir 'opencode_app\.opencode\skills'))
 
     Run 'opencode --list-skills' for detailed descriptions
     Run 'opencode --skill <name> \"prompt\"' to invoke a skill
@@ -1808,93 +1756,12 @@ function Deploy-Skills {
         }
          Write-LogSuccess "Skills copied successfully to $SkillsDir"
          
-        $skillCount = @(Get-ChildItem $SkillsDir -Directory -ErrorAction SilentlyContinue).Count
+        $skillCount = Get-SkillCount $SkillsDir
         Write-Host ""
         Write-Host "Deployed $skillCount skills to $SkillsDir" -ForegroundColor Green
         Write-Host ""
-        Write-Host "  Skill Categories:" -ForegroundColor Cyan
-          Write-Host "    Framework (19):"
-        Write-Host "      - test-generator-framework, linting-workflow"
-        Write-Host "      - pr-creation-workflow, pr-merge-workflow"
-        Write-Host "      - error-resolver-workflow, tdd-workflow"
-        Write-Host "      - docx-creation, xlsx-specialist, pdf-specialist"
-        Write-Host "      - frontend-design"
-        Write-Host "      - uiux-review-skill"
-        Write-Host "      - api-design-skill, openapi-contract-adherence-skill"
-        Write-Host "      - performance-optimization-skill"
-        Write-Host "      - srs-creation-skill"
-        Write-Host "      - brd-creation-skill"
-        Write-Host "      - technical-design-creation-skill"
-        Write-Host "      - vision-creation-skill"
-        Write-Host "      - interactive-document-rendering-skill"
-        Write-Host "    Language-Specific (8):"
-        Write-Host "      - python-pytest-creator, python-ruff-linter"
-        Write-Host "      - javascript-eslint-linter, changelog-python-cliff"
-        Write-Host "      - python-backend-skill, python-packaging-skill"
-        Write-Host "      - csharp-linter-skill, java-linter-skill"
-        Write-Host "    Presentation (3):"
-        Write-Host "      - pptx-generate-slide-skill, pptx-generate-template-skill"
-        Write-Host "      - pptx-template-modifier-skill"
-        Write-Host "    Office Utilities (2):"
-        Write-Host "      - ooxml-editing-skill, office-thumbnail-skill"
-        Write-Host "    Framework-Specific (10):"
-        Write-Host "      - nextjs-pr-workflow, nextjs-unit-test-creator"
-        Write-Host "      - nextjs-standard-setup, nextjs-image-usage"
-        Write-Host "      - nextjs-devtools-mcp"
-        Write-Host "      - amplify-nextjs-deployment"
-        Write-Host "      - typescript-dry-principle, accessibility-a11y-skill"
-        Write-Host "      - react-nextjs-antipatterns-skill"
-        Write-Host "      - threejs-nextjs-skill"
-        Write-Host "    OpenCode Meta (4):"
-        Write-Host "      - opencode-agent-creation, opencode-skill-creation"
-        Write-Host "      - opencode-skills-maintainer"
-        Write-Host "      - documentation-consistency-skill"
-        Write-Host "    OpenTofu (7):"
-        Write-Host "      - opentofu-aws-explorer, opentofu-keycloak-explorer"
-        Write-Host "      - opentofu-kubernetes-explorer, opentofu-neon-explorer"
-        Write-Host "      - opentofu-provider-setup, opentofu-provisioning-workflow"
-        Write-Host "      - opentofu-ecr-provision"
-         Write-Host "    Git/Workflow (13):"
-         Write-Host "      - ascii-diagram-creator, mermaid-diagram-creator"
-         Write-Host "      - ticket-plan-workflow-skill, plan-execution-skill"
-         Write-Host "      - plan-automation-loop-skill"
-        Write-Host "      - git-issue-labeler, git-issue-updater"
-        Write-Host "      - git-semantic-commits, semantic-release-convention"
-        Write-Host "      - git-compact-commits"
-        Write-Host "      - plan-updater"
-        Write-Host "      - version-bump-standard"
-        Write-Host "      - git-branch-workflow-setup-skill"
-        Write-Host "    Documentation (3):"
-        Write-Host "      - coverage-readme-workflow, docstring-generator"
-        Write-Host "      - documentation-sync-workflow"
-         Write-Host "    Academic & Research Writing (2):"
-         Write-Host "      - horseshoe-paper-writing-skill, research-paper-generation-skill"
-         Write-Host "    JIRA (3):"
-         Write-Host "      - jira-status-updater, jira-git-integration, jira-ticket-labeler"
-        Write-Host "    Code Quality (8):"
-        Write-Host "      - solid-principles, clean-code, clean-architecture"
-        Write-Host "      - design-patterns, object-design, code-smells"
-        Write-Host "      - complexity-management, deprecated-code-cleanup-skill"
-        Write-Host "    Agent Optimization (7):"
-        Write-Host "      - continuous-learning, eval-harness"
-        Write-Host "      - strategic-compact, verification-loop"
-        Write-Host "      - search-first, context-budget"
-        Write-Host "      - agent-introspection-debugging"
-        Write-Host "    Startup/Business (3):"
-        Write-Host "      - startup-pitch-deck-skill, startup-business-docs-skill"
-        Write-Host "      - construction-bd-skill"
-        Write-Host "    Configuration (3):"
-        Write-Host "      - microsoft-m365-config-skill, codegraph-setup-skill, markitdown-mcp-skill"
-        Write-Host "    Planning & Alignment (4):"
-        Write-Host "      - grilling-skill, domain-modeling-skill"
-        Write-Host "      - grill-with-docs-skill, grill-me-skill"
-        Write-Host "    Responsive & Visual Testing (2):"
-        Write-Host "      - wireframer-skill, playwright-responsive-audit-skill"
-        Write-Host "    CAD & Hardware Design (14):"
-        Write-Host "      - cad-generation-skill, cad-viewer-skill, cad-step-parts-skill"
-        Write-Host "      - cad-dxf-skill, cad-urdf-skill, cad-srdf-skill, cad-sdf-skill"
-        Write-Host "      - cad-sendcutsend-skill, cad-gcode-skill, cad-bambu-labs-skill"
-        Write-Host "      - cad-implicit-skill, autodesk-aps-skill, civil-3d-skill, open3d-skill"
+         Write-Host "  Skill Categories:" -ForegroundColor Cyan
+        Get-SkillCategories $SkillsDir
         Write-Host ""
         Write-Host "  Run 'opencode --list-skills' for detailed descriptions"
         Write-Host ""
@@ -2704,16 +2571,11 @@ function Show-NextSteps {
     Write-Host "         opencode `"prompt`" (uses build)"
      Write-Host ""
     Write-Host "=====================================================================" -ForegroundColor White
-      Write-Host "                     123 Skills Available" -ForegroundColor White
+      Write-Host "                     $(Get-SkillCount (Join-Path $RepoDir 'opencode_app\.opencode\skills')) Skills Available" -ForegroundColor White
      Write-Host "=====================================================================" -ForegroundColor White
+      Write-Host ""
+      Get-SkillCategories (Join-Path $RepoDir 'opencode_app\.opencode\skills')
      Write-Host ""
-     Write-Host "  Framework (19) • Language-Specific (8) • Presentation (3)"
-      Write-Host "  Office Utilities (2) • Framework-Specific (10) • OpenCode Meta (4)"
-      Write-Host "  OpenTofu (7) • Git/Workflow (13) • Documentation (3) • JIRA (3) • Code Quality (8)"
-      Write-Host "  Agent Optimization (7) • Planning & Alignment (4) • Academic & Research Writing (2)"
-     Write-Host "  Responsive & Visual Testing (2)"
-     Write-Host "  CAD & Hardware Design (14)"
-    Write-Host ""
     Write-Host "  Run 'opencode --list-skills' for detailed descriptions"
     Write-Host "  Run 'opencode --skill <name> `"prompt`"' to invoke a skill"
     Write-Host ""

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -404,6 +404,25 @@ log_warn() { log "WARNING" "$@"; }
 log_error() { log "ERROR" "$@"; }
 log_success() { log "SUCCESS" "$@"; }
 
+# Count active SKILL.md files in a directory, excluding _archived (matches
+# the deploy's rsync --exclude='_archived'). Used by banners/status listings
+# so skill counts can never drift from disk. BT-157.
+count_skills() {
+    [ -d "$1" ] || { echo 0; return; }
+    find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" 2>/dev/null | wc -l
+}
+
+# Auto-derive per-category counts from skill frontmatter (category: field),
+# excluding _archived. Drift-proof replacement for the hand-maintained listings.
+# Prints "Category (N)" lines sorted by count desc. BT-157.
+print_skill_categories() {
+    [ -d "$1" ] || return
+    find "$1" -type f -name "SKILL.md" -not -path "*/_archived/*" -exec grep -hE '^[[:space:]]*category:' {} + 2>/dev/null \
+        | sed -E 's/^[[:space:]]*category:[[:space:]]*//' \
+        | sort | uniq -c | sort -rn \
+        | while read -r n c; do [ -n "$c" ] && echo "    - ${c} (${n})"; done
+}
+
 ################################################################################
 # ERROR HANDLING
 ################################################################################
@@ -682,96 +701,11 @@ USAGE:
       google-gce         Google Compute Engine management
       google-gke         Google Kubernetes Engine management
 
-    SKILLS (126):
-              Framework (19):       test-generator-framework, linting-workflow,
-                                      pr-creation-workflow, pr-merge-workflow,
-                                      error-resolver-workflow, tdd-workflow,
-                                      docx-creation,
-                                      xlsx-specialist, pdf-specialist, frontend-design,
-                                      uiux-review-skill,
-                                      api-design-skill, openapi-contract-adherence-skill,
-                                      performance-optimization-skill, srs-creation-skill,
-                                      brd-creation-skill, technical-design-creation-skill,
-                                      vision-creation-skill, interactive-document-rendering-skill
+    SKILLS ($(count_skills "${REPO_DIR}/opencode_app/.opencode/skills")):
 
-            Presentation (3):       pptx-generate-slide-skill, pptx-generate-template-skill,
-                                      pptx-template-modifier-skill
+$(print_skill_categories "${REPO_DIR}/opencode_app/.opencode/skills")
 
-            Office Utilities (2):   ooxml-editing-skill, office-thumbnail-skill
-
-            Language-Specific (8): python-pytest-creator, python-ruff-linter,
-                                  javascript-eslint-linter, changelog-python-cliff,
-                                  python-backend-skill, python-packaging-skill,
-                                  csharp-linter-skill, java-linter-skill
-
-          Framework-Specific (10): nextjs-pr-workflow, nextjs-unit-test-creator,
-                                 nextjs-standard-setup, nextjs-image-usage,
-                                 nextjs-devtools-mcp, amplify-nextjs-deployment,
-                                  typescript-dry-principle, accessibility-a11y-skill,
-                                  react-nextjs-antipatterns-skill,
-                                  threejs-nextjs-skill
-
-           OpenCode Meta (4):    opencode-agent-creation, opencode-skill-creation,
-                                 opencode-skills-maintainer,
-                                 documentation-consistency-skill
-
-           OpenTofu (7):         opentofu-aws-explorer, opentofu-keycloak-explorer,
-                                 opentofu-kubernetes-explorer, opentofu-neon-explorer,
-                                 opentofu-provider-setup, opentofu-provisioning-workflow,
-                                 opentofu-ecr-provision
-
-            Git/Workflow (13):   ascii-diagram-creator, mermaid-diagram-creator,
-                                  ticket-plan-workflow-skill, plan-execution-skill,
-                                  plan-automation-loop-skill,
-                                  git-issue-labeler, git-issue-updater,
-                                  git-semantic-commits, semantic-release-convention,
-                                  git-compact-commits, plan-updater, version-bump-standard,
-                                  git-branch-workflow-setup-skill
-
-          Documentation (3):    coverage-readme-workflow, docstring-generator,
-                                 documentation-sync-workflow
-
-          JIRA (3):             jira-status-updater, jira-git-integration, jira-ticket-labeler
-
-         Code Quality (8):     solid-principles-skill, clean-code-skill, clean-architecture-skill,
-                               design-patterns-skill, object-design-skill, code-smells-skill,
-                               complexity-management-skill, deprecated-code-cleanup-skill
-
-       Agent Optimization (7):  continuous-learning-skill, eval-harness-skill,
-                                strategic-compact-skill, verification-loop-skill,
-                                search-first-skill, context-budget-skill,
-                                agent-introspection-debugging-skill
-
-            Autoresearch (4):  autoresearch-core-skill, autoresearch-ml-skill,
-                                autoresearch-code-skill, autoresearch-research-skill
-
-            Startup/Business (3): startup-pitch-deck-skill, startup-business-docs-skill,
-                                  construction-bd-skill
-
-            Configuration (3):    microsoft-m365-config-skill, codegraph-setup-skill,
-                                  markitdown-mcp-skill
-
-              Security (2):     security-audit-skill, authentication-authorization-skill
-
-                 DevOps (4):     docker-containerization-skill, monorepo-management-skill,
-                                 database-migration-skill, logging-observability-skill
-
-       Planning & Alignment (4): grilling-skill, domain-modeling-skill,
-                                 grill-with-docs-skill, grill-me-skill
-
- Responsive & Visual Testing (2): wireframer-skill,
-                                   playwright-responsive-audit-skill
-
-    CAD & Hardware Design (14): cad-generation, cad-viewer, cad-step-parts,
-                                 cad-dxf, cad-urdf, cad-srdf, cad-sdf,
-                                 cad-sendcutsend, cad-gcode, cad-bambu-labs,
-                                 cad-implicit, autodesk-aps-skill,
-                                 civil-3d-skill, open3d-skill
-
-  Academic & Research Writing (2): horseshoe-paper-writing-skill,
-                                    research-paper-generation-skill
-
-    Run 'opencode --list-skills' for detailed descriptions
+     Run 'opencode --list-skills' for detailed descriptions
     Run 'opencode --skill <name> "prompt"' to invoke a skill
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -3444,123 +3378,9 @@ print_summary() {
 
     # skills directory status
     if [ -d "$SKILLS_DIR" ] && [ "$(ls -A "${SKILLS_DIR}" 2>/dev/null)" ]; then
-        local skill_count=$(find "${SKILLS_DIR}" -type f -name "SKILL.md" 2>/dev/null | wc -l)
+        local skill_count=$(count_skills "${SKILLS_DIR}")
         echo "✓ skills: ${skill_count} skills deployed to ${SKILLS_DIR}/"
-        echo "    - Framework (19):"
-        echo "      - test-generator-framework"
-        echo "      - linting-workflow"
-        echo "      - pr-creation-workflow"
-        echo "      - pr-merge-workflow"
-        echo "      - error-resolver-workflow"
-        echo "      - tdd-workflow"
-        echo "      - docx-creation"
-        echo "      - xlsx-specialist"
-        echo "      - pdf-specialist"
-        echo "      - frontend-design"
-        echo "      - uiux-review-skill"
-        echo "      - api-design-skill"
-        echo "      - openapi-contract-adherence-skill"
-        echo "      - performance-optimization-skill"
-        echo "      - srs-creation-skill"
-        echo "      - brd-creation-skill"
-        echo "      - technical-design-creation-skill"
-        echo "      - vision-creation-skill"
-        echo "      - interactive-document-rendering-skill"
-        echo "    - Language-Specific (8):"
-        echo "      - python-pytest-creator"
-        echo "      - python-ruff-linter"
-        echo "      - javascript-eslint-linter"
-        echo "      - changelog-python-cliff"
-        echo "      - python-backend-skill"
-        echo "      - python-packaging-skill"
-        echo "      - csharp-linter-skill"
-        echo "      - java-linter-skill"
-        echo "    - Presentation (3):"
-        echo "      - pptx-generate-slide-skill, pptx-generate-template-skill"
-        echo "      - pptx-template-modifier-skill"
-        echo "    - Office Utilities (2):"
-        echo "      - ooxml-editing-skill, office-thumbnail-skill"
-        echo "    - Framework-Specific (10):"
-        echo "      - nextjs-pr-workflow"
-        echo "      - nextjs-unit-test-creator"
-        echo "      - nextjs-standard-setup"
-        echo "      - nextjs-image-usage"
-        echo "      - nextjs-devtools-mcp"
-        echo "      - amplify-nextjs-deployment"
-        echo "      - typescript-dry-principle"
-        echo "      - accessibility-a11y-skill"
-        echo "      - react-nextjs-antipatterns-skill"
-        echo "      - threejs-nextjs-skill"
-        echo "    - OpenCode Meta (4):"
-        echo "      - opencode-agent-creation"
-        echo "      - opencode-skill-creation"
-        echo "      - opencode-skills-maintainer"
-        echo "      - documentation-consistency-skill"
-        echo "    - OpenTofu (7):"
-        echo "      - opentofu-aws-explorer"
-        echo "      - opentofu-keycloak-explorer"
-        echo "      - opentofu-kubernetes-explorer"
-        echo "      - opentofu-neon-explorer"
-        echo "      - opentofu-provider-setup"
-        echo "      - opentofu-provisioning-workflow"
-        echo "      - opentofu-ecr-provision"
-        echo "    - Git/Workflow (13):"
-        echo "      - ascii-diagram-creator"
-        echo "      - mermaid-diagram-creator"
-        echo "      - ticket-plan-workflow-skill"
-        echo "      - plan-execution-skill"
-        echo "      - plan-automation-loop-skill"
-        echo "      - git-issue-labeler"
-        echo "      - git-issue-updater"
-        echo "      - git-semantic-commits"
-        echo "      - semantic-release-convention"
-        echo "      - git-compact-commits"
-        echo "      - plan-updater"
-        echo "      - version-bump-standard"
-        echo "      - git-branch-workflow-setup-skill"
-        echo "    - Documentation (3):"
-        echo "      - coverage-readme-workflow"
-        echo "      - docstring-generator"
-        echo "      - documentation-sync-workflow"
-         echo "    - Academic & Research Writing (2):"
-         echo "      - horseshoe-paper-writing-skill"
-         echo "      - research-paper-generation-skill"
-         echo "    - JIRA (3):"
-         echo "      - jira-status-updater"
-         echo "      - jira-git-integration"
-         echo "      - jira-ticket-labeler"
-        echo "    - Code Quality (8):"
-        echo "      - solid-principles"
-        echo "      - clean-code"
-        echo "      - clean-architecture"
-        echo "      - design-patterns"
-        echo "      - object-design"
-        echo "      - code-smells"
-        echo "      - complexity-management"
-        echo "      - deprecated-code-cleanup-skill"
-         echo "    - Planning & Alignment (4):"
-         echo "      - grilling-skill"
-         echo "      - domain-modeling-skill"
-         echo "      - grill-with-docs-skill"
-         echo "      - grill-me-skill"
-        echo "    - Responsive & Visual Testing (2):"
-        echo "      - wireframer-skill"
-        echo "      - playwright-responsive-audit-skill"
-        echo "    - CAD & Hardware Design (14):"
-        echo "      - cad-generation-skill"
-        echo "      - cad-viewer-skill"
-        echo "      - cad-step-parts-skill"
-        echo "      - cad-dxf-skill"
-        echo "      - cad-urdf-skill"
-        echo "      - cad-srdf-skill"
-        echo "      - cad-sdf-skill"
-        echo "      - cad-sendcutsend-skill"
-        echo "      - cad-gcode-skill"
-        echo "      - cad-bambu-labs-skill"
-        echo "      - cad-implicit-skill"
-        echo "      - autodesk-aps-skill"
-        echo "      - civil-3d-skill"
-        echo "      - open3d-skill"
+        print_skill_categories "${SKILLS_DIR}"
 
     else
         echo "✗ skills: Not deployed"
@@ -3626,16 +3446,11 @@ print_next_steps() {
     echo "         opencode \"prompt\" (uses build)"
      echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-      echo "                     📦 123 Skills Available"
+      echo "                     📦 $(count_skills "${REPO_DIR}/opencode_app/.opencode/skills") Skills Available"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo ""
-     echo "  Framework (19) • Language-Specific (8) • Presentation (3)"
-     echo "  Office Utilities (2) • Framework-Specific (10) • OpenCode Meta (4)"
-      echo "  OpenTofu (7) • Git/Workflow (13) • Documentation (3) • JIRA (3) • Code Quality (8)"
-    echo "  Agent Optimization (7) • Planning & Alignment (4) • Academic & Research Writing (2)"
-    echo "  Responsive & Visual Testing (2)"
-    echo "  CAD & Hardware Design (14)"
-    echo ""
+     echo ""
+     print_skill_categories "${REPO_DIR}/opencode_app/.opencode/skills"
+     echo ""
     echo "  Run 'opencode --list-skills' for detailed descriptions"
     echo "  Run 'opencode --skill <name> \"prompt\"' to use a skill"
     echo ""

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -24,13 +24,16 @@ teardown() { rm -rf "$TMP_PROJ"; }
   agents=$(jq_get "len(d['agents'])" < "$REG")
   skills=$(jq_get "len(d['skills'])" < "$REG")
   echo "agents=$agents skills=$skills" >&3
-  [ "$agents" = "38" ]
-  [ "$skills" = "126" ]
+  # Count-agnostic: registry must match disk (excludes _archived). BT-157.
+  disk_agents=$(find "${REPO}/opencode_app/.opencode/agents" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+  disk_skills=$(find "${REPO}/opencode_app/.opencode/skills" -name 'SKILL.md' -not -path '*/_archived/*' 2>/dev/null | wc -l | tr -d ' ')
+  [ "$agents" = "$disk_agents" ]
+  [ "$skills" = "$disk_skills" ]
 }
 
-@test "--list agents is valid JSON with 38 entries" {
+@test "--list agents is valid JSON matching registry count" {
   count=$($INIT --list agents 2>/dev/null | jq_len)
-  [ "$count" = "38" ]
+  [ "$count" = "$(jq_get "len(d['agents'])" < "$REG")" ]
 }
 
 @test "--list agents --category review filters to reviewers" {
@@ -38,9 +41,9 @@ teardown() { rm -rf "$TMP_PROJ"; }
   [ "$count" = "7" ]
 }
 
-@test "--list skills is valid JSON with 126 entries" {
+@test "--list skills is valid JSON matching registry count" {
   count=$($INIT --list skills 2>/dev/null | jq_len)
-  [ "$count" = "126" ]
+  [ "$count" = "$(jq_get "len(d['skills'])" < "$REG")" ]
 }
 
 @test "--list categories is valid non-empty JSON" {

--- a/tests/test_markitdown_skill.bats
+++ b/tests/test_markitdown_skill.bats
@@ -67,22 +67,25 @@ AGENTS_WITH_SKILL_GRANT=(
 }
 
 # =============================================================================
-# Cross-file skill count consistency (locks the count at 124)
+# Cross-file skill count consistency (dynamic: count_skills == disk == README)
 # =============================================================================
 
 @test "skill_count_consistent_across_docs" {
-  actual=$(find opencode_app/.opencode/skills -maxdepth 2 -name SKILL.md | wc -l)
+  # Active count excludes _archived (matches count_skills/Get-SkillCount). BT-157.
+  actual=$(find opencode_app/.opencode/skills -maxdepth 2 -name SKILL.md -not -path '*/_archived/*' | wc -l | tr -d ' ')
   echo "Actual skill count: $actual" >&3
 
-  # setup.sh help text
-  setup_count=$(grep -oE 'SKILLS \([0-9]+\)' deploy/setup.sh | grep -oE '[0-9]+' | head -1)
-  echo "setup.sh count: $setup_count" >&3
+  # setup.sh: dynamic via count_skills() helper — source it, verify output == disk,
+  # and confirm no stale hardcoded literal remains. BT-157.
+  source <(sed -n '/^count_skills()/,/^}/p' deploy/setup.sh)
+  setup_count=$(count_skills opencode_app/.opencode/skills | tr -d ' ')
+  echo "setup.sh count_skills output: $setup_count" >&3
   [ "$setup_count" = "$actual" ]
+  ! grep -qE 'SKILLS \([0-9]+\)' deploy/setup.sh
 
-  # setup.ps1 help text
-  setupps1_count=$(grep -oE 'SKILLS \([0-9]+\)' deploy/setup.ps1 | grep -oE '[0-9]+' | head -1)
-  echo "setup.ps1 count: $setupps1_count" >&3
-  [ "$setupps1_count" = "$actual" ]
+  # setup.ps1: dynamic via Get-SkillCount — verify helper present + no stale literal.
+  grep -q 'function Get-SkillCount' deploy/setup.ps1
+  ! grep -qE 'SKILLS \([0-9]+\)' deploy/setup.ps1
 
   # opencode_app/README.md skill directory count
   docker_count=$(grep -oE '[0-9]+ skill director(y|ies)' opencode_app/README.md | grep -oE '[0-9]+' | head -1)


### PR DESCRIPTION
## Summary

Eliminates the recurring skill-count drift in the deploy scripts (3rd remediation cycle: PLAN-GIT-237 → #297 → now). **Every** skill count and category breakdown now derives from disk at runtime — no hardcoded literals remain.

Resolves [BT-157](https://betekk.atlassian.net/browse/BT-157) / #299. Implements `PLANS/PLAN-BT-157.md` (v2, revised after opencode-tooling-subagent review).

## What changed

**`setup.sh`** — added `count_skills()` + `print_skill_categories()` helpers:
- `count_skills <dir>` counts active `SKILL.md` excluding `_archived` (matches the deploy's `rsync --exclude='_archived'`).
- `print_skill_categories <dir>` auto-derives per-category counts from the `category:` frontmatter field (drift-proof — 126/126 active skills carry it).
- Wired into all 3 consumers with correct **source-vs-deployed** semantics: `show_help` + `print_next_steps` → SOURCE count (shown pre-deploy); `--status` → DEPLOYED count.
- Replaced ~300 lines of hardcoded listings across 3 locations.

**`setup.ps1`** — `Get-SkillCount` + `Get-SkillCategories` parity; replaced the wrong directory-count metric with SKILL.md-file count; replaced help/status/summary listings.

**`README.md`** — flagged the 2 hand-maintained `126` literals as sync targets (markdown can't interpolate).

**`tests/init.bats`** — made 4 count assertions **count-agnostic** (registry==disk, CLI==registry) so they self-heal instead of rotting.

## Key review-driven corrections (v1 → v2)

The original PLAN had 3 critical defects caught by review:
1. **"reality = 132" was wrong** — naive `find` counted 6 `_archived` skills; active count is **126**. All computations now exclude `_archived`.
2. **"lift to function scope" was unworkable** — the 3 consumers are in 3 different functions; fixed with a helper.
3. **"categories are editorial" was false** — 126/126 skills carry a `category:` field; auto-derived instead of hand-maintained.

## Verification (all green)

- `bash -n deploy/setup.sh` ✓
- `registry.json` + `opencode.json` valid JSON ✓
- All skill frontmatter parses (0 errors) ✓
- **276/276 bats tests pass** ✓
- **Zero** hardcoded count/category literals remain in deploy scripts ✓
- `setup.sh --help` shows dynamic `SKILLS (126):` ✓

## Semantic impact

`feat(deploy)` → minor bump (4.11.0 → 4.12.0).