### PR TITLE
ci: bump actions to latest majors + Node 24, add Pages deploy retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
           persist-credentials: false
@@ -40,9 +40,9 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Registry drift guard
         run: |
@@ -75,7 +75,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.create_release)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -137,23 +137,29 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Build catalog site
         run: node deploy/build-site.mjs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+        timeout-minutes: 15
+        continue-on-error: true
+      - name: Retry deploy on failure
+        if: steps.deployment.outcome == 'failure'
+        uses: actions/deploy-pages@v5
+        timeout-minutes: 15


### PR DESCRIPTION
## Summary

Bump all GitHub Actions off the **deprecated Node 20 runtime** and onto current majors, and make the Pages deploy resilient to the transient backend timeouts that caused #322/#324 to fail.

## Changes

**Action version bumps** (Node 20 deprecation fix):
- `checkout` v4/v6 (mixed) → **v7**
- `setup-node` v4/v6 (mixed) → **v7**
- `upload-pages-artifact` v3 → **v5**
- `deploy-pages` v4 → **v5`
- `upload-artifact` v7 (already current)

**Node runtime:** `20` → `24` across all jobs (test/release/pages)

**Pages deploy retry** (real mitigation for transient timeouts):
- `timeout-minutes: 15` on both deploy steps
- `continue-on-error` on first attempt + conditional retry step (`if: steps.deployment.outcome == 'failure'`)

## Context

- #322/#324 failed because the Pages backend stalled past `deploy-pages`' internal ~10m timeout (bats + release jobs passed)
- #325 deployed successfully in 5m16s → Pages setup is **correct**, failures were transient backend slowness
- **Note:** `deploy-pages@v5` is purely a Node 24 runtime bump (confirmed via changelog) — it does **not** change timeout/retry behavior, hence the explicit retry step

## Verification
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI passes on merge (bats + release + pages)