### PR TITLE
fix(ci): update preset count 10→9 (google/microsoft removed in #309)

### DIFF
--- a/tests/init.bats
+++ b/tests/init.bats
@@ -51,9 +51,9 @@ teardown() { rm -rf "$TMP_PROJ"; }
   [ "$count" -gt 10 ]
 }
 
-@test "--list presets shows all 10 presets" {
+@test "--list presets shows all 9 presets" {
   count=$($INIT --list presets 2>/dev/null | jq_len)
-  [ "$count" = "10" ]
+  [ "$count" = "9" ]
 }
 
 @test "--describe code-review-subagent returns skills+delegates+modelAvailable" {


### PR DESCRIPTION
Trivial fix: PR #309 (google/microsoft MCP removal) deleted preset files but the test still expected 10. Now 9 presets exist. Full suite: 295 pass / 0 fail.