### PR TITLE
fix(pptx-template-modifier): repair-worthy defects in designer_promoter output

### DIFF
--- a/opencode_app/.opencode/skills/pptx-template-modifier-skill/SKILL.md
+++ b/opencode_app/.opencode/skills/pptx-template-modifier-skill/SKILL.md
@@ -155,10 +155,27 @@ print(report.to_dict())
 | `scripts/container_check.py` | `container_violations(layout)` / `check_template(prs)` — static geometry check. Raises `ContainerFitError` on critical violations when invoked as a gate. |
 | `scripts/contrast_check.py` | `contrast_violations(layout, theme, auto_fix)` / `contrast_ratio(fg, bg)` — WCAG 2.1 contrast verification with optional auto-fix (flips low-contrast placeholder text to white/black based on background luminance). |
 | `scripts/vision_extractor.py` | `render_slides_to_pngs(pptx)` / `build_image_analyzer_prompt(...)` / `aggregate_vision_results(...)` / `fallback_xml_background(slide, theme)` — vision-assisted schema extraction. Composes with the XML path: vision provides `dominant_bg_hex` for master + layout bg injection; XML provides precise shape geometry. |
+| `scripts/pptx_validate.py` | Post-build validation gate: 8 static OOXML checks (zip, XML, content-types, broken/dangling rels, rel-type mismatch, empty r:id, duplicate layout ids) + `--fix` auto-repair + `--com` authoritative PowerPoint open test. **Run after every build.** |
 
 ### Cross-link to Capability B
 
 Capability B (`state_machine.resolve_and_clone`) and Capability C (`designer_promoter.promote_designer_slides`) are siblings: B borrows from a donor, C reverse-engineers from the source. The orchestrator (`pptx-specialist-subagent` Stage -1) routes between them based on whether the master is empty.
+
+## Post-build validation gate (MANDATORY)
+
+python-pptx/lxml stay silent on defects that make PowerPoint show **"needs repair"**. After ANY Capability B/C build, run:
+
+```bash
+python scripts/pptx_validate.py <output>.pptx --fix --com
+```
+
+Exit 0 = clean. `--fix` safely repairs id collisions + empty `r:id` attrs in place. `--com` (Windows + PowerPoint + pywin32) is the **authoritative gate**: PowerPoint hard-fails COM open on repair-worthy files. Without LibreOffice, this replaces vision-render smoke testing. Kill lingering `POWERPNT.EXE` after a failed COM open before retesting (hidden modal blocks later opens); HRESULT `0x80070070` is PowerPoint's generic open-failure code, not disk-full.
+
+Three defect classes this gate exists to catch (all seen in the wild on designer promotion):
+
+1. **Duplicate `sldLayoutId` ids** — PowerPoint treats `sldMasterId` + `sldLayoutId` as ONE presentation-wide uniqueness space. Allocating from a single master's list collides on multi-master decks. (`designer_promoter._max_layout_id` now scans all masters + `sldMasterIdLst`.)
+2. **Dangling relationship refs** — shapes `deepcopy`ed from slides carry `r:embed`/`r:link`/`r:id` values whose rIds don't exist in the new layout's `.rels`. (`_remap_shape_rels` recreates every referenced rel on the new part at copy time.)
+3. **Rel-id type collision** — a copied `p14:media r:embed="rId1"` pointing at the layout's `rId1` = slideMaster rel (structural rel where image/media/video expected). Same fix: remap, never copy rIds verbatim. Empty `r:id=""` (from `ppaction://media` hlinks) is also invalid and is dropped.
 
 ## Reference
 

--- a/opencode_app/.opencode/skills/pptx-template-modifier-skill/scripts/designer_promoter.py
+++ b/opencode_app/.opencode/skills/pptx-template-modifier-skill/scripts/designer_promoter.py
@@ -643,6 +643,12 @@ def _promote_slide_to_layout(
     if bg_hex:
         _inject_layout_background(new_element, bg_hex)
 
+    # 3. Wrap in a new SlideLayoutPart with a fresh partname.
+    #    Created BEFORE the shape copy so copied shapes can have their
+    #    relationships recreated on this part (see _remap_shape_rels).
+    new_partname = package.next_partname("/ppt/slideLayouts/slideLayout%d.xml")
+    new_part = SlideLayoutPart(new_partname, CT.PML_SLIDE_LAYOUT, package, new_element)
+
     # 2. Copy each shape from the source slide into the new layout's spTree,
     #    converting clustered shapes to placeholders in-place.
     spTree = new_element.find(qn("p:cSld")).find(qn("p:spTree"))
@@ -655,6 +661,7 @@ def _promote_slide_to_layout(
             continue
         sr = role_by_shape_id.get(sid)
         new_elem = deepcopy(shp._element)
+        _remap_shape_rels(slide.part, new_part, new_elem)
         if (
             sr
             and sr.role in ("title", "body", "picture", "table")
@@ -665,10 +672,6 @@ def _promote_slide_to_layout(
             promoted.append(sr)
         spTree.append(new_elem)
 
-    # 3. Wrap in a new SlideLayoutPart with a fresh partname.
-    new_partname = package.next_partname("/ppt/slideLayouts/slideLayout%d.xml")
-    new_part = SlideLayoutPart(new_partname, CT.PML_SLIDE_LAYOUT, package, new_element)
-
     # 4. Master → layout relationship.
     rId = master_part.relate_to(new_part, RT.SLIDE_LAYOUT)
 
@@ -676,7 +679,7 @@ def _promote_slide_to_layout(
     #    up in the Slide Master's layout gallery).
     sld_layout_id_lst = master_element.get_or_add_sldLayoutIdLst()
     entry = sld_layout_id_lst._add_sldLayoutId(rId=rId)
-    entry.set("id", str(_max_layout_id(sld_layout_id_lst)))
+    entry.set("id", str(_max_layout_id(package)))
 
     # 6. Layout → master relationship (the layout's only structural rel).
     new_part.relate_to(master_part, RT.SLIDE_MASTER)
@@ -703,16 +706,67 @@ def _promote_slide_to_layout(
     return new_layout, promoted
 
 
-def _max_layout_id(sld_layout_id_lst) -> int:
-    """Next unique <p:sldLayoutId id> (ECMA-376 min 2147483648)."""
+_R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+
+def _remap_shape_rels(source_part, new_part, element) -> None:
+    """Recreate on ``new_part`` every relationship referenced by copied shape XML.
+
+    ``deepcopy`` carries r:embed / r:link / r:id values verbatim, but rIds are
+    scoped to the SOURCE part's .rels. In the new layout they either dangle or,
+    worse, collide with the layout's own rels (e.g. rId1 = slideMaster while the
+    copied p14:media expects a media rel) — both make PowerPoint flag the file
+    for repair. Empty r:id="" (leftover ppaction://media hlinks) is invalid and
+    is dropped.
+    """
+    for el in element.iter():
+        for attr in list(el.attrib):
+            if not attr.startswith("{" + _R_NS + "}"):
+                continue
+            val = el.attrib[attr]
+            if not val:
+                del el.attrib[attr]
+                continue
+            try:
+                rel = source_part.rels[val]
+            except KeyError:
+                continue
+            if rel.is_external:
+                new_rId = new_part.rels.get_or_add_ext_rel(rel.reltype, rel.target_ref)
+            else:
+                new_rId = new_part.relate_to(rel.target_part, rel.reltype)
+            el.attrib[attr] = new_rId
+
+
+def _max_layout_id(package) -> int:
+    """Next unique <p:sldLayoutId id> (ECMA-376 min 2147483648).
+
+    PowerPoint treats sldMasterId and sldLayoutId ids as ONE presentation-wide
+    uniqueness space. Scanning a single master's list (the old behaviour)
+    produced ids already used by another master on multi-master decks, and
+    PowerPoint flagged the file for repair. Scan every master + sldMasterIdLst.
+    """
     max_id = 2147483647
-    for entry in sld_layout_id_lst.sldLayoutId_lst:
+
+    def _bump(e) -> None:
+        nonlocal max_id
         try:
-            id_val = int(entry.get("id", "0"))
-            if id_val > max_id:
-                max_id = id_val
+            max_id = max(max_id, int(e.get("id", "0")))
         except (TypeError, ValueError):
-            continue
+            pass
+
+    pres_elem = package.main_document_part._element
+    lst = pres_elem.find(qn("p:sldMasterIdLst"))
+    if lst is not None:
+        for e in lst:
+            _bump(e)
+    for part in package.iter_parts():
+        pn = str(part.partname)
+        if pn.startswith("/ppt/slideMasters/slideMaster") and pn.endswith(".xml"):
+            l = part._element.find(qn("p:sldLayoutIdLst"))
+            if l is not None:
+                for e in l:
+                    _bump(e)
     return max_id + 1
 
 
@@ -723,10 +777,20 @@ def _max_layout_id(sld_layout_id_lst) -> int:
 def _strip_slides(prs) -> int:
     """Remove every slide from ``prs`` (template ≠ deck). Returns count removed."""
     # python-pptx has no public drop_slides; manipulate the sldIdLst.
+    # Also drop the presentation→slide relationships: parts left reachable in
+    # the rel graph are serialized as orphan slide parts (bloat + they carry
+    # source-deck defects the validator flags). Notes slides hang off slides
+    # and drop transitively; media still referenced by promoted layouts stays.
     sldIdLst = prs.slides._sldIdLst
     count = len(list(sldIdLst))
     for child in list(sldIdLst):
+        rId = child.get(qn("r:id"))
         sldIdLst.remove(child)
+        if rId:
+            try:
+                prs.part.drop_rel(rId)
+            except Exception:
+                pass
     return count
 
 

--- a/opencode_app/.opencode/skills/pptx-template-modifier-skill/scripts/pptx_validate.py
+++ b/opencode_app/.opencode/skills/pptx-template-modifier-skill/scripts/pptx_validate.py
@@ -1,0 +1,246 @@
+"""pptx_validate.py — post-build validation gate for generated/promoted PPTX files.
+
+python-pptx and lxml stay silent on defects that make PowerPoint show the
+"needs repair" dialog. This script is the gate: it runs static OOXML checks,
+optionally auto-fixes the two safe classes (--fix), and optionally performs
+the authoritative open test in real PowerPoint via COM (--com, Windows only).
+
+Usage:
+    python pptx_validate.py file.pptx [--fix] [--com]
+
+Exit code 0 = clean (or fully fixed), 1 = defects remain.
+
+Checks:
+  1. zip integrity
+  2. XML well-formedness of every .xml/.rels part
+  3. [Content_Types].xml coverage for every part
+  4. broken relationship targets (rel -> missing part)
+  5. dangling r:* references (XML refs an rId its part's .rels doesn't define)
+  6. rel-type mismatch: r:embed/r:link pointing at a structural rel
+     (slideMaster/slideLayout/notesSlide) instead of image/media/video
+  7. empty r:id="" attributes
+  8. duplicate sldLayoutId ids across masters, and overlap with sldMasterIds
+     (PowerPoint treats these as one presentation-wide uniqueness space)
+
+--fix repairs (in place): (7) empty r:id removal, (8) id renumbering.
+Dangling refs / type mismatches (5, 6) must be fixed at generation time —
+see designer_promoter._remap_shape_rels.
+"""
+
+import posixpath
+import re
+import sys
+import zipfile
+from lxml import etree
+
+P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+NS = {"p": P_NS}
+
+STRUCTURAL_REL_SUFFIXES = ("/slideMaster", "/slideLayout", "/notesSlide", "/slide")
+
+
+def _parts(z):
+    return [n for n in z.namelist() if not n.endswith("/")]
+
+
+def check_zip(path):
+    try:
+        z = zipfile.ZipFile(path)
+    except Exception as e:
+        return None, [f"zip open failed: {e}"]
+    bad = z.testzip()
+    return z, ([] if bad is None else [f"corrupt zip member: {bad}"])
+
+
+def check_xml(z):
+    errs = []
+    for n in _parts(z):
+        if n.endswith((".xml", ".rels")):
+            try:
+                etree.fromstring(z.read(n))
+            except Exception as e:
+                errs.append(f"XML parse fail {n}: {e}")
+    return errs
+
+
+def check_content_types(z, names):
+    ct = z.read("[Content_Types].xml").decode()
+    overrides = set(re.findall(r'PartName="([^"]+)"', ct))
+    defaults = set(re.findall(r'Extension="([^"]+)"', ct))
+    return [
+        f"no content-type for {n}"
+        for n in names
+        if "/" + n not in overrides and n.rsplit(".", 1)[-1] not in defaults
+    ]
+
+
+def _defined_rids(z, relpath, names):
+    if relpath not in names:
+        return {}, set()
+    root = etree.fromstring(z.read(relpath))
+    rels = {r.get("Id"): r for r in root}
+    return rels, set(rels)
+
+
+def check_rels(z, names):
+    """Broken targets, dangling refs, type mismatches, empty r:id."""
+    broken, dangling, mismatch, empty = [], [], [], []
+    for n in names:
+        if n.endswith(".rels"):
+            base = posixpath.dirname(posixpath.dirname(n))
+            for rel in etree.fromstring(z.read(n)):
+                if rel.get("TargetMode") == "External":
+                    continue
+                p = posixpath.normpath(posixpath.join(base, rel.get("Target")))
+                if p not in names:
+                    broken.append(f"{n}: missing target {rel.get('Target')}")
+        m = re.match(r"(ppt/[\w]+)/([^/]+\.xml)$", n)
+        if not m:
+            continue
+        relpath = posixpath.join(m.group(1), "_rels", m.group(2) + ".rels")
+        rels, defined = _defined_rids(z, relpath, names)
+        root = etree.fromstring(z.read(n))
+        for e in root.iter():
+            for a, v in e.attrib.items():
+                if not a.startswith("{" + R_NS + "}"):
+                    continue
+                if v == "":
+                    empty.append(f"{n}: empty r:id on <{etree.QName(e).localname}>")
+                elif v not in defined:
+                    dangling.append(f"{n}: dangling ref {v} on <{etree.QName(e).localname}>")
+                elif a.endswith(("}embed", "}link")):
+                    rt = rels[v].get("Type", "")
+                    if rt.endswith(STRUCTURAL_REL_SUFFIXES):
+                        mismatch.append(
+                            f"{n}: {v} ({etree.QName(e).localname}) points at structural rel {rt}"
+                        )
+    return broken, dangling, mismatch, empty
+
+
+def _layout_ids(z, names):
+    """(master_part_name, element) pairs + presentation sldMasterId values."""
+    masters = []
+    for n in names:
+        if re.match(r"ppt/slideMasters/slideMaster\d+\.xml$", n):
+            root = etree.fromstring(z.read(n))
+            ids = [int(e.get("id")) for e in root.findall(".//p:sldLayoutId", NS)]
+            masters.append((n, ids))
+    pres = etree.fromstring(z.read("ppt/presentation.xml"))
+    master_ids = [int(e.get("id")) for e in pres.findall(".//p:sldMasterId", NS)]
+    return masters, master_ids
+
+
+def check_ids(z, names):
+    masters, master_ids = _layout_ids(z, names)
+    all_lids = [i for _, ids in masters for i in ids]
+    dups = sorted({i for i in all_lids if all_lids.count(i) > 1})
+    overlap = sorted(set(master_ids) & set(all_lids))
+    errs = [f"duplicate sldLayoutId {i} across masters" for i in dups]
+    errs += [f"sldLayoutId {i} collides with a sldMasterId" for i in overlap]
+    return errs
+
+
+def fix_file(path):
+    """In-place: renumber colliding layout ids, drop empty r:id attrs."""
+    tmp = path + ".fixed"
+    zin = zipfile.ZipFile(path)
+    names = zin.namelist()
+    out = {}
+    # --- renumber ids (presentation-wide uniqueness) ---
+    masters, master_ids = _layout_ids(zin, names)
+    all_lids = [i for _, ids in masters for i in ids]
+    used = set(all_lids) | set(master_ids)
+    bad = {i for i in all_lids if all_lids.count(i) > 1} | (set(master_ids) & set(all_lids))
+    nxt = max(used) + 1 if used else 2147483648
+    for n, _ in masters:
+        root = etree.fromstring(zin.read(n))
+        dirty = False
+        for e in root.findall(".//p:sldLayoutId", NS):
+            if int(e.get("id")) in bad:
+                while nxt in used:
+                    nxt += 1
+                e.set("id", str(nxt))
+                used.add(nxt)
+                dirty = True
+        if dirty:
+            out[n] = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
+    # --- empty r:id removal ---
+    for n in names:
+        if n in out or not n.endswith(".xml"):
+            continue
+        root = etree.fromstring(zin.read(n))
+        dirty = False
+        for e in root.iter():
+            for a in list(e.attrib):
+                if a.startswith("{" + R_NS + "}") and e.attrib[a] == "":
+                    del e.attrib[a]
+                    dirty = True
+        if dirty:
+            out[n] = etree.tostring(root, xml_declaration=True, encoding="UTF-8", standalone=True)
+    if out:
+        with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as z:
+            for item in names:
+                z.writestr(item, out.get(item, zin.read(item)))
+        zin.close()
+        import shutil
+
+        shutil.move(tmp, path)
+    zin.close() if not out else None
+    return len(out)
+
+
+def com_open_test(path):
+    """Authoritative gate: open in real PowerPoint via COM (pywin32).
+
+    PowerPoint hard-fails COM open on repair-worthy files while python-pptx
+    stays silent. Kill lingering POWERPNT.EXE after a failure before retesting
+    (a hidden modal blocks later opens). HRESULT 0x80070070 is PowerPoint's
+    generic open-failure code here, not an actual disk-full condition.
+    """
+    import win32com.client
+
+    ppt = win32com.client.Dispatch("PowerPoint.Application")
+    try:
+        pres = ppt.Presentations.Open(path, ReadOnly=True, WithWindow=False)
+        info = (pres.Slides.Count, pres.Designs.Count)
+        pres.Close()
+        return True, f"opened OK (slides={info[0]}, designs={info[1]})"
+    except Exception as e:
+        return False, f"PowerPoint refused to open: {e}"
+    finally:
+        ppt.Quit()
+
+
+def main(argv):
+    import os
+
+    path = argv[1]
+    do_fix = "--fix" in argv
+    do_com = "--com" in argv
+    if do_fix:
+        n = fix_file(path)
+        print(f"--fix: rewrote {n} parts")
+    z, errs = check_zip(path)
+    if z is None:
+        print("\n".join(errs))
+        return 1
+    names = set(_parts(z))
+    errs += check_xml(z)
+    errs += check_content_types(z, names)
+    broken, dangling, mismatch, empty = check_rels(z, names)
+    errs += broken + dangling + mismatch + empty
+    errs += check_ids(z, names)
+    for e in errs:
+        print("DEFECT:", e)
+    if do_com:
+        ok, msg = com_open_test(os.path.abspath(path))
+        print(("COM PASS: " if ok else "COM FAIL: ") + msg)
+        if not ok:
+            errs.append(msg)
+    print(f"{os.path.basename(path)}: {'CLEAN' if not errs else f'{len(errs)} defect(s)'}")
+    return 0 if not errs else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #331.

## What
Fixes 3 defects that made Capability C (designer_promoter) output trigger PowerPoint's "needs repair" dialog, plus adds a mandatory post-build validation gate.

## Changes
- `designer_promoter._max_layout_id` — scan all masters + `sldMasterIdLst` (presentation-wide id uniqueness)
- `designer_promoter._remap_shape_rels` (new) — recreate referenced rels on new layout part at copy time; drops empty `r:id`
- `designer_promoter._strip_slides` — drop presentation→slide rels (no orphan slide parts in output)
- `scripts/pptx_validate.py` (new) — 8 static OOXML checks + `--fix` + `--com` PowerPoint open gate
- SKILL.md — mandatory post-build validation section

## Verification
- 120/120 skill tests pass
- Fresh promoter run on the real affected deck → validator **CLEAN + COM PASS** (opens in PowerPoint, no repair)